### PR TITLE
`copy_from_slice` expects a same-sized slice. Let's give it one.

### DIFF
--- a/rtnetlink/src/packets/message.rs
+++ b/rtnetlink/src/packets/message.rs
@@ -316,7 +316,7 @@ impl Emitable for NetlinkMessage {
     fn emit(&self, buffer: &mut [u8]) {
         use self::RtnlMessage::*;
         self.header.emit(buffer);
-        let buffer = &mut buffer[self.header.buffer_len()..];
+        let buffer = &mut buffer[self.header.buffer_len()..self.header.length() as usize];
         match self.message {
             Noop | Done => {},
 


### PR DESCRIPTION
If one constructs an `Other` type message and tries to send it (calling `emit` in the process) the thread will panic on line 325 because `buffer` and `bytes` are most likely not the same size but `copy_from_slice` expects them to be.