### PR TITLE
Add RTNL support for routing rules

### DIFF
--- a/netlink-packet-route/src/rtnl/buffer.rs
+++ b/netlink-packet-route/src/rtnl/buffer.rs
@@ -95,7 +95,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<RtnlMessageBuffer<&'a T>
             }
 
             // Route messages
-            RTM_NEWROUTE | RTM_GETROUTE | RTM_DELROUTE => {
+            RTM_NEWROUTE | RTM_GETROUTE | RTM_DELROUTE |
+            RTM_NEWRULE | RTM_DELRULE | RTM_GETRULE => {
                 let msg = match RouteMessageBuffer::new_checked(&buf.inner()) {
                     Ok(buf) => RouteMessage::parse(&buf).context("invalid route message")?,
                     // HACK: iproute2 sends invalid RTM_GETROUTE message, where the header is
@@ -121,6 +122,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<RtnlMessageBuffer<&'a T>
                     RTM_NEWROUTE => NewRoute(msg),
                     RTM_GETROUTE => GetRoute(msg),
                     RTM_DELROUTE => DelRoute(msg),
+                    RTM_NEWRULE => NewRule(msg),
+                    RTM_GETRULE => GetRule(msg),
+                    RTM_DELRULE => DelRule(msg),
                     _ => unreachable!(),
                 }
             }

--- a/netlink-packet-route/src/rtnl/message.rs
+++ b/netlink-packet-route/src/rtnl/message.rs
@@ -26,6 +26,9 @@ pub enum RtnlMessage {
     NewRoute(RouteMessage),
     DelRoute(RouteMessage),
     GetRoute(RouteMessage),
+    NewRule(RouteMessage),
+    DelRule(RouteMessage),
+    GetRule(RouteMessage),
     NewQueueDiscipline(TcMessage),
     DelQueueDiscipline(TcMessage),
     GetQueueDiscipline(TcMessage),
@@ -265,6 +268,30 @@ impl RtnlMessage {
         }
     }
 
+    pub fn is_new_rule(&self) -> bool {
+        if let RtnlMessage::NewRule(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_get_rule(&self) -> bool {
+        if let RtnlMessage::GetRule(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_del_rule(&self) -> bool {
+        if let RtnlMessage::DelRule(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn message_type(&self) -> u16 {
         use self::RtnlMessage::*;
 
@@ -285,6 +312,9 @@ impl RtnlMessage {
             NewRoute(_) => RTM_NEWROUTE,
             DelRoute(_) => RTM_DELROUTE,
             GetRoute(_) => RTM_GETROUTE,
+            NewRule(_) => RTM_NEWRULE,
+            DelRule(_) => RTM_DELRULE,
+            GetRule(_) => RTM_GETRULE,
             NewQueueDiscipline(_) => RTM_NEWQDISC,
             DelQueueDiscipline(_) => RTM_DELQDISC,
             GetQueueDiscipline(_) => RTM_GETQDISC,
@@ -330,6 +360,9 @@ impl Emitable for RtnlMessage {
             | NewRoute(ref msg)
             | DelRoute(ref msg)
             | GetRoute(ref msg)
+            | NewRule(ref msg)
+            | DelRule(ref msg)
+            | GetRule(ref msg)
             => msg.buffer_len(),
 
             | NewQueueDiscipline(ref msg)
@@ -378,6 +411,9 @@ impl Emitable for RtnlMessage {
             | NewRoute(ref msg)
             | DelRoute(ref msg)
             | GetRoute(ref msg)
+            | NewRule(ref msg)
+            | DelRule(ref msg)
+            | GetRule(ref msg)
             => msg.emit(buffer),
 
             | NewQueueDiscipline(ref msg)


### PR DESCRIPTION
Well this was easy. According to `man 7 rtnetlink` these messages just carry a `struct rtmsg`.

Fixes #5