### PR TITLE
Add support for adding, getting and deleting routes.

### DIFF
--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1.3.2"
 libc = "0.2.61"
 netlink-packet-core = { path = "../netlink-packet-core", version = "0.1" }
 netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.1" }
+bitflags = "1.2.1"
 
 [[example]]
 name = "dump_links"

--- a/netlink-packet-route/src/lib.rs
+++ b/netlink-packet-route/src/lib.rs
@@ -1,4 +1,6 @@
 #[macro_use]
+extern crate bitflags;
+#[macro_use]
 pub(crate) extern crate netlink_packet_utils as utils;
 pub(crate) use self::utils::parsers;
 pub use self::utils::{traits, DecodeError};

--- a/netlink-packet-route/src/rtnl/mod.rs
+++ b/netlink-packet-route/src/rtnl/mod.rs
@@ -19,10 +19,7 @@ pub mod nsid;
 pub use nsid::{NsidHeader, NsidMessage, NsidMessageBuffer, NSID_HEADER_LEN};
 
 pub mod route;
-pub use route::{
-    RouteFlags, RouteHeader, RouteKind, RouteMessage, RouteMessageBuffer, RouteProtocol,
-    RouteScope, RouteTable, ROUTE_HEADER_LEN,
-};
+pub use route::{RouteFlags, RouteHeader, RouteMessage, RouteMessageBuffer, ROUTE_HEADER_LEN};
 
 pub mod tc;
 pub use tc::{TcHeader, TcMessage, TcMessageBuffer, TC_HEADER_LEN};

--- a/netlink-packet-route/src/rtnl/route/buffer.rs
+++ b/netlink-packet-route/src/rtnl/route/buffer.rs
@@ -7,9 +7,9 @@ pub const ROUTE_HEADER_LEN: usize = 12;
 
 buffer!(RouteMessageBuffer(ROUTE_HEADER_LEN) {
     address_family: (u8, 0),
-    destination_length: (u8, 1),
-    source_length: (u8, 2),
-    tos: (u8, 2),
+    destination_prefix_length: (u8, 1),
+    source_prefix_length: (u8, 2),
+    tos: (u8, 3),
     table: (u8, 4),
     protocol: (u8, 5),
     scope: (u8, 6),

--- a/netlink-packet-route/src/rtnl/route/header.rs
+++ b/netlink-packet-route/src/rtnl/route/header.rs
@@ -4,376 +4,35 @@ use crate::{
     DecodeError, RouteMessageBuffer, ROUTE_HEADER_LEN,
 };
 
-/// Route type
-///
-/// ```rust
-/// # extern crate netlink_packet_route;
-/// # use netlink_packet_route::RouteKind;
-/// #
-/// # fn main() {
-/// assert_eq!(RouteKind::default(), RouteKind::Unspec);
-/// # }
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub enum RouteKind {
-    /// Unknown route
-    Unspec,
-    /// A gateway or direct route
-    Unicast,
-    /// A local interface route
-    Local,
-    /// A local broadcast route (sent as a broadcast)
-    Broadcast,
-    /// A local broadcast route (sent as a unicast)
-    Anycast,
-    /// A multicast route
-    Multicast,
-    /// A packet dropping route
-    Blackhole,
-    /// An unreachable destination
-    Unreachable,
-    /// A packet rejection route
-    Prohibit,
-    /// Continue routing lookup in another table
-    Throw,
-    /// A network address translation rule
-    Nat,
-    /// Refer to an external resolver (not implemented)
-    Xresolve,
-    Unknown(u8),
+bitflags! {
+    /// Flags that can be set in a `RTM_GETROUTE` ([`RtnlMessage::GetRoute`]) message.
+    pub struct RouteFlags: u32 {
+        /// If the route changes, notify the user via rtnetlink
+        const RTM_F_NOTIFY = RTM_F_NOTIFY;
+        /// This route is cloned. Cloned routes are routes coming from the cache instead of the
+        /// FIB. For IPv4, the cache was removed in Linux 3.6 (see [IPv4 route lookup on Linux] for
+        /// more information about IPv4 routing)
+        ///
+        /// [IPv4 route lookup on Linux]: https://vincent.bernat.ch/en/blog/2017-ipv4-route-lookup-linux
+        const RTM_F_CLONED = RTM_F_CLONED;
+        /// Multipath equalizer (not yet implemented)
+        const RTM_F_EQUALIZE = RTM_F_EQUALIZE;
+        /// Prefix addresses
+        const RTM_F_PREFIX = RTM_F_PREFIX;
+        /// Show the table from which the lookup result comes. Note that before commit
+        /// `c36ba6603a11`, Linux would always hardcode [`RouteMessageHeader.table`] (known as
+        /// `rtmsg.rtm_table` in the kernel) to `RT_TABLE_MAIN`.
+        ///
+        /// [`RouteMessageHeader.table`]: ../struct.RouteMessageHeader.html#structfield.table
+        const RTM_F_LOOKUP_TABLE = RTM_F_LOOKUP_TABLE;
+        /// Return the full FIB lookup match (see commit `b61798130f1be5bff08712308126c2d7ebe390ef`)
+        const RTM_F_FIB_MATCH = RTM_F_FIB_MATCH;
+    }
 }
 
-impl Default for RouteKind {
+impl Default for RouteFlags {
     fn default() -> Self {
-        RouteKind::Unspec
-    }
-}
-
-impl From<RouteKind> for u8 {
-    fn from(value: RouteKind) -> u8 {
-        use self::RouteKind::*;
-        match value {
-            Unspec => RTN_UNSPEC,
-            Unicast => RTN_UNICAST,
-            Local => RTN_LOCAL,
-            Broadcast => RTN_BROADCAST,
-            Anycast => RTN_ANYCAST,
-            Multicast => RTN_MULTICAST,
-            Blackhole => RTN_BLACKHOLE,
-            Unreachable => RTN_UNREACHABLE,
-            Prohibit => RTN_PROHIBIT,
-            Throw => RTN_THROW,
-            Nat => RTN_NAT,
-            Xresolve => RTN_XRESOLVE,
-            Unknown(t) => t,
-        }
-    }
-}
-
-impl From<u8> for RouteKind {
-    fn from(value: u8) -> RouteKind {
-        use self::RouteKind::*;
-        match value {
-            RTN_UNSPEC => Unspec,
-            RTN_UNICAST => Unicast,
-            RTN_LOCAL => Local,
-            RTN_BROADCAST => Broadcast,
-            RTN_ANYCAST => Anycast,
-            RTN_MULTICAST => Multicast,
-            RTN_BLACKHOLE => Blackhole,
-            RTN_UNREACHABLE => Unreachable,
-            RTN_PROHIBIT => Prohibit,
-            RTN_THROW => Throw,
-            RTN_NAT => Nat,
-            RTN_XRESOLVE => Xresolve,
-            _ => Unknown(value),
-        }
-    }
-}
-
-/// Protocol from which a route was learnt.
-///
-/// ```rust
-/// # extern crate netlink_packet_route;
-/// # use netlink_packet_route::RouteProtocol;
-/// #
-/// # fn main() {
-/// assert_eq!(RouteProtocol::default(), RouteProtocol::Unspec);
-/// # }
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub enum RouteProtocol {
-    /// Unknown
-    Unspec,
-    /// Route was learnt by an ICMP redirect
-    Redirect,
-    /// Route was learnt by the kernel
-    Kernel,
-    /// Route was learnt during boot
-    Boot,
-    /// Route was set statically
-    Static,
-    Gated,
-    Ra,
-    Mrt,
-    Zebra,
-    Bird,
-    Dnrouted,
-    Xorp,
-    Ntk,
-    Dhcp,
-    Mrouted,
-    Babel,
-    Unknown(u8),
-}
-
-impl Default for RouteProtocol {
-    fn default() -> Self {
-        RouteProtocol::Unspec
-    }
-}
-
-impl From<RouteProtocol> for u8 {
-    fn from(value: RouteProtocol) -> u8 {
-        use self::RouteProtocol::*;
-        match value {
-            Unspec => RTPROT_UNSPEC,
-            Redirect => RTPROT_REDIRECT,
-            Kernel => RTPROT_KERNEL,
-            Boot => RTPROT_BOOT,
-            Static => RTPROT_STATIC,
-            Gated => RTPROT_GATED,
-            Ra => RTPROT_RA,
-            Mrt => RTPROT_MRT,
-            Zebra => RTPROT_ZEBRA,
-            Bird => RTPROT_BIRD,
-            Dnrouted => RTPROT_DNROUTED,
-            Xorp => RTPROT_XORP,
-            Ntk => RTPROT_NTK,
-            Dhcp => RTPROT_DHCP,
-            Mrouted => RTPROT_MROUTED,
-            Babel => RTPROT_BABEL,
-            Unknown(t) => t,
-        }
-    }
-}
-
-impl From<u8> for RouteProtocol {
-    fn from(value: u8) -> RouteProtocol {
-        use self::RouteProtocol::*;
-        match value {
-            RTPROT_UNSPEC => Unspec,
-            RTPROT_REDIRECT => Redirect,
-            RTPROT_KERNEL => Kernel,
-            RTPROT_BOOT => Boot,
-            RTPROT_STATIC => Static,
-            RTPROT_GATED => Gated,
-            RTPROT_RA => Ra,
-            RTPROT_MRT => Mrt,
-            RTPROT_ZEBRA => Zebra,
-            RTPROT_BIRD => Bird,
-            RTPROT_DNROUTED => Dnrouted,
-            RTPROT_XORP => Xorp,
-            RTPROT_NTK => Ntk,
-            RTPROT_DHCP => Dhcp,
-            RTPROT_MROUTED => Mrouted,
-            RTPROT_BABEL => Babel,
-            _ => Unknown(value),
-        }
-    }
-}
-
-/// Distance to the destination
-///
-/// ```rust
-/// # extern crate netlink_packet_route;
-/// # use netlink_packet_route::RouteScope;
-/// #
-/// # fn main() {
-/// assert_eq!(RouteScope::default(), RouteScope::Universe);
-/// # }
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub enum RouteScope {
-    /// Global route
-    Universe,
-    /// Interior route in the local autonomous system
-    Site,
-    /// Route on this link
-    Link,
-    /// Route on the local host
-    Host,
-    /// Destination doesn't exist
-    Nowhere,
-    Unknown(u8),
-}
-
-impl Default for RouteScope {
-    fn default() -> Self {
-        RouteScope::Universe
-    }
-}
-
-impl From<RouteScope> for u8 {
-    fn from(value: RouteScope) -> u8 {
-        use self::RouteScope::*;
-        match value {
-            Universe => RT_SCOPE_UNIVERSE,
-            Site => RT_SCOPE_SITE,
-            Link => RT_SCOPE_LINK,
-            Host => RT_SCOPE_HOST,
-            Nowhere => RT_SCOPE_NOWHERE,
-            Unknown(t) => t,
-        }
-    }
-}
-
-impl From<u8> for RouteScope {
-    fn from(value: u8) -> RouteScope {
-        use self::RouteScope::*;
-        match value {
-            RT_SCOPE_UNIVERSE => Universe,
-            RT_SCOPE_SITE => Site,
-            RT_SCOPE_LINK => Link,
-            RT_SCOPE_HOST => Host,
-            RT_SCOPE_NOWHERE => Nowhere,
-            _ => Unknown(value),
-        }
-    }
-}
-
-/// Routing table
-///
-/// ```rust
-/// # extern crate netlink_packet_route;
-/// # use netlink_packet_route::RouteTable;
-/// #
-/// # fn main() {
-/// assert_eq!(RouteTable::default(), RouteTable::Unspec);
-/// # }
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-pub enum RouteTable {
-    Unspec,
-    Compat,
-    Default,
-    Main,
-    Local,
-    Unknown(u8),
-}
-
-impl Default for RouteTable {
-    fn default() -> Self {
-        RouteTable::Unspec
-    }
-}
-
-impl From<RouteTable> for u8 {
-    fn from(value: RouteTable) -> u8 {
-        use self::RouteTable::*;
-        match value {
-            Unspec => RT_TABLE_UNSPEC,
-            Compat => RT_TABLE_COMPAT,
-            Default => RT_TABLE_DEFAULT,
-            Main => RT_TABLE_MAIN,
-            Local => RT_TABLE_LOCAL,
-            Unknown(t) => t,
-        }
-    }
-}
-
-impl From<u8> for RouteTable {
-    fn from(value: u8) -> RouteTable {
-        use self::RouteTable::*;
-        match value {
-            RT_TABLE_UNSPEC => Unspec,
-            RT_TABLE_COMPAT => Compat,
-            RT_TABLE_DEFAULT => Default,
-            RT_TABLE_MAIN => Main,
-            RT_TABLE_LOCAL => Local,
-            _ => Unknown(value),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Default)]
-pub struct RouteFlags(u32);
-
-impl From<u32> for RouteFlags {
-    fn from(value: u32) -> Self {
-        RouteFlags(value)
-    }
-}
-
-impl From<RouteFlags> for u32 {
-    fn from(value: RouteFlags) -> Self {
-        value.0
-    }
-}
-
-impl RouteFlags {
-    /// Create a new empty flags field (no flag is set)
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Check whether the`RTM_F_NOTIFY` flag is set. If this flag is set and the route changes, a
-    /// rtnetlink notification is sent to the user by the kernel.
-    pub fn has_notify(self) -> bool {
-        self.0 & RTM_F_NOTIFY == RTM_F_NOTIFY
-    }
-
-    /// Set the `RTM_F_NOTIFY` flag. If this flag is set and the route changes, a rtnetlink
-    /// notification is sent to the user by the kernel.
-    pub fn set_notify(&mut self) {
-        self.0 |= RTM_F_NOTIFY
-    }
-
-    /// Check whether the`RTM_F_CLONED` flag is set. This flag is set if the route is cloned from
-    /// another route.
-    pub fn has_cloned(self) -> bool {
-        self.0 & RTM_F_CLONED == RTM_F_CLONED
-    }
-
-    /// Set the`RTM_F_CLONED` flag. This flag is set if the route is cloned from another route.
-    pub fn set_cloned(&mut self) {
-        self.0 |= RTM_F_CLONED
-    }
-
-    /// Check whether the`RTM_F_EQUALIZE` flag is set.
-    pub fn has_equalize(self) -> bool {
-        self.0 & RTM_F_EQUALIZE == RTM_F_EQUALIZE
-    }
-
-    /// Set the`RTM_F_EQUALIZE` flag.
-    pub fn set_equalize(&mut self) {
-        self.0 |= RTM_F_EQUALIZE
-    }
-
-    /// Check whether the`RTM_F_PREFIX` flag is set.
-    pub fn has_prefix(self) -> bool {
-        self.0 & RTM_F_PREFIX == RTM_F_PREFIX
-    }
-
-    /// Set the`RTM_F_PREFIX` flag.
-    pub fn set_prefix(&mut self) {
-        self.0 |= RTM_F_PREFIX
-    }
-
-    /// Check whether the`RTM_F_LOOKUP_TABLE` flag is set.
-    pub fn has_lookup_table(self) -> bool {
-        self.0 & RTM_F_LOOKUP_TABLE == RTM_F_LOOKUP_TABLE
-    }
-
-    /// Set the`RTM_F_LOOKUP_TABLE` flag.
-    pub fn set_lookup_table(&mut self) {
-        self.0 |= RTM_F_LOOKUP_TABLE
-    }
-
-    /// Check whether the`RTM_F_FIB_MATCH` flag is set.
-    pub fn has_fib_match(self) -> bool {
-        self.0 & RTM_F_FIB_MATCH == RTM_F_FIB_MATCH
-    }
-
-    /// Set the`RTM_F_FIB_MATCH` flag.
-    pub fn set_fib_match(&mut self) {
-        self.0 |= RTM_F_FIB_MATCH
+        Self::empty()
     }
 }
 
@@ -397,48 +56,74 @@ impl RouteFlags {
 ///
 /// ```rust
 /// extern crate netlink_packet_route;
-/// use netlink_packet_route::{RouteHeader, RouteFlags, RouteProtocol, RouteTable, RouteScope, RouteKind};
+/// use netlink_packet_route::{constants::*, RouteHeader, RouteFlags};
 ///
 /// fn main() {
 ///     let mut hdr = RouteHeader::default();
 ///     assert_eq!(hdr.address_family, 0u8);
-///     assert_eq!(hdr.destination_length, 0u8);
-///     assert_eq!(hdr.source_length, 0u8);
+///     assert_eq!(hdr.destination_prefix_length, 0u8);
+///     assert_eq!(hdr.source_prefix_length, 0u8);
 ///     assert_eq!(hdr.tos, 0u8);
-///     assert_eq!(hdr.table, RouteTable::Unspec);
-///     assert_eq!(hdr.protocol, RouteProtocol::Unspec);
-///     assert_eq!(hdr.scope, RouteScope::Universe);
-///     assert_eq!(hdr.kind, RouteKind::Unspec);
-///     assert_eq!(u32::from(hdr.flags), 0u32);
+///     assert_eq!(hdr.table, RT_TABLE_UNSPEC);
+///     assert_eq!(hdr.protocol, RTPROT_UNSPEC);
+///     assert_eq!(hdr.scope, RT_SCOPE_UNIVERSE);
+///     assert_eq!(hdr.kind, RTN_UNSPEC);
+///     assert_eq!(hdr.flags.bits(), 0u32);
 ///
-///     hdr.destination_length = 8;
-///     hdr.table = RouteTable::Default;
-///     hdr.protocol = RouteProtocol::Kernel;
-///     hdr.scope = RouteScope::Nowhere;
+///     // set some values
+///     hdr.destination_prefix_length = 8;
+///     hdr.table = RT_TABLE_MAIN;
+///     hdr.protocol = RTPROT_KERNEL;
+///     hdr.scope = RT_SCOPE_NOWHERE;
 ///
 ///     // ...
 /// }
 /// ```
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct RouteHeader {
-    /// Address family of the route
+    /// Address family of the route: either [`AF_INET`] for IPv4 prefixes, or [`AF_INET6`] for IPv6
+    /// prefixes.
     pub address_family: u8,
-    /// Length of destination
-    pub destination_length: u8,
-    /// Length of source
-    pub source_length: u8,
+    /// Prefix length of the destination subnet.
+    ///
+    /// Note that setting
+    pub destination_prefix_length: u8,
+    /// Prefix length of the source address.
+    ///
+    /// There could be multiple addresses from which a certain network is reachable. To decide which
+    /// source address to use to reach and address in that network, the kernel rely on the route's
+    /// source address for this destination.
+    ///
+    /// For instance, interface `if1` could have two addresses `10.0.0.1/24` and `10.0.0.128/24`,
+    /// and we could have the following routes:
+    ///
+    /// ```no_rust
+    /// 10.0.0.10/32 dev if1 scope link src 10.0.0.1
+    /// 10.0.0.11/32 dev if1 scope link src 10.0.0.1
+    /// 10.0.0.12/32 dev if1 scope link src 10.0.0.1
+    /// 10.0.0.0/24 dev if1 scope link src 10.0.0.128
+    /// ```
+    ///
+    /// It means that for `10.0.0.10`, `10.0.0.11` and `10.0.0.12` the packets will be sent with
+    /// `10.0.0.1` as source address, while for the rest of the `10.0.0.0/24` subnet, the source
+    /// address will be `10.0.0.128`
+    pub source_prefix_length: u8,
     /// TOS filter
     pub tos: u8,
-
-    /// The routing table ID
-    pub table: RouteTable,
-    /// The routing protocol
-    pub protocol: RouteProtocol,
-    /// Distance to the destination
-    pub scope: RouteScope,
-    /// Route type
-    pub kind: RouteKind,
-
+    /// Routing table ID. It can be one of the `RT_TABLE_*` constants or a custom table number
+    /// between 1 and 251 (included). Note that Linux supports routing table with an ID greater than
+    /// 255, in which case this attribute will be set to [`RT_TABLE_COMPAT`] and an [`Nla::Table`]
+    /// netlink attribute will be present in the message.
+    pub table: u8,
+    /// Protocol from which the route was learnt. It should be set to one of the `RTPROT_*`
+    /// constants.
+    pub protocol: u8,
+    /// The scope of the area where the addresses in the destination subnet are valid. Predefined
+    /// scope values are the `RT_SCOPE_*` constants.
+    pub scope: u8,
+    /// Route type. It should be set to one of the `RTN_*` constants.
+    pub kind: u8,
+    /// Flags when querying the kernel with a `RTM_GETROUTE` message. See [`RouteFlags`].
     pub flags: RouteFlags,
 }
 
@@ -446,14 +131,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteMessageBuffer<&'a T>> for Route
     fn parse(buf: &RouteMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(RouteHeader {
             address_family: buf.address_family(),
-            destination_length: buf.destination_length(),
-            source_length: buf.source_length(),
+            destination_prefix_length: buf.destination_prefix_length(),
+            source_prefix_length: buf.source_prefix_length(),
             tos: buf.tos(),
             table: buf.table().into(),
             protocol: buf.protocol().into(),
             scope: buf.scope().into(),
             kind: buf.kind().into(),
-            flags: buf.flags().into(),
+            flags: RouteFlags::from_bits_truncate(buf.flags()),
         })
     }
 }
@@ -466,13 +151,13 @@ impl Emitable for RouteHeader {
     fn emit(&self, buffer: &mut [u8]) {
         let mut buffer = RouteMessageBuffer::new(buffer);
         buffer.set_address_family(self.address_family);
-        buffer.set_destination_length(self.destination_length);
-        buffer.set_source_length(self.source_length);
+        buffer.set_destination_prefix_length(self.destination_prefix_length);
+        buffer.set_source_prefix_length(self.source_prefix_length);
         buffer.set_tos(self.tos);
-        buffer.set_table(self.table.into());
-        buffer.set_protocol(self.protocol.into());
-        buffer.set_scope(self.scope.into());
-        buffer.set_kind(self.kind.into());
-        buffer.set_flags(self.flags.into());
+        buffer.set_table(self.table);
+        buffer.set_protocol(self.protocol);
+        buffer.set_scope(self.scope);
+        buffer.set_kind(self.kind);
+        buffer.set_flags(self.flags.bits());
     }
 }

--- a/rtnetlink/examples/add_route.rs
+++ b/rtnetlink/examples/add_route.rs
@@ -1,0 +1,57 @@
+use std::env;
+
+use ipnetwork::Ipv4Network;
+use rtnetlink::{new_connection, Error, Handle};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        usage();
+        return Ok(());
+    }
+
+    let dest: Ipv4Network = args[1].parse().unwrap_or_else(|_| {
+        eprintln!("invalid destination");
+        std::process::exit(1);
+    });
+    let gateway: Ipv4Network = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("invalid gateway");
+        std::process::exit(1);
+    });
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    if let Err(e) = add_route(&dest, &gateway, handle.clone()).await {
+        eprintln!("{}", e);
+    }
+    Ok(())
+}
+
+async fn add_route(dest: &Ipv4Network, gateway: &Ipv4Network, handle: Handle) -> Result<(), Error> {
+    let route = handle.route();
+    route
+        .add_v4()
+        .destination_prefix(dest.ip(), dest.prefix())
+        .gateway(gateway.ip())
+        .execute()
+        .await?;
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example add_route -- <destination>/<prefix_length> <gateway>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example add_route
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./add_route <destination>/<prefix_length> <gateway>"
+    );
+}

--- a/rtnetlink/examples/get_route.rs
+++ b/rtnetlink/examples/get_route.rs
@@ -1,0 +1,30 @@
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle, IpVersion};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    println!("dumping routes for IPv4");
+    if let Err(e) = dump_addresses(handle.clone(), IpVersion::V4).await {
+        eprintln!("{}", e);
+    }
+    println!();
+
+    println!("dumping routes for IPv6");
+    if let Err(e) = dump_addresses(handle.clone(), IpVersion::V6).await {
+        eprintln!("{}", e);
+    }
+    println!();
+
+    Ok(())
+}
+
+async fn dump_addresses(handle: Handle, ip_version: IpVersion) -> Result<(), Error> {
+    let mut routes = handle.route().get(ip_version).execute();
+    while let Some(route) = routes.try_next().await? {
+        println!("{:?}", route);
+    }
+    Ok(())
+}

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
-    AddressHandle, Error, ErrorKind, LinkHandle,
+    AddressHandle, Error, ErrorKind, LinkHandle, RouteHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -39,5 +39,10 @@ impl Handle {
     /// Create a new handle, specifically for address requests (equivalent to `ip addr` commands)
     pub fn address(&self) -> AddressHandle {
         AddressHandle::new(self.clone())
+    }
+
+    /// Create a new handle, specifically for routing table requests (equivalent to `ip route` commands)
+    pub fn route(&self) -> RouteHandle {
+        RouteHandle::new(self.clone())
     }
 }

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -17,6 +17,9 @@ pub use crate::link::*;
 mod addr;
 pub use crate::addr::*;
 
+mod route;
+pub use crate::route::*;
+
 mod connection;
 pub use crate::connection::*;
 

--- a/rtnetlink/src/route/add.rs
+++ b/rtnetlink/src/route/add.rs
@@ -1,0 +1,268 @@
+use futures::stream::StreamExt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use netlink_packet_route::{
+    constants::*, nlas::route::Nla, NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage,
+};
+
+use crate::{Error, ErrorKind, Handle};
+
+/// A request to create a new route. This is equivalent to the `ip route add` commands.
+struct RouteAddRequest {
+    handle: Handle,
+    message: RouteMessage,
+}
+
+impl RouteAddRequest {
+    fn new(handle: Handle) -> Self {
+        let mut message = RouteMessage::default();
+
+        message.header.table = RT_TABLE_MAIN;
+        message.header.protocol = RTPROT_STATIC;
+        message.header.scope = RT_SCOPE_UNIVERSE;
+        message.header.kind = RTN_UNICAST;
+
+        RouteAddRequest { handle, message }
+    }
+
+    /// Sets the input interface index.
+    fn input_interface(mut self, index: u32) -> Self {
+        self.message.nlas.push(Nla::Iif(index));
+        self
+    }
+
+    /// Sets the output interface index.
+    fn output_interface(mut self, index: u32) -> Self {
+        self.message.nlas.push(Nla::Oif(index));
+        self
+    }
+
+    /// Sets the route table.
+    ///
+    /// Default is main route table.
+    fn table(mut self, table: u8) -> Self {
+        self.message.header.table = table;
+        self
+    }
+
+    /// Sets the route protocol.
+    ///
+    /// Default is static route protocol.
+    fn protocol(mut self, protocol: u8) -> Self {
+        self.message.header.protocol = protocol;
+        self
+    }
+
+    /// Sets the route scope.
+    ///
+    /// Default is universe route scope.
+    fn scope(mut self, scope: u8) -> Self {
+        self.message.header.scope = scope;
+        self
+    }
+
+    /// Sets the route kind.
+    ///
+    /// Default is unicast route kind.
+    fn kind(mut self, kind: u8) -> Self {
+        self.message.header.kind = kind;
+        self
+    }
+
+    /// Execute the request.
+    pub async fn execute(self) -> Result<(), Error> {
+        let RouteAddRequest {
+            mut handle,
+            message,
+        } = self;
+        let mut req = NetlinkMessage::from(RtnlMessage::NewRoute(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+
+        let mut response = handle.request(req)?;
+        while let Some(message) = response.next().await {
+            if let NetlinkPayload::Error(err) = message.payload {
+                return Err(ErrorKind::NetlinkError(err).into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Return a mutable reference to the request message.
+    fn message_mut(&mut self) -> &mut RouteMessage {
+        &mut self.message
+    }
+}
+
+pub struct RouteAddIpv4Request(RouteAddRequest);
+
+impl RouteAddIpv4Request {
+    pub fn new(handle: Handle) -> Self {
+        let mut req = RouteAddRequest::new(handle);
+        req.message_mut().header.address_family = AF_INET as u8;
+        Self(req)
+    }
+
+    /// Sets the input interface index.
+    pub fn input_interface(self, index: u32) -> Self {
+        Self(self.0.input_interface(index))
+    }
+
+    /// Sets the output interface index.
+    pub fn output_interface(self, index: u32) -> Self {
+        Self(self.0.output_interface(index))
+    }
+
+    /// Sets the source address prefix.
+    pub fn source_prefix(mut self, addr: Ipv4Addr, prefix_length: u8) -> Self {
+        self.0.message.header.source_prefix_length = prefix_length;
+        self.0
+            .message
+            .nlas
+            .push(Nla::Source(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the destination address prefix.
+    pub fn destination_prefix(mut self, addr: Ipv4Addr, prefix_length: u8) -> Self {
+        self.0.message.header.destination_prefix_length = prefix_length;
+        self.0
+            .message
+            .nlas
+            .push(Nla::Destination(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the gateway (via) address.
+    pub fn gateway(mut self, addr: Ipv4Addr) -> Self {
+        self.0
+            .message
+            .nlas
+            .push(Nla::Gateway(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the route table.
+    ///
+    /// Default is main route table.
+    pub fn table(self, table: u8) -> Self {
+        Self(self.0.table(table))
+    }
+
+    /// Sets the route protocol.
+    ///
+    /// Default is static route protocol.
+    pub fn protocol(self, protocol: u8) -> Self {
+        Self(self.0.protocol(protocol))
+    }
+
+    /// Sets the route scope.
+    ///
+    /// Default is universe route scope.
+    pub fn scope(self, scope: u8) -> Self {
+        Self(self.0.scope(scope))
+    }
+
+    /// Sets the route kind.
+    ///
+    /// Default is unicast route kind.
+    pub fn kind(self, kind: u8) -> Self {
+        Self(self.0.kind(kind))
+    }
+
+    /// Execute the request.
+    pub async fn execute(self) -> Result<(), Error> {
+        self.0.execute().await
+    }
+
+    /// Return a mutable reference to the request message.
+    pub fn message_mut(&mut self) -> &mut RouteMessage {
+        self.0.message_mut()
+    }
+}
+
+pub struct RouteAddIpv6Request(RouteAddRequest);
+
+impl RouteAddIpv6Request {
+    pub fn new(handle: Handle) -> Self {
+        let mut req = RouteAddRequest::new(handle);
+        req.message_mut().header.address_family = AF_INET6 as u8;
+        Self(req)
+    }
+
+    /// Sets the input interface index.
+    pub fn input_interface(self, index: u32) -> Self {
+        Self(self.0.input_interface(index))
+    }
+
+    /// Sets the output interface index.
+    pub fn output_interface(self, index: u32) -> Self {
+        Self(self.0.output_interface(index))
+    }
+
+    /// Sets the source address prefix.
+    pub fn source_prefix(mut self, addr: Ipv6Addr, prefix_length: u8) -> Self {
+        self.0.message.header.source_prefix_length = prefix_length;
+        self.0
+            .message
+            .nlas
+            .push(Nla::Source(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the destination address prefix.
+    pub fn destination_prefix(mut self, addr: Ipv6Addr, prefix_length: u8) -> Self {
+        self.0.message.header.destination_prefix_length = prefix_length;
+        self.0
+            .message
+            .nlas
+            .push(Nla::Destination(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the gateway (via) address.
+    pub fn gateway(mut self, addr: Ipv6Addr) -> Self {
+        self.0
+            .message
+            .nlas
+            .push(Nla::Gateway(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the route table.
+    ///
+    /// Default is main route table.
+    pub fn table(self, table: u8) -> Self {
+        Self(self.0.table(table))
+    }
+
+    /// Sets the route protocol.
+    ///
+    /// Default is static route protocol.
+    pub fn protocol(self, protocol: u8) -> Self {
+        Self(self.0.protocol(protocol))
+    }
+
+    /// Sets the route scope.
+    ///
+    /// Default is universe route scope.
+    pub fn scope(self, scope: u8) -> Self {
+        Self(self.0.scope(scope))
+    }
+
+    /// Sets the route kind.
+    ///
+    /// Default is unicast route kind.
+    pub fn kind(self, kind: u8) -> Self {
+        Self(self.0.kind(kind))
+    }
+
+    /// Execute the request.
+    pub async fn execute(self) -> Result<(), Error> {
+        self.0.execute().await
+    }
+
+    /// Return a mutable reference to the request message.
+    pub fn message_mut(&mut self) -> &mut RouteMessage {
+        self.0.message_mut()
+    }
+}

--- a/rtnetlink/src/route/del.rs
+++ b/rtnetlink/src/route/del.rs
@@ -1,0 +1,39 @@
+use futures::stream::StreamExt;
+
+use crate::{
+    packet::{NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST},
+    Error, ErrorKind, Handle,
+};
+
+pub struct RouteDelRequest {
+    handle: Handle,
+    message: RouteMessage,
+}
+
+impl RouteDelRequest {
+    pub(crate) fn new(handle: Handle, message: RouteMessage) -> Self {
+        RouteDelRequest { handle, message }
+    }
+
+    /// Execute the request
+    pub async fn execute(self) -> Result<(), Error> {
+        let RouteDelRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::DelRoute(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        let mut response = handle.request(req)?;
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                return Err(ErrorKind::NetlinkError(e).into());
+            }
+        }
+        Ok(())
+    }
+
+    pub fn message_mut(&mut self) -> &mut RouteMessage {
+        &mut self.message
+    }
+}

--- a/rtnetlink/src/route/get.rs
+++ b/rtnetlink/src/route/get.rs
@@ -1,0 +1,80 @@
+use futures::{
+    future::{self, Either},
+    stream::{StreamExt, TryStream},
+    FutureExt,
+};
+
+use netlink_packet_route::{
+    constants::*, NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage,
+};
+
+use crate::{Error, ErrorKind, Handle};
+
+pub struct RouteGetRequest {
+    handle: Handle,
+    message: RouteMessage,
+}
+
+/// Internet Protocol (IP) version.
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+pub enum IpVersion {
+    /// IPv4
+    V4,
+    /// IPv6
+    V6,
+}
+
+impl RouteGetRequest {
+    pub(crate) fn new(handle: Handle, ip_version: IpVersion) -> Self {
+        let mut message = RouteMessage::default();
+        message.header.address_family = match ip_version {
+            IpVersion::V4 => AF_INET as u8,
+            IpVersion::V6 => AF_INET6 as u8,
+        };
+        // As per rtnetlink(7) documentation, setting the following
+        // fields to 0 gets us all the routes from all the tables
+        //
+        // > For RTM_GETROUTE, setting rtm_dst_len and rtm_src_len to 0
+        // > means you get all entries for the specified routing table.
+        // > For the other fields, except rtm_table and rtm_protocol, 0
+        // > is the wildcard.
+        message.header.destination_prefix_length = 0;
+        message.header.source_prefix_length = 0;
+        message.header.scope = RT_SCOPE_UNIVERSE;
+        message.header.kind = RTN_UNSPEC;
+
+        // I don't know if these two fields matter
+        message.header.table = RT_TABLE_UNSPEC;
+        message.header.protocol = RTPROT_UNSPEC;
+
+        RouteGetRequest { handle, message }
+    }
+
+    pub fn message_mut(&mut self) -> &mut RouteMessage {
+        &mut self.message
+    }
+
+    pub fn execute(self) -> impl TryStream<Ok = RouteMessage, Error = Error> {
+        let RouteGetRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::GetRoute(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        match handle.request(req) {
+            Ok(response) => Either::Left(response.map(move |msg| {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    NetlinkPayload::InnerMessage(RtnlMessage::NewRoute(msg)) => Ok(msg),
+                    NetlinkPayload::Error(err) => Err(ErrorKind::NetlinkError(err).into()),
+                    _ => Err(
+                        ErrorKind::UnexpectedMessage(NetlinkMessage::new(header, payload)).into(),
+                    ),
+                }
+            })),
+            Err(e) => Either::Right(future::err::<RouteMessage, Error>(e).into_stream()),
+        }
+    }
+}

--- a/rtnetlink/src/route/handle.rs
+++ b/rtnetlink/src/route/handle.rs
@@ -1,0 +1,33 @@
+//use std::net::IpAddr;
+
+use super::{RouteAddIpv4Request, RouteAddIpv6Request};
+use crate::{Handle, IpVersion, RouteDelRequest, RouteGetRequest};
+use netlink_packet_route::RouteMessage;
+
+pub struct RouteHandle(Handle);
+
+impl RouteHandle {
+    pub fn new(handle: Handle) -> Self {
+        RouteHandle(handle)
+    }
+
+    /// Retrieve the list of routing table entries (equivalent to `ip route show`)
+    pub fn get(&self, ip_version: IpVersion) -> RouteGetRequest {
+        RouteGetRequest::new(self.0.clone(), ip_version)
+    }
+
+    /// Add an routing table entry (equivalent to `ip route add`)
+    pub fn add_v4(&self) -> RouteAddIpv4Request {
+        RouteAddIpv4Request::new(self.0.clone())
+    }
+
+    /// Add an routing table entry (equivalent to `ip route add`)
+    pub fn add_v6(&self) -> RouteAddIpv6Request {
+        RouteAddIpv6Request::new(self.0.clone())
+    }
+
+    /// Delete the given routing table entry (equivalent to `ip route del`)
+    pub fn del(&self, route: RouteMessage) -> RouteDelRequest {
+        RouteDelRequest::new(self.0.clone(), route)
+    }
+}

--- a/rtnetlink/src/route/mod.rs
+++ b/rtnetlink/src/route/mod.rs
@@ -1,0 +1,11 @@
+mod handle;
+pub use self::handle::*;
+
+mod add;
+pub use self::add::*;
+
+mod del;
+pub use self::del::*;
+
+mod get;
+pub use self::get::*;


### PR DESCRIPTION
Taking over https://github.com/little-dude/netlink/pull/57. I used that opportunity to get rid of `RouteScope`, `RouteKind`, `RouteProtocol` and `RouteTable`. The constants, also they are weird names, are much more searchable.

Thanks a lot for this @surban!