### PR TITLE
Remove dependence on kernel structs

### DIFF
--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -25,6 +25,7 @@ name = "dump_links"
 criterion = "0.2.11"
 pcap-file = "0.10.0"
 netlink-sys = { path = "../netlink-sys", version = "0.2" }
+lazy_static = "1"
 
 [[bench]]
 name = "link_message"

--- a/netlink-packet-route/src/rtnl/link/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/mod.rs
@@ -165,9 +165,9 @@ pub enum LinkNla {
     LinkNetnsId(i32),
     // custom
     OperState(LinkState),
-    Stats(LinkStats),
-    Stats64(LinkStats64),
-    Map(LinkMap),
+    Stats(Vec<u8>),
+    Stats64(Vec<u8>),
+    Map(Vec<u8>),
     // AF_SPEC (the type of af_spec depends on the interface family of the message)
     AfSpecInet(Vec<LinkAfSpecInetNla>),
     // AfSpecBridge(Vec<LinkAfSpecBridgeNla>),
@@ -205,6 +205,7 @@ impl Nla for LinkNla {
                 | Broadcast(ref bytes)
                 | AfSpecUnknown(ref bytes)
                 | AfSpecBridge(ref bytes)
+                | Map(ref bytes)
                 => bytes.len(),
 
             // strings: +1 because we need to append a nul byte
@@ -240,7 +241,6 @@ impl Nla for LinkNla {
 
             // Defaults
             OperState(_) => size_of::<u8>(),
-            Map(_) => LINK_MAP_LEN,
             Stats(_) => LINK_STATS_LEN,
             Stats64(_) => LINK_STATS64_LEN,
             LinkInfo(ref nlas) => nlas.as_slice().buffer_len(),
@@ -280,6 +280,9 @@ impl Nla for LinkNla {
                 | Broadcast(ref bytes)
                 | AfSpecUnknown(ref bytes)
                 | AfSpecBridge(ref bytes)
+                | Stats(ref bytes)
+                | Stats64(ref bytes)
+                | Map(ref bytes)
                 => buffer.copy_from_slice(bytes.as_slice()),
 
             // String
@@ -320,9 +323,6 @@ impl Nla for LinkNla {
                 => NativeEndian::write_i32(buffer, *value),
 
             OperState(state) => buffer[0] = state.into(),
-            Map(ref map) => map.emit(buffer),
-            Stats(ref stats) => stats.emit(buffer),
-            Stats64(ref stats64) => stats64.emit(buffer),
             LinkInfo(ref nlas) => nlas.as_slice().emit(buffer),
             AfSpecInet(ref nlas) => nlas.as_slice().emit(buffer),
             // AfSpecBridge(ref nlas) => nlas.as_slice().emit(buffer),
@@ -483,22 +483,9 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized> ParseableParametrized<LinkNla, u16>
                     .context("invalid IFLA_OPERSTATE value")?
                     .into(),
             ),
-            IFLA_MAP => Map(LinkMapBuffer::new_checked(payload)
-                .context("invalid IFLA_MAP value")?
-                .parse()
-                .context("invalid IFLA_MAP value")?),
-            IFLA_STATS => Stats(
-                LinkStatsBuffer::new_checked(payload)
-                    .context("invalid IFLA_STATS value")?
-                    .parse()
-                    .context("invalid IFLA_STATS value")?,
-            ),
-            IFLA_STATS64 => Stats64(
-                LinkStats64Buffer::new_checked(payload)
-                    .context("invalid IFLA_STATS64 value")?
-                    .parse()
-                    .context("invalid IFLA_STATS64 value")?,
-            ),
+            IFLA_MAP => Map(payload.to_vec()),
+            IFLA_STATS => Stats(payload.to_vec()),
+            IFLA_STATS64 => Stats64(payload.to_vec()),
             IFLA_AF_SPEC => match interface_family as u16 {
                 AF_INET | AF_INET6 | AF_UNSPEC => {
                     let mut nlas = vec![];

--- a/netlink-packet-route/src/rtnl/link/nlas/tests.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/tests.rs
@@ -177,16 +177,22 @@ fn get_nlas() -> impl Iterator<Item = Result<NlaBuffer<&'static [u8]>, DecodeErr
     NlasIterator::new(&*BUFFER.value())
 }
 
+fn get_byte_buffer(nla: &dyn Emitable) -> Vec<u8> {
+    let mut buf = vec![0u8; nla.buffer_len()];
+    nla.emit(&mut buf);
+    buf
+}
+
 lazy_static! {
     static ref PARSED_AF_INET6: LinkAfSpecInetNla = LinkAfSpecInetNla::Inet6(vec![
         LinkAfInet6Nla::Flags(2147483648),
-        LinkAfInet6Nla::CacheInfo(LinkInet6CacheInfo {
+        LinkAfInet6Nla::CacheInfo(get_byte_buffer(&LinkInet6CacheInfo {
             max_reasm_len: 65535,
             tstamp: 175,
             reachable_time: 25730,
             retrans_time: 1000,
-        }),
-        LinkAfInet6Nla::DevConf(Box::new(LinkInet6DevConf {
+        })),
+        LinkAfInet6Nla::DevConf(get_byte_buffer(&LinkInet6DevConf {
             forwarding: 0,
             hoplimit: 64,
             mtu6: 65536,
@@ -239,7 +245,7 @@ lazy_static! {
             accept_ra_rt_info_min_plen: 0,
             ndisc_tclass: 0,
         })),
-        LinkAfInet6Nla::Stats(Box::new(LinkInet6Stats {
+        LinkAfInet6Nla::Stats(get_byte_buffer(&LinkInet6Stats {
             num: 36,
             in_pkts: 6,
             in_octets: 420,
@@ -277,14 +283,14 @@ lazy_static! {
             in_ect0_pkts: 0,
             in_ce_pkts: 0,
         })),
-        LinkAfInet6Nla::IcmpStats(LinkIcmp6Stats {
+        LinkAfInet6Nla::IcmpStats(get_byte_buffer(&LinkIcmp6Stats {
             num: 6,
             in_msgs: 0,
             in_errors: 0,
             out_msgs: 0,
             out_errors: 0,
             csum_errors: 0,
-        }),
+        })),
         LinkAfInet6Nla::Token([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
         LinkAfInet6Nla::AddrGenMode(0),
     ]);
@@ -292,39 +298,41 @@ lazy_static! {
 
 lazy_static! {
     static ref PARSED_AF_INET: LinkAfSpecInetNla =
-        LinkAfSpecInetNla::Inet(vec![LinkAfInetNla::DevConf(LinkInetDevConf {
-            forwarding: 1,
-            mc_forwarding: 0,
-            proxy_arp: 0,
-            accept_redirects: 1,
-            secure_redirects: 1,
-            send_redirects: 1,
-            shared_media: 1,
-            rp_filter: 0,
-            accept_source_route: 1,
-            bootp_relay: 0,
-            log_martians: 0,
-            tag: 0,
-            arpfilter: 0,
-            medium_id: 0,
-            noxfrm: 1,
-            nopolicy: 1,
-            force_igmp_version: 0,
-            arp_announce: 0,
-            arp_ignore: 0,
-            promote_secondaries: 0,
-            arp_accept: 0,
-            arp_notify: 0,
-            accept_local: 0,
-            src_vmark: 0,
-            proxy_arp_pvlan: 0,
-            route_localnet: 0,
-            igmpv2_unsolicited_report_interval: 10000,
-            igmpv3_unsolicited_report_interval: 1000,
-            ignore_routes_with_linkdown: 0,
-            drop_unicast_in_l2_multicast: 0,
-            drop_gratuitous_arp: 0,
-        })]);
+        LinkAfSpecInetNla::Inet(vec![LinkAfInetNla::DevConf(get_byte_buffer(
+            &LinkInetDevConf {
+                forwarding: 1,
+                mc_forwarding: 0,
+                proxy_arp: 0,
+                accept_redirects: 1,
+                secure_redirects: 1,
+                send_redirects: 1,
+                shared_media: 1,
+                rp_filter: 0,
+                accept_source_route: 1,
+                bootp_relay: 0,
+                log_martians: 0,
+                tag: 0,
+                arpfilter: 0,
+                medium_id: 0,
+                noxfrm: 1,
+                nopolicy: 1,
+                force_igmp_version: 0,
+                arp_announce: 0,
+                arp_ignore: 0,
+                promote_secondaries: 0,
+                arp_accept: 0,
+                arp_notify: 0,
+                accept_local: 0,
+                src_vmark: 0,
+                proxy_arp_pvlan: 0,
+                route_localnet: 0,
+                igmpv2_unsolicited_report_interval: 10000,
+                igmpv3_unsolicited_report_interval: 1000,
+                ignore_routes_with_linkdown: 0,
+                drop_unicast_in_l2_multicast: 0,
+                drop_gratuitous_arp: 0,
+            }
+        ))]);
 }
 
 #[test]

--- a/netlink-packet-route/src/rtnl/neighbour/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/nlas/mod.rs
@@ -9,7 +9,7 @@ use failure::ResultExt;
 use crate::{
     rtnl::{
         nla::{DefaultNla, Nla, NlaBuffer},
-        traits::{Emitable, Parseable},
+        traits::Parseable,
         utils::{parse_u16, parse_u32},
     },
     DecodeError,
@@ -33,7 +33,7 @@ pub enum NeighbourNla {
     Unspec(Vec<u8>),
     Destination(Vec<u8>),
     LinkLocalAddress(Vec<u8>),
-    CacheInfo(NeighbourCacheInfo),
+    CacheInfo(Vec<u8>),
     Probes(Vec<u8>),
     Vlan(u16),
     Port(Vec<u8>),
@@ -56,8 +56,8 @@ impl Nla for NeighbourNla {
             | Probes(ref bytes)
             | Port(ref bytes)
             | Master(ref bytes)
+            | CacheInfo(ref bytes)
             | LinkNetNsId(ref bytes) => bytes.len(),
-            CacheInfo(_) => NEIGHBOUR_CACHE_INFO_LEN,
             Vlan(_) => size_of::<u16>(),
             Vni(_)
             | IfIndex(_)
@@ -76,8 +76,8 @@ impl Nla for NeighbourNla {
             | Probes(ref bytes)
             | Port(ref bytes)
             | Master(ref bytes)
+            | CacheInfo(ref bytes)
             | LinkNetNsId(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
-            CacheInfo(ref cacheinfo) => cacheinfo.emit(buffer),
             Vlan(ref value) => NativeEndian::write_u16(buffer, *value),
             Vni(ref value)
             | IfIndex(ref value)
@@ -114,11 +114,7 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NeighbourNla> for NlaBuffer<&'b
             NDA_UNSPEC => Unspec(payload.to_vec()),
             NDA_DST => Destination(payload.to_vec()),
             NDA_LLADDR => LinkLocalAddress(payload.to_vec()),
-            NDA_CACHEINFO => CacheInfo(
-                NeighbourCacheInfoBuffer::new(payload)
-                    .parse()
-                    .context("invalid NDA_CACHEINFO value")?,
-            ),
+            NDA_CACHEINFO => CacheInfo(payload.to_vec()),
             NDA_PROBES => Probes(payload.to_vec()),
             NDA_VLAN => Vlan(parse_u16(payload)?),
             NDA_PORT => Port(payload.to_vec()),

--- a/netlink-packet-route/src/rtnl/neighbour_table/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/nlas/mod.rs
@@ -12,7 +12,7 @@ use failure::ResultExt;
 use crate::{
     rtnl::{
         nla::{DefaultNla, Nla, NlaBuffer},
-        traits::{Emitable, Parseable},
+        traits::Parseable,
         utils::{parse_string, parse_u32, parse_u64},
     },
     DecodeError,
@@ -38,8 +38,8 @@ pub enum NeighbourTableNla {
     Threshold1(u32),
     Threshold2(u32),
     Threshold3(u32),
-    Config(NeighbourTableConfig),
-    Stats(NeighbourTableStats),
+    Config(Vec<u8>),
+    Stats(Vec<u8>),
     GcInterval(u64),
     Other(DefaultNla),
 }
@@ -49,13 +49,11 @@ impl Nla for NeighbourTableNla {
     fn value_len(&self) -> usize {
         use self::NeighbourTableNla::*;
         match *self {
-            Unspec(ref bytes) | Parms(ref bytes) => bytes.len(),
+            Unspec(ref bytes) | Parms(ref bytes) | Config(ref bytes) | Stats(ref bytes)=> bytes.len(),
             // strings: +1 because we need to append a nul byte
             Name(ref s) => s.len() + 1,
             Threshold1(_) | Threshold2(_) | Threshold3(_) => size_of::<u32>(),
             GcInterval(_) => size_of::<u64>(),
-            Config(_) => NEIGHBOUR_TABLE_CONFIG_LEN,
-            Stats(_) => NEIGHBOUR_TABLE_STATS_LEN,
             Other(ref attr) => attr.value_len(),
         }
     }
@@ -63,13 +61,13 @@ impl Nla for NeighbourTableNla {
     fn emit_value(&self, buffer: &mut [u8]) {
         use self::NeighbourTableNla::*;
         match *self {
-            Unspec(ref bytes) | Parms(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Unspec(ref bytes) | Parms(ref bytes) | Config(ref bytes) | Stats(ref bytes) => {
+                buffer.copy_from_slice(bytes.as_slice())
+            }
             Name(ref string) => {
                 buffer[..string.len()].copy_from_slice(string.as_bytes());
                 buffer[string.len()] = 0;
             }
-            Config(ref config) => config.emit(buffer),
-            Stats(ref stats) => stats.emit(buffer),
             GcInterval(ref value) => NativeEndian::write_u64(buffer, *value),
             Threshold1(ref value) | Threshold2(ref value) | Threshold3(ref value) => {
                 NativeEndian::write_u32(buffer, *value)
@@ -102,16 +100,8 @@ impl<'buffer, T: AsRef<[u8]> + ?Sized> Parseable<NeighbourTableNla> for NlaBuffe
         Ok(match self.kind() {
             NDTA_UNSPEC => Unspec(payload.to_vec()),
             NDTA_NAME => Name(parse_string(payload).context("invalid NDTA_NAME value")?),
-            NDTA_CONFIG => Config(
-                NeighbourTableConfigBuffer::new(payload)
-                    .parse()
-                    .context("invalid NDTA_CONFIG value")?,
-            ),
-            NDTA_STATS => Stats(
-                NeighbourTableStatsBuffer::new(payload)
-                    .parse()
-                    .context("invalid NDTA_STATS value")?,
-            ),
+            NDTA_CONFIG => Config(payload.to_vec()),
+            NDTA_STATS => Stats(payload.to_vec()),
             NDTA_PARMS => Parms(payload.to_vec()),
             NDTA_GC_INTERVAL => {
                 GcInterval(parse_u64(payload).context("invalid NDTA_GC_INTERVAL value")?)


### PR DESCRIPTION
We've been having issues with running this library on multiple different kernels when receiving netlink messages which layout is kernel specific - if the length of a struct is different on a different kernel, then the serialization will fail and panic. The changes I've got here just change the the different NLA enumerations to not actually contain any kernel specific structures. Unfortunately, this means that all of the different structs that may be different on different kernels are now represented as byte vectors, but the user of the library may still use the existing code to parse the byte vectors into the already defined structs. 
If these changes are too intrusive, I'm open to finding a better solution :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/little-dude/netlink/51)
<!-- Reviewable:end -->
