### PR TITLE
Set link layer flags in `Link` type

### DIFF
--- a/iproute2/src/link/mod.rs
+++ b/iproute2/src/link/mod.rs
@@ -257,6 +257,7 @@ impl Link {
         link.set_index(header.index())
             .set_address_family(header.address_family())
             .set_link_layer_type(header.link_layer_type())
+            .set_flags(header.flags())
             .set_change_mask(header.change_mask());
         for nla in nlas.drain(..) {
             let _ = match nla {


### PR DESCRIPTION
This PR updates the creation of a `Link` type from a `LinkMessage` so that the flags are correctly loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/little-dude/netlink/10)
<!-- Reviewable:end -->
