### PR TITLE
Implement FromRawFd for netlink_sys::Socket

### DIFF
--- a/netlink-sys/src/sys.rs
+++ b/netlink-sys/src/sys.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::{Error, Result};
 use std::mem;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use super::Protocol;
 
@@ -14,6 +14,12 @@ pub struct Socket(RawFd);
 impl AsRawFd for Socket {
     fn as_raw_fd(&self) -> RawFd {
         self.0
+    }
+}
+
+impl FromRawFd for Socket {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Socket(fd)
     }
 }
 


### PR DESCRIPTION
This should allow users comfortable with calling into `libc::socket()` themselves create sockets that are not only `SOCK_DGRAM`, as `Socket::new()` currently provides no other way to specify the socket type otherwise.

This pull request does not modify the safe `Socket::new()` constructor nor add new ones for supporting other socket types, but perhaps that can be introduced in a follow-up PR.

Fixes #58.