### PR TITLE
Fix nla emission in neighbour message

### DIFF
--- a/netlink-packet-route/src/rtnl/neighbour/header.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/header.rs
@@ -3,6 +3,20 @@ use crate::{
     DecodeError, NeighbourMessageBuffer, NEIGHBOUR_HEADER_LEN,
 };
 
+/// Neighbour headers have the following structure:
+///
+/// ```no_rust
+/// 0                8                16              24               32
+/// +----------------+----------------+----------------+----------------+
+/// |     family     |                     padding                      |
+/// +----------------+----------------+----------------+----------------+
+/// |                             link index                            |
+/// +----------------+----------------+----------------+----------------+
+/// |              state              |     flags      |     ntype      |
+/// +----------------+----------------+----------------+----------------+
+/// ```
+///
+/// `NeighbourHeader` exposes all these fields.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct NeighbourHeader {
     pub family: u8,

--- a/netlink-packet-route/src/rtnl/neighbour/message.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/message.rs
@@ -19,7 +19,7 @@ impl Emitable for NeighbourMessage {
 
     fn emit(&self, buffer: &mut [u8]) {
         self.header.emit(buffer);
-        self.nlas.as_slice().emit(buffer);
+        self.nlas.as_slice().emit(&mut buffer[self.header.buffer_len()..]);
     }
 }
 
@@ -40,5 +40,76 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourMessageBuffer<&'a T>> for Vec<N
             nlas.push(Nla::parse(&nla_buf?)?);
         }
         Ok(nlas)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        constants::*,
+        traits::Emitable,
+        NeighbourHeader, NeighbourMessage, NeighbourMessageBuffer
+    };
+
+    // 0020   0a 00 00 00 02 00 00 00 02 00 80 01 14 00 01 00
+    // 0030   2a 02 80 10 66 d5 00 00 f6 90 ea ff fe 00 2d 83
+    // 0040   0a 00 02 00 f4 90 ea 00 2d 83 00 00 08 00 04 00
+    // 0050   01 00 00 00 14 00 03 00 00 00 00 00 00 00 00 00
+    // 0060   00 00 00 00 02 00 00 00
+
+
+    #[rustfmt::skip]
+    static HEADER: [u8; 12] = [
+        0x0a, // interface family (inet6)
+        0xff, 0xff, 0xff, // padding
+        0x01, 0x00, 0x00, 0x00, // interface index = 1
+        0x02, 0x00, // state NUD_REACHABLE
+        0x80, // flags NTF_PROXY
+        0x01  // ntype
+
+        // nlas
+        // will add some once I've got them parsed out.
+    ];
+
+    #[test]
+    fn packet_header_read() {
+        let packet = NeighbourMessageBuffer::new(&HEADER[0..12]);
+        assert_eq!(packet.family(), AF_INET6 as u8);
+        assert_eq!(packet.ifindex(), 1);
+        assert_eq!(packet.state(), NUD_REACHABLE);
+        assert_eq!(packet.flags(), NTF_ROUTER);
+        assert_eq!(packet.ntype(), NDA_DST as u8);
+    }
+
+    #[test]
+    fn packet_header_build() {
+        let mut buf = vec![0xff; 12];
+        {
+            let mut packet = NeighbourMessageBuffer::new(&mut buf);
+            packet.set_family(AF_INET6 as u8);
+            packet.set_ifindex(1);
+            packet.set_state(NUD_REACHABLE);
+            packet.set_flags(NTF_ROUTER);
+            packet.set_ntype(NDA_DST as u8);
+        }
+        assert_eq!(&buf[..], &HEADER[0..12]);
+    }
+
+    #[test]
+    fn emit() {
+        let header = NeighbourHeader {
+            family: AF_INET6 as u8,
+            ifindex: 1,
+            state: NUD_REACHABLE,
+            flags: NTF_ROUTER,
+            ntype: NDA_DST as u8
+        };
+
+        let nlas = vec![];
+        let packet = NeighbourMessage { header, nlas };
+        let mut buf = vec![0; 12];
+
+        assert_eq!(packet.buffer_len(), 12);
+        packet.emit(&mut buf[..]);
     }
 }


### PR DESCRIPTION
Slice dst buffer to avoid overwriting the header.