### PR TITLE
Allow ErrorMessage Conversion into std::io::Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/rtnetlink/src/errors.rs
+++ b/rtnetlink/src/errors.rs
@@ -14,7 +14,7 @@ pub enum ErrorKind {
     #[fail(display = "Received an unexpected message {:?}", _0)]
     UnexpectedMessage(NetlinkMessage<RtnlMessage>),
 
-    #[fail(display = "Received a netlink error message {:?}", _0)]
+    #[fail(display = "Received a netlink error message {}", _0)]
     NetlinkError(ErrorMessage),
 
     #[fail(display = "A netlink request failed")]


### PR DESCRIPTION
according to [netlink(7)](https://linux.die.net/man/7/netlink), the **`NLMSG_ERROR`** return sys errno code in **`Negative`** value. This can be converted into **`std::io::Error`** using **`from_raw_os_error`** and the absolute value of the errno code for a better error handling since currently the error message is displayed in raw value.