### PR TITLE
Implement address support

### DIFF
--- a/iproute2/Cargo.toml
+++ b/iproute2/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.0.1"
 eui48 = "0.3.2"
 failure = "0.1.1"
 failure_derive = "0.1.1"
+ipnetwork = "0.13"
 
 [dependencies.rtnetlink]
 version = "0.0"

--- a/iproute2/examples/add_address.rs
+++ b/iproute2/examples/add_address.rs
@@ -1,4 +1,5 @@
 extern crate futures;
+extern crate ipnetwork;
 extern crate iproute2;
 extern crate tokio_core;
 
@@ -6,28 +7,35 @@ use std::env;
 use std::thread::spawn;
 
 use futures::Future;
+use ipnetwork::IpNetwork;
 use tokio_core::reactor::Core;
 
 use iproute2::new_connection;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
+    if args.len() != 3 {
         return usage();
     }
     let link_name = &args[1];
+    let ip: IpNetwork = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("invalid address");
+        std::process::exit(1);
+    });
 
+    // Create a netlink connection, and a handle to send requests via this connection
     let (connection, handle) = new_connection().unwrap();
+
+    // The connection we run in its own thread
     spawn(move || Core::new().unwrap().run(connection));
 
     // Get the list of links
     let links = handle.link().get().execute().wait().unwrap();
 
     for link in links {
-        // Find the link with the name provided as argument, and delete it
+        // Find the link with the name provided as argument
         if link.name().unwrap() == link_name {
-            println!("deleting link {}", link_name);
-            let req = handle.link().del(link.index());
+            let req = handle.address().add(link.index(), ip);
             match req.execute().wait() {
                 Ok(()) => println!("done"),
                 Err(e) => eprintln!("error: {}", e),
@@ -41,15 +49,15 @@ fn main() {
 fn usage() {
     eprintln!(
         "usage:
-    cargo run --example del_link -- <link name>
+    cargo run --example add_address -- <link_name> <ip_address>
 
 Note that you need to run this program as root. Instead of running cargo as root,
 build the example normally:
 
-    cd iproute2 ; cargo build --example del_link
+    cd iproute2 ; cargo build --example add_address
 
 Then find the binary in the target directory:
 
-    cd ../target/debug/example ; sudo ./del_link <link_name>"
+    cd ../target/debug/example ; sudo ./add_address <link_name> <ip_address>"
     );
 }

--- a/iproute2/examples/del_address.rs
+++ b/iproute2/examples/del_address.rs
@@ -1,4 +1,5 @@
 extern crate futures;
+extern crate ipnetwork;
 extern crate iproute2;
 extern crate tokio_core;
 
@@ -6,28 +7,35 @@ use std::env;
 use std::thread::spawn;
 
 use futures::Future;
+use ipnetwork::IpNetwork;
 use tokio_core::reactor::Core;
 
 use iproute2::new_connection;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
+    if args.len() != 3 {
         return usage();
     }
     let link_name = &args[1];
+    let ip: IpNetwork = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("invalid address");
+        std::process::exit(1);
+    });
 
+    // Create a netlink connection, and a handle to send requests via this connection
     let (connection, handle) = new_connection().unwrap();
+
+    // The connection we run in its own thread
     spawn(move || Core::new().unwrap().run(connection));
 
     // Get the list of links
     let links = handle.link().get().execute().wait().unwrap();
 
     for link in links {
-        // Find the link with the name provided as argument, and delete it
+        // Find the link with the name provided as argument
         if link.name().unwrap() == link_name {
-            println!("deleting link {}", link_name);
-            let req = handle.link().del(link.index());
+            let req = handle.address().del(link.index(), ip);
             match req.execute().wait() {
                 Ok(()) => println!("done"),
                 Err(e) => eprintln!("error: {}", e),
@@ -41,15 +49,15 @@ fn main() {
 fn usage() {
     eprintln!(
         "usage:
-    cargo run --example del_link -- <link name>
+    cargo run --example del_address -- <link_name> <ip_address>
 
 Note that you need to run this program as root. Instead of running cargo as root,
 build the example normally:
 
-    cd iproute2 ; cargo build --example del_link
+    cd iproute2 ; cargo build --example del_address
 
 Then find the binary in the target directory:
 
-    cd ../target/debug/example ; sudo ./del_link <link_name>"
+    cd ../target/debug/example ; sudo ./del_address <link_name> <ip_address>"
     );
 }

--- a/iproute2/examples/dump_addresses.rs
+++ b/iproute2/examples/dump_addresses.rs
@@ -1,0 +1,46 @@
+extern crate futures;
+extern crate iproute2;
+extern crate tokio_core;
+
+use futures::Future;
+use iproute2::new_connection;
+use tokio_core::reactor::Core;
+
+fn main() {
+    // Create a netlink connection for each request,
+    // and a handle to send requests via each connection
+    let (connection1, handle1) = new_connection().unwrap();
+    let (connection2, handle2) = new_connection().unwrap();
+
+    // The connections will run in an event loop
+    let mut core = Core::new().unwrap();
+    core.handle().spawn(connection1.map_err(|_| ()));
+    core.handle().spawn(connection2.map_err(|_| ()));
+
+    // Get the IP addresses for all links
+    let addresses = handle1.address().get().execute();
+
+    // Get the list of links
+    let links = handle2.link().get().execute();
+
+    let request = links.join(addresses).and_then(|(links, addresses)| {
+        for addr in addresses {
+            let ip = addr
+                .address()
+                .map(|a| a.to_string())
+                .unwrap_or("".to_string());
+
+            // find the corresponding link name using the address link index
+            let link_name = links
+                .iter()
+                .find(|link| link.index() == addr.index())
+                .map(|link| link.name().unwrap_or(""))
+                .unwrap_or("");
+            println!("{}\t{}\t{}", addr.index(), link_name, ip);
+        }
+        Ok(())
+    });
+
+    // Run the request on the event loop
+    core.run(request).unwrap();
+}

--- a/iproute2/examples/flush_addresses.rs
+++ b/iproute2/examples/flush_addresses.rs
@@ -2,7 +2,6 @@ extern crate futures;
 extern crate iproute2;
 extern crate tokio_core;
 
-use std::env;
 use std::thread::spawn;
 
 use futures::Future;
@@ -11,23 +10,26 @@ use tokio_core::reactor::Core;
 use iproute2::new_connection;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let args: Vec<String> = std::env::args().collect();
     if args.len() != 2 {
         return usage();
     }
     let link_name = &args[1];
 
+    // Create a netlink connection, and a handle to send requests via this connection
     let (connection, handle) = new_connection().unwrap();
+
+    // The connection we run in its own thread
     spawn(move || Core::new().unwrap().run(connection));
 
     // Get the list of links
     let links = handle.link().get().execute().wait().unwrap();
 
     for link in links {
-        // Find the link with the name provided as argument, and delete it
+        // Find the link with the name provided as argument
         if link.name().unwrap() == link_name {
-            println!("deleting link {}", link_name);
-            let req = handle.link().del(link.index());
+            // Flush all addresses on the given link
+            let req = handle.address().flush(link.index());
             match req.execute().wait() {
                 Ok(()) => println!("done"),
                 Err(e) => eprintln!("error: {}", e),
@@ -38,18 +40,19 @@ fn main() {
     eprintln!("link {} not found", link_name);
 }
 
+
 fn usage() {
     eprintln!(
         "usage:
-    cargo run --example del_link -- <link name>
+    cargo run --example flush_addresses -- <link_name>
 
 Note that you need to run this program as root. Instead of running cargo as root,
 build the example normally:
 
-    cd iproute2 ; cargo build --example del_link
+    cd iproute2 ; cargo build --example flush_addresses
 
 Then find the binary in the target directory:
 
-    cd ../target/debug/example ; sudo ./del_link <link_name>"
+    cd ../target/debug/example ; sudo ./flush_addresses <link_name>"
     );
 }

--- a/iproute2/src/addr/add.rs
+++ b/iproute2/src/addr/add.rs
@@ -1,0 +1,90 @@
+use futures::Future;
+use ipnetwork::IpNetwork;
+use std::net::IpAddr;
+
+use rtnetlink::constants::{NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST};
+use rtnetlink::{constants, AddressMessage, AddressNla, NetlinkFlags, NetlinkMessage, RtnlMessage};
+
+use connection::ConnectionHandle;
+use errors::NetlinkIpError;
+
+use Stream2Ack;
+
+lazy_static! {
+    // Flags for `ip addr add`
+    static ref ADD_FLAGS: NetlinkFlags = NetlinkFlags::from(NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE);
+}
+
+/// A request to create a new address. This is equivalent to the `ip address add` commands.
+pub struct AddressAddRequest {
+    handle: ConnectionHandle,
+    message: AddressMessage,
+}
+
+impl AddressAddRequest {
+    pub(crate) fn new(handle: ConnectionHandle, index: u32, net: IpNetwork) -> Self {
+        let mut message = AddressMessage::default();
+        message.header.family = af_for_net(net);
+        message.header.prefix_len = net.prefix();
+        message.header.index = index;
+
+        let ip = net.ip();
+
+        if ip.is_multicast() {
+            let nla = AddressNla::Multicast(ip_to_vec(ip));
+            message.nlas.push(nla);
+        } else if ip.is_unspecified() {
+            let nla = AddressNla::Unspec(ip_to_vec(ip));
+            message.nlas.push(nla);
+        } else {
+            let nla = AddressNla::Address(ip_to_vec(ip));
+            message.nlas.push(nla);
+
+            // for IPv4 the IFA_LOCAL address can be set to the same value as IFA_ADDRESS
+            if ip.is_ipv4() {
+                let nla = AddressNla::Local(ip_to_vec(ip));
+                message.nlas.push(nla);
+            }
+
+            // for IPv4 set the IFA_BROADCAST address as well (IPv6 does not support broadcast)
+            if let IpNetwork::V4(n) = net {
+                let bytes = n.broadcast().octets().to_vec();
+                let nla = AddressNla::Broadcast(bytes);
+                message.nlas.push(nla);
+            }
+        }
+        AddressAddRequest { handle, message }
+    }
+
+    /// Execute the request.
+    pub fn execute(self) -> impl Future<Item = (), Error = NetlinkIpError> {
+        let mut handle = self.handle;
+        let mut req = NetlinkMessage::from(RtnlMessage::NewAddress(self.message));
+        req.header_mut().set_flags(*ADD_FLAGS);
+        Stream2Ack::new(handle.request(req))
+    }
+
+    /// Return a mutable reference to the request message.
+    pub fn message_mut(&mut self) -> &mut AddressMessage {
+        &mut self.message
+    }
+}
+
+// get the address family for a given IpNetwork
+fn af_for_net(net: IpNetwork) -> u8 {
+    if net.is_ipv4() {
+        constants::AF_INET as u8
+    } else if net.is_ipv6() {
+        constants::AF_INET6 as u8
+    } else {
+        unreachable!()
+    }
+}
+
+// convert an IP address to a Vec<u8>
+fn ip_to_vec(ip: IpAddr) -> Vec<u8> {
+    match ip {
+        IpAddr::V4(i) => i.octets().to_vec(),
+        IpAddr::V6(i) => i.octets().to_vec(),
+    }
+}

--- a/iproute2/src/addr/del.rs
+++ b/iproute2/src/addr/del.rs
@@ -1,0 +1,62 @@
+use futures::{stream, Async, Future, Poll, Stream};
+
+use rtnetlink::constants::{NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST};
+use rtnetlink::{AddressMessage, NetlinkFlags, NetlinkMessage, RtnlMessage};
+
+use connection::ConnectionHandle;
+use errors::NetlinkIpError;
+
+use Stream2Ack;
+
+lazy_static! {
+    // Flags for `ip addr del`
+    static ref DEL_FLAGS: NetlinkFlags =
+        NetlinkFlags::from(NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE);
+}
+
+pub struct AddressDelRequest {
+    handle: ConnectionHandle,
+    messages: Vec<AddressMessage>,
+}
+
+impl AddressDelRequest {
+    pub(crate) fn new(handle: ConnectionHandle, messages: Vec<AddressMessage>) -> Self {
+        AddressDelRequest { handle, messages }
+    }
+}
+
+pub struct AddressDelRequestFuture<T>(pub(crate) T);
+
+impl<T> Future for AddressDelRequestFuture<T>
+where
+    T: Future<Item = AddressDelRequest>,
+    NetlinkIpError: ::std::convert::From<<T as ::futures::Future>::Error>,
+{
+    type Item = AddressDelRequest;
+    type Error = NetlinkIpError;
+
+    fn poll(&mut self) -> Poll<Self::Item, NetlinkIpError> {
+        let value = try_ready!(self.0.poll());
+        Ok(Async::Ready(value))
+    }
+}
+
+impl<T> AddressDelRequestFuture<T>
+where
+    T: Future<Item = AddressDelRequest>,
+    NetlinkIpError: ::std::convert::From<<T as ::futures::Future>::Error>,
+{
+    /// Execute the request
+    pub fn execute(self) -> impl Future<Item = (), Error = NetlinkIpError> {
+        self.and_then(|s| {
+            let mut handle = s.handle;
+            let reqs = stream::iter_ok(s.messages)
+                .map(move |message| {
+                    let mut req = NetlinkMessage::from(RtnlMessage::DelAddress(message));
+                    req.header_mut().set_flags(*DEL_FLAGS);
+                    handle.request(req)
+                }).flatten();
+            Stream2Ack::new(reqs)
+        })
+    }
+}

--- a/iproute2/src/addr/get.rs
+++ b/iproute2/src/addr/get.rs
@@ -1,0 +1,74 @@
+use futures::{Future, Stream};
+
+use rtnetlink::constants::{NLM_F_DUMP, NLM_F_REQUEST};
+use rtnetlink::{AddressMessage, NetlinkFlags, NetlinkMessage, RtnlMessage};
+
+use super::Address;
+use connection::ConnectionHandle;
+use errors::NetlinkIpError;
+
+use Stream2Vec;
+
+lazy_static! {
+    // Flags for `ip link get`
+    static ref GET_FLAGS: NetlinkFlags = NetlinkFlags::from(NLM_F_REQUEST | NLM_F_DUMP);
+}
+
+pub struct AddressGetRequest {
+    handle: ConnectionHandle,
+    message: AddressMessage,
+}
+
+impl AddressGetRequest {
+    pub(crate) fn new(handle: ConnectionHandle) -> Self {
+        let message = AddressMessage::default();
+        AddressGetRequest { handle, message }
+    }
+
+    /// Execute the request
+    pub fn execute(self) -> impl Future<Item = Vec<Address>, Error = NetlinkIpError> {
+        Stream2Vec::new(
+            self.get_address_msgs_stream()
+                .map(|addr_msg| match addr_msg {
+                    Ok(value) => Address::from_address_message(value),
+                    Err(e) => Err(e),
+                }),
+        )
+    }
+
+    /// Get the raw rtnetlink address messages as a Stream
+    pub(crate) fn get_address_msgs_stream(
+        self,
+    ) -> impl Stream<Item = Result<AddressMessage, NetlinkIpError>, Error = NetlinkIpError> {
+        let AddressGetRequest {
+            mut handle,
+            message,
+        } = self;
+        let mut req = NetlinkMessage::from(RtnlMessage::GetAddress(message));
+        req.header_mut().set_flags(*GET_FLAGS);
+        handle.request(req).map(move |msg| {
+            if !msg.is_new_address() {
+                return Err(NetlinkIpError::UnexpectedMessage(msg));
+            }
+
+            if let (_, RtnlMessage::NewAddress(addr_message)) = msg.into_parts() {
+                Ok(addr_message)
+            } else {
+                // We checked that msg.is_new_address() above, so the else should not be reachable.
+                unreachable!();
+            }
+        })
+    }
+
+    /// Get the raw rtnetlink address messages as a Stream
+    pub(crate) fn get_address_msgs_future(
+        self,
+    ) -> impl Future<Item = Vec<AddressMessage>, Error = NetlinkIpError> {
+        Stream2Vec::new(self.get_address_msgs_stream())
+    }
+
+    /// Return a mutable reference to the request
+    pub fn message_mut(&mut self) -> &mut AddressMessage {
+        &mut self.message
+    }
+}

--- a/iproute2/src/addr/handle.rs
+++ b/iproute2/src/addr/handle.rs
@@ -1,0 +1,88 @@
+use super::bytes_to_ip_addr;
+use connection::ConnectionHandle;
+use errors::NetlinkIpError;
+use futures::Future;
+use ipnetwork::IpNetwork;
+use rtnetlink::AddressNla;
+
+use super::{AddressAddRequest, AddressDelRequest, AddressDelRequestFuture, AddressGetRequest};
+
+pub struct AddressHandle(ConnectionHandle);
+
+impl AddressHandle {
+    pub fn new(handle: ConnectionHandle) -> Self {
+        AddressHandle(handle)
+    }
+
+    /// Retrieve the list of ip addresses (equivalent to `ip addr show`)
+    pub fn get(&self) -> AddressGetRequest {
+        AddressGetRequest::new(self.0.clone())
+    }
+
+    /// Add an ip address on an interface (equivalent to `ip addr add`)
+    pub fn add(&self, index: u32, net: IpNetwork) -> AddressAddRequest {
+        AddressAddRequest::new(self.0.clone(), index, net)
+    }
+
+    /// Delete all ip addresses on an interface with the given index (equivalent to `ip addr flush`)
+    pub fn flush(
+        self,
+        index: u32,
+    ) -> AddressDelRequestFuture<impl Future<Item = AddressDelRequest, Error = NetlinkIpError>>
+    {
+        // get all addresses first
+        // then create a delete request with all address messages included
+        let future = self.get().get_address_msgs_future().map(move |addr_msgs| {
+            let msgs = addr_msgs
+                .into_iter()
+                .filter(|msg| msg.header.index == index)
+                .collect::<Vec<_>>();
+            AddressDelRequest::new(self.0.clone(), msgs)
+        });
+        AddressDelRequestFuture(future)
+    }
+
+    /// Delete the given IP address on the interface with the given index
+    pub fn del(
+        self,
+        index: u32,
+        net: IpNetwork,
+    ) -> AddressDelRequestFuture<impl Future<Item = AddressDelRequest, Error = NetlinkIpError>>
+    {
+        // get all address messages first, find the one matching the given IPNetwork
+        // then create a delete request with the corresponding address message included
+        let future = self.get().get_address_msgs_future().map(move |addr_msgs| {
+            let msgs = addr_msgs
+                .into_iter()
+                .filter(|msg| msg.header.index == index)
+                .find(|msg| {
+                    if msg.header.prefix_len != net.prefix() {
+                        return false;
+                    }
+                    for nla in msg.nlas.iter() {
+                        match nla {
+                            AddressNla::Unspec(bytes)
+                            | AddressNla::Address(bytes)
+                            | AddressNla::Local(bytes)
+                            | AddressNla::Multicast(bytes)
+                            | AddressNla::Anycast(bytes) => {
+                                match bytes_to_ip_addr(&bytes[..]) {
+                                    Ok(ip) => {
+                                        if ip == net.ip() {
+                                            return true;
+                                        }
+                                    }
+                                    Err(_) => continue,
+                                };
+                            }
+                            _ => continue,
+                        }
+                    }
+                    return false;
+                }).map(|msg| vec![msg])
+                .unwrap_or(vec![]);
+            AddressDelRequest::new(self.0.clone(), msgs)
+        });
+        AddressDelRequestFuture(future)
+    }
+}

--- a/iproute2/src/addr/mod.rs
+++ b/iproute2/src/addr/mod.rs
@@ -1,0 +1,248 @@
+use errors::NetlinkIpError;
+use failure::Error;
+use ipnetwork::IpNetwork;
+use rtnetlink::{AddressCacheInfo, AddressHeader, AddressMessage, AddressNla};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+mod handle;
+pub use self::handle::*;
+
+mod add;
+pub use self::add::*;
+
+mod del;
+pub use self::del::*;
+
+mod get;
+pub use self::get::*;
+
+#[derive(Clone, Debug, Default)]
+pub struct Address {
+    // the header common to all address messages
+    header: AddressHeader,
+
+    // the attributes that come inside the body
+    label: Option<String>,
+    flags: Option<u32>,
+    cache_info: AddressCacheInfo,
+    attributes: Vec<AddressNla>,
+
+    // Different types of IP addresses
+
+    // Important comment:
+    // IFA_ADDRESS is prefix address, rather than local interface address.
+    // It makes no difference for normally configured broadcast interfaces,
+    // but for point-to-point IFA_ADDRESS is DESTINATION address,
+    // local address is supplied in IFA_LOCAL attribute.
+    ifa_address: Option<IpAddr>,
+    ifa_local: Option<IpAddr>,
+    ifa_broadcast: Option<IpAddr>,
+    ifa_anycast: Option<IpAddr>,
+    ifa_multicast: Option<IpAddr>,
+    ifa_unspec: Option<IpAddr>,
+}
+
+impl Address {
+    pub fn new() -> Self {
+        Address::default()
+    }
+
+    pub fn family(&self) -> u8 {
+        self.header.family
+    }
+
+    pub fn family_mut(&mut self) -> &mut u8 {
+        &mut self.header.family
+    }
+
+    pub fn set_family(&mut self, value: u8) -> &mut Self {
+        self.header.family = value;
+        self
+    }
+
+    pub fn prefix_len(&self) -> u8 {
+        self.header.prefix_len
+    }
+
+    pub fn prefix_len_mut(&mut self) -> &mut u8 {
+        &mut self.header.prefix_len
+    }
+
+    pub fn set_prefix_len(&mut self, value: u8) -> &mut Self {
+        self.header.prefix_len = value;
+        self
+    }
+
+    pub fn index(&self) -> u32 {
+        self.header.index
+    }
+
+    pub fn index_mut(&mut self) -> &mut u32 {
+        &mut self.header.index
+    }
+
+    pub fn set_index(&mut self, value: u32) -> &mut Self {
+        self.header.index = value;
+        self
+    }
+
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_ref().map(String::as_ref)
+    }
+
+    pub fn label_mut(&mut self) -> Option<&mut String> {
+        self.label.as_mut()
+    }
+
+    pub fn set_label(&mut self, value: String) -> &mut Self {
+        self.label = Some(value);
+        self
+    }
+
+    pub fn flags(&self) -> u8 {
+        self.header.flags
+    }
+
+    pub fn flags_mut(&mut self) -> &mut u8 {
+        &mut self.header.flags
+    }
+
+    pub fn set_flags(&mut self, value: u8) -> &mut Self {
+        self.header.flags = value;
+        self
+    }
+
+    pub fn scope(&self) -> u8 {
+        self.header.scope
+    }
+
+    pub fn scope_mut(&mut self) -> &mut u8 {
+        &mut self.header.scope
+    }
+
+    pub fn set_scope(&mut self, value: u8) -> &mut Self {
+        self.header.scope = value;
+        self
+    }
+
+    pub fn ifa_address(&self) -> Option<IpAddr> {
+        self.ifa_address
+    }
+
+    pub fn set_ifa_address(&mut self, value: IpAddr) -> &mut Self {
+        self.ifa_address = Some(value);
+        self
+    }
+
+    pub fn ifa_local(&self) -> Option<IpAddr> {
+        self.ifa_local
+    }
+
+    pub fn set_ifa_local(&mut self, value: IpAddr) -> &mut Self {
+        self.ifa_local = Some(value);
+        self
+    }
+
+    pub fn ifa_unspec(&self) -> Option<IpAddr> {
+        self.ifa_unspec
+    }
+
+    pub fn set_ifa_unspec(&mut self, value: IpAddr) -> &mut Self {
+        self.ifa_unspec = Some(value);
+        self
+    }
+
+    pub fn ifa_broadcast(&self) -> Option<IpAddr> {
+        self.ifa_broadcast
+    }
+
+    pub fn set_ifa_broadcast(&mut self, value: IpAddr) -> &mut Self {
+        self.ifa_broadcast = Some(value);
+        self
+    }
+
+    pub fn ifa_anycast(&self) -> Option<IpAddr> {
+        self.ifa_anycast
+    }
+
+    pub fn set_ifa_anycast(&mut self, value: IpAddr) -> &mut Self {
+        self.ifa_anycast = Some(value);
+        self
+    }
+
+    pub fn ifa_multicast(&self) -> Option<IpAddr> {
+        self.ifa_multicast
+    }
+
+    pub fn set_ifa_multicast(&mut self, value: IpAddr) -> &mut Self {
+        self.ifa_multicast = Some(value);
+        self
+    }
+
+    /// Get the local interface address (the main address) as IpNetwork
+    /// which is the ifa_local address (if specified) or ifa_address otherwise
+    pub fn address(&self) -> Result<IpNetwork, Error> {
+        if let Some(ip) = self.ifa_local {
+            Ok(IpNetwork::new(ip, self.prefix_len())?)
+        } else if let Some(ip) = self.ifa_address {
+            Ok(IpNetwork::new(ip, self.prefix_len())?)
+        } else {
+            bail!("IP address not present")
+        }
+    }
+
+    pub fn from_address_message(value: AddressMessage) -> Result<Self, NetlinkIpError> {
+        let (header, mut nlas) = (value.header, value.nlas);
+        let mut addr = Address::new();
+        addr.header = header;
+        for nla in nlas.drain(..) {
+            match nla {
+                AddressNla::Unspec(bytes) => {
+                    addr.set_ifa_unspec(bytes_to_ip_addr(&bytes[..])?);
+                }
+                AddressNla::Address(bytes) => {
+                    addr.set_ifa_address(bytes_to_ip_addr(&bytes[..])?);
+                }
+                AddressNla::Local(bytes) => {
+                    addr.set_ifa_local(bytes_to_ip_addr(&bytes[..])?);
+                }
+                AddressNla::Label(label) => {
+                    addr.label = Some(label);
+                }
+                AddressNla::Broadcast(bytes) => {
+                    addr.set_ifa_broadcast(bytes_to_ip_addr(&bytes[..])?);
+                }
+                AddressNla::Anycast(bytes) => {
+                    addr.set_ifa_anycast(bytes_to_ip_addr(&bytes[..])?);
+                }
+                AddressNla::CacheInfo(cache_info) => {
+                    addr.cache_info = cache_info;
+                }
+                AddressNla::Multicast(bytes) => {
+                    addr.set_ifa_multicast(bytes_to_ip_addr(&bytes[..])?);
+                }
+                AddressNla::Flags(flags) => {
+                    addr.flags = Some(flags);
+                }
+                _ => addr.attributes.push(nla),
+            }
+        }
+        Ok(addr)
+    }
+}
+
+fn bytes_to_ip_addr(bytes: &[u8]) -> Result<IpAddr, NetlinkIpError> {
+    match bytes.len() {
+        4 => {
+            let mut array = [0; 4];
+            array.copy_from_slice(bytes);
+            Ok(Ipv4Addr::from(array).into())
+        }
+        16 => {
+            let mut array = [0; 16];
+            array.copy_from_slice(bytes);
+            Ok(Ipv6Addr::from(array).into())
+        }
+        _ => Err(NetlinkIpError::InvalidAddress(bytes.to_vec())),
+    }
+}

--- a/iproute2/src/connection/handle.rs
+++ b/iproute2/src/connection/handle.rs
@@ -1,6 +1,7 @@
 use futures::sync::mpsc::{unbounded, UnboundedSender};
 use futures::Stream;
 use rtnetlink::NetlinkMessage;
+use AddressHandle;
 use LinkHandle;
 
 use errors::NetlinkIpError;
@@ -42,5 +43,10 @@ impl ConnectionHandle {
     /// Create a new handle, specifically for link requests (equivalent to `ip link` commands)
     pub fn link(&self) -> LinkHandle {
         LinkHandle::new(self.clone())
+    }
+
+    /// Create a new handle, specifically for address requests (equivalent to `ip addr` commands)
+    pub fn address(&self) -> AddressHandle {
+        AddressHandle::new(self.clone())
     }
 }

--- a/iproute2/src/errors.rs
+++ b/iproute2/src/errors.rs
@@ -15,11 +15,19 @@ pub enum NetlinkIpError {
     #[fail(display = "Did not receive an ACK for a request")]
     NoAck,
 
-    #[fail(display = "Received an error message as a response: {:?}", _0)]
+    #[fail(
+        display = "Received an error message as a response: {:?}",
+        _0
+    )]
     NetlinkError(NetlinkMessage),
 
     #[fail(
         display = "Received a link message (RTM_GETLINK, RTM_NEWLINK, RTM_SETLINK or RTMGETLINK) with an invalid hardware address attribute."
     )]
     InvalidLinkAddress(Vec<u8>),
+
+    #[fail(
+        display = "Received an address message (RTM_GETADDR, RTM_NEWADDR or RTM_DELADDR) with an invalid address attribute."
+    )]
+    InvalidAddress(Vec<u8>),
 }

--- a/iproute2/src/lib.rs
+++ b/iproute2/src/lib.rs
@@ -110,20 +110,25 @@ extern crate log;
 extern crate lazy_static;
 extern crate bytes;
 extern crate eui48;
+#[macro_use]
 extern crate futures;
+extern crate ipnetwork;
 extern crate tokio_core;
 
 extern crate netlink_socket;
 extern crate rtnetlink;
 
+#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 
+mod addr;
 mod connection;
 mod errors;
 mod link;
 
+pub use addr::*;
 pub use connection::*;
 pub use errors::*;
 pub use link::*;

--- a/iproute2/src/link/add.rs
+++ b/iproute2/src/link/add.rs
@@ -106,8 +106,7 @@ impl LinkAddRequest {
             .link_info(
                 LinkInfoKind::Vlan,
                 Some(LinkInfoData::Vlan(vec![LinkInfoVlan::Id(vlan_id)])),
-            )
-            .append_nla(LinkNla::Link(index))
+            ).append_nla(LinkNla::Link(index))
             .up()
     }
 

--- a/rtnetlink/src/packets/rtnl/address/message.rs
+++ b/rtnetlink/src/packets/rtnl/address/message.rs
@@ -1,13 +1,13 @@
 use super::{AddressBuffer, AddressNla};
 use {Emitable, Parseable, Result, ADDRESS_HEADER_LEN};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct AddressMessage {
     pub header: AddressHeader,
     pub nlas: Vec<AddressNla>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct AddressHeader {
     pub family: u8,
     pub prefix_len: u8,
@@ -39,7 +39,7 @@ impl Emitable for AddressMessage {
     fn emit(&self, buffer: &mut [u8]) {
         // in rust, we're guaranteed that when doing `a() + b(), a() is evaluated first
         self.header.emit(buffer);
-        self.nlas.as_slice().emit(buffer);
+        self.nlas.as_slice().emit(&mut buffer[self.header.buffer_len()..]);
     }
 }
 

--- a/rtnetlink/src/packets/rtnl/address/nla.rs
+++ b/rtnetlink/src/packets/rtnl/address/nla.rs
@@ -61,8 +61,8 @@ impl Nla for AddressNla {
 
             // String
             Label(ref string) => {
-                buffer.copy_from_slice(string.as_bytes());
-                buffer[string.as_bytes().len()] = 0;
+                buffer[..string.len()].copy_from_slice(string.as_bytes());
+                buffer[string.len()] = 0;
             }
 
             // u32
@@ -113,7 +113,7 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<AddressNla> for NlaBuffer<&'buf
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct AddressCacheInfo {
     pub ifa_preferred: i32,
     pub ifa_valid: i32,


### PR DESCRIPTION
This commit is adding a higher level API to `iproute2` that can be used for the same purpose as `ip addr` util.

This commit is also fixing a bug in the `rtnetlink` lib.

Note: I've seen some strange behavior when sharing a handle between link and address (it was randomly failing to run the second future) so there is probably some bug in the connection handling part. The workaround was to create two handles (see the `flush_addresses` example).


