### PR TITLE
Replace `failure` with `thiserror`

### DIFF
--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -13,7 +13,7 @@ description = "linux audit via netlink"
 
 [dependencies]
 futures = "0.3.1"
-failure = "0.1.6"
+thiserror = "1"
 netlink-packet-audit = { path = "../netlink-packet-audit", version = "0.1" }
 netlink-proto = { path = "../netlink-proto", features = ["workaround-audit-bug"], version = "0.2" }
 

--- a/audit/src/errors.rs
+++ b/audit/src/errors.rs
@@ -1,57 +1,15 @@
-use std::fmt::{self, Display};
-
-use failure::{Backtrace, Context, Fail};
+use thiserror::Error;
 
 use crate::packet::{AuditMessage, ErrorMessage, NetlinkMessage};
 
-#[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
-pub enum ErrorKind {
-    #[fail(display = "Received an unexpected message {:?}", _0)]
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum Error {
+    #[error("Received an unexpected message {0:?}")]
     UnexpectedMessage(NetlinkMessage<AuditMessage>),
 
-    #[fail(display = "Received a netlink error message {:?}", _0)]
+    #[error("Received a netlink error message {0:?}")]
     NetlinkError(ErrorMessage),
 
-    #[fail(display = "Request failed")]
+    #[error("Request failed")]
     RequestFailed,
-}
-
-impl Fail for Error {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
-}
-impl Error {
-    pub fn kind(&self) -> ErrorKind {
-        self.inner.get_context().clone()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            inner: Context::new(kind),
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
-    }
 }

--- a/audit/src/lib.rs
+++ b/audit/src/lib.rs
@@ -1,6 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(module_inception))]
-
-use failure;
+#![allow(clippy::module_inception)]
 
 use netlink_proto::{sys::Protocol, Connection};
 

--- a/netlink-packet-audit/Cargo.toml
+++ b/netlink-packet-audit/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/little-dude/netlink"
 description = "netlink packet types"
 
 [dependencies]
-failure = "0.1.6"
+anyhow = "1.0.31"
 byteorder = "1.3.2"
 netlink-packet-core = { path = "../netlink-packet-core", version = "0.1" }
 netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.1" }

--- a/netlink-packet-audit/src/buffer.rs
+++ b/netlink-packet-audit/src/buffer.rs
@@ -4,7 +4,7 @@ use crate::{
     traits::{Parseable, ParseableParametrized},
     AuditMessage, DecodeError, StatusMessage, StatusMessageBuffer,
 };
-use failure::ResultExt;
+use anyhow::Context;
 
 pub struct AuditBuffer<T> {
     buffer: T,

--- a/netlink-packet-audit/src/message.rs
+++ b/netlink-packet-audit/src/message.rs
@@ -1,5 +1,3 @@
-use failure::{Compat as FailureError, Fail};
-
 use crate::{
     constants::*,
     rules::RuleMessage,
@@ -137,13 +135,13 @@ impl NetlinkSerializable<AuditMessage> for AuditMessage {
 }
 
 impl NetlinkDeserializable<AuditMessage> for AuditMessage {
-    type Error = FailureError<DecodeError>;
+    type Error = DecodeError;
     fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
         match AuditBuffer::new_checked(payload) {
-            Err(e) => return Err(e.compat()),
+            Err(e) => Err(e),
             Ok(buffer) => match AuditMessage::parse_with_param(&buffer, header.message_type) {
-                Err(e) => return Err(e.compat()),
-                Ok(message) => return Ok(message),
+                Err(e) => Err(e),
+                Ok(message) => Ok(message),
             },
         }
     }

--- a/netlink-packet-audit/src/rules/buffer.rs
+++ b/netlink-packet-audit/src/rules/buffer.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{constants::*, rules::*, traits::Parseable, DecodeError, Field};
 

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/little-dude/netlink"
 description = "netlink packet types"
 
 [dependencies]
-failure = "0.1.6"
+anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
 netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.1" }

--- a/netlink-packet-core/src/message.rs
+++ b/netlink-packet-core/src/message.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 use std::fmt::Debug;
 
 use crate::{

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/little-dude/netlink"
 description = "netlink packet types"
 
 [dependencies]
-failure = "0.1.6"
+anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
 netlink-packet-core = { path = "../netlink-packet-core", version = "0.1" }

--- a/netlink-packet-route/src/rtnl/address/message.rs
+++ b/netlink-packet-route/src/rtnl/address/message.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     nlas::address::Nla,

--- a/netlink-packet-route/src/rtnl/address/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/address/nlas/mod.rs
@@ -3,8 +3,8 @@ pub use self::cache_info::*;
 
 use std::mem::size_of;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/buffer.rs
+++ b/netlink-packet-route/src/rtnl/buffer.rs
@@ -6,7 +6,7 @@ use crate::{
     NeighbourTableMessageBuffer, NsidMessage, NsidMessageBuffer, RouteHeader, RouteMessage,
     RouteMessageBuffer, RtnlMessage, RuleMessage, RuleMessageBuffer, TcMessage, TcMessageBuffer,
 };
-use failure::ResultExt;
+use anyhow::Context;
 
 buffer!(RtnlMessageBuffer);
 

--- a/netlink-packet-route/src/rtnl/link/message.rs
+++ b/netlink-packet-route/src/rtnl/link/message.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     nlas::link::Nla,

--- a/netlink-packet-route/src/rtnl/link/nlas/af_spec_inet.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/af_spec_inet.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use super::{inet, inet6};
 use crate::{

--- a/netlink-packet-route/src/rtnl/link/nlas/inet/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet/mod.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     constants::{IFLA_INET_CONF, IFLA_INET_UNSPEC},

--- a/netlink-packet-route/src/rtnl/link/nlas/inet6/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet6/mod.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -5,8 +5,8 @@ use crate::{
     traits::{Emitable, Parseable},
     DecodeError, LinkMessage, LinkMessageBuffer,
 };
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 const DUMMY: &str = "dummy";
 const IFB: &str = "ifb";

--- a/netlink-packet-route/src/rtnl/link/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/mod.rs
@@ -27,8 +27,8 @@ mod tests;
 
 use std::os::unix::io::RawFd;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/message.rs
+++ b/netlink-packet-route/src/rtnl/message.rs
@@ -1,5 +1,3 @@
-use failure::{Compat as FailureError, Fail};
-
 use crate::{
     constants::*,
     traits::{Emitable, ParseableParametrized},
@@ -454,11 +452,11 @@ impl NetlinkSerializable<RtnlMessage> for RtnlMessage {
 }
 
 impl NetlinkDeserializable<RtnlMessage> for RtnlMessage {
-    type Error = FailureError<DecodeError>;
+    type Error = DecodeError;
     fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
         let buf = RtnlMessageBuffer::new(payload);
         match RtnlMessage::parse_with_param(&buf, header.message_type) {
-            Err(e) => Err(e.compat()),
+            Err(e) => Err(e),
             Ok(message) => Ok(message),
         }
     }

--- a/netlink-packet-route/src/rtnl/neighbour/message.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/message.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     nlas::neighbour::Nla,
@@ -19,7 +19,9 @@ impl Emitable for NeighbourMessage {
 
     fn emit(&self, buffer: &mut [u8]) {
         self.header.emit(buffer);
-        self.nlas.as_slice().emit(&mut buffer[self.header.buffer_len()..]);
+        self.nlas
+            .as_slice()
+            .emit(&mut buffer[self.header.buffer_len()..]);
     }
 }
 
@@ -46,9 +48,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<NeighbourMessageBuffer<&'a T>> for Vec<N
 #[cfg(test)]
 mod test {
     use crate::{
-        constants::*,
-        traits::Emitable,
-        NeighbourHeader, NeighbourMessage, NeighbourMessageBuffer
+        constants::*, traits::Emitable, NeighbourHeader, NeighbourMessage, NeighbourMessageBuffer,
     };
 
     // 0020   0a 00 00 00 02 00 00 00 02 00 80 01 14 00 01 00
@@ -56,7 +56,6 @@ mod test {
     // 0040   0a 00 02 00 f4 90 ea 00 2d 83 00 00 08 00 04 00
     // 0050   01 00 00 00 14 00 03 00 00 00 00 00 00 00 00 00
     // 0060   00 00 00 00 02 00 00 00
-
 
     #[rustfmt::skip]
     static HEADER: [u8; 12] = [
@@ -102,7 +101,7 @@ mod test {
             ifindex: 1,
             state: NUD_REACHABLE,
             flags: NTF_ROUTER,
-            ntype: NDA_DST as u8
+            ntype: NDA_DST as u8,
         };
 
         let nlas = vec![];

--- a/netlink-packet-route/src/rtnl/neighbour/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/nlas/mod.rs
@@ -1,8 +1,8 @@
 mod cache_info;
 pub use self::cache_info::*;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/neighbour_table/message.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/message.rs
@@ -3,7 +3,7 @@ use crate::{
     traits::{Emitable, Parseable},
     DecodeError, NeighbourTableHeader, NeighbourTableMessageBuffer,
 };
-use failure::ResultExt;
+use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NeighbourTableMessage {

--- a/netlink-packet-route/src/rtnl/neighbour_table/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/nlas/mod.rs
@@ -4,8 +4,8 @@ pub use config::*;
 mod stats;
 pub use stats::*;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/nsid/message.rs
+++ b/netlink-packet-route/src/rtnl/nsid/message.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     nlas::nsid::Nla,

--- a/netlink-packet-route/src/rtnl/nsid/nlas.rs
+++ b/netlink-packet-route/src/rtnl/nsid/nlas.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/route/header.rs
+++ b/netlink-packet-route/src/rtnl/route/header.rs
@@ -134,10 +134,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<RouteMessageBuffer<&'a T>> for Route
             destination_prefix_length: buf.destination_prefix_length(),
             source_prefix_length: buf.source_prefix_length(),
             tos: buf.tos(),
-            table: buf.table().into(),
-            protocol: buf.protocol().into(),
-            scope: buf.scope().into(),
-            kind: buf.kind().into(),
+            table: buf.table(),
+            protocol: buf.protocol(),
+            scope: buf.scope(),
+            kind: buf.kind(),
             flags: RouteFlags::from_bits_truncate(buf.flags()),
         })
     }

--- a/netlink-packet-route/src/rtnl/route/message.rs
+++ b/netlink-packet-route/src/rtnl/route/message.rs
@@ -3,7 +3,7 @@ use crate::{
     traits::{Emitable, Parseable},
     DecodeError, RouteHeader, RouteMessageBuffer,
 };
-use failure::ResultExt;
+use anyhow::Context;
 use std::net::IpAddr;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]

--- a/netlink-packet-route/src/rtnl/route/nlas/metrics.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/metrics.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 use std::mem::size_of;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/route/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/mod.rs
@@ -7,8 +7,8 @@ pub use self::metrics::*;
 mod mfc_stats;
 pub use self::mfc_stats::*;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/rule/message.rs
+++ b/netlink-packet-route/src/rtnl/rule/message.rs
@@ -3,7 +3,7 @@ use super::header::RuleHeader;
 use super::nlas::Nla;
 use crate::utils::{Emitable, Parseable};
 use crate::DecodeError;
-use failure::ResultExt;
+use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct RuleMessage {

--- a/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     FRA_SPORT_RANGE, FRA_SRC, FRA_SUPPRESS_IFGROUP, FRA_SUPPRESS_PREFIXLEN, FRA_TABLE, FRA_TUN_ID,
     FRA_UID_RANGE, FRA_UNSPEC,
 };
-use failure::ResultExt;
+use anyhow::Context;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Nla {

--- a/netlink-packet-route/src/rtnl/tc/message.rs
+++ b/netlink-packet-route/src/rtnl/tc/message.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     nlas::tc::Nla,

--- a/netlink-packet-utils/Cargo.toml
+++ b/netlink-packet-utils/Cargo.toml
@@ -10,6 +10,7 @@ description = "macros and helpers for parsing netlink messages"
 
 
 [dependencies]
+anyhow = "1.0.31"
 byteorder = "1.3.2"
-failure = "0.1.6"
 paste = "0.1.6"
+thiserror = "1"

--- a/netlink-packet-utils/src/errors.rs
+++ b/netlink-packet-utils/src/errors.rs
@@ -1,31 +1,16 @@
-use core::fmt::{self, Display};
-use failure::{Backtrace, Context, Fail};
+use anyhow::anyhow;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("Encode error occurred: {inner}")]
 pub struct EncodeError {
-    inner: Context<String>,
-}
-
-impl Fail for EncodeError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for EncodeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
+    inner: anyhow::Error,
 }
 
 impl From<&'static str> for EncodeError {
     fn from(msg: &'static str) -> Self {
         EncodeError {
-            inner: Context::new(msg.into()),
+            inner: anyhow!(msg),
         }
     }
 }
@@ -33,50 +18,27 @@ impl From<&'static str> for EncodeError {
 impl From<String> for EncodeError {
     fn from(msg: String) -> Self {
         EncodeError {
-            inner: Context::new(msg),
+            inner: anyhow!(msg),
         }
     }
 }
 
-impl From<Context<String>> for EncodeError {
-    fn from(inner: Context<String>) -> Self {
+impl From<anyhow::Error> for EncodeError {
+    fn from(inner: anyhow::Error) -> EncodeError {
         EncodeError { inner }
     }
 }
 
-impl From<Context<&'static str>> for EncodeError {
-    fn from(inner: Context<&'static str>) -> Self {
-        EncodeError {
-            inner: inner.map(|s| s.to_string()),
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("Decode error occurred: {inner}")]
 pub struct DecodeError {
-    inner: Context<String>,
-}
-
-impl Fail for DecodeError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
+    inner: anyhow::Error,
 }
 
 impl From<&'static str> for DecodeError {
     fn from(msg: &'static str) -> Self {
         DecodeError {
-            inner: Context::new(msg.into()),
+            inner: anyhow!(msg),
         }
     }
 }
@@ -84,21 +46,13 @@ impl From<&'static str> for DecodeError {
 impl From<String> for DecodeError {
     fn from(msg: String) -> Self {
         DecodeError {
-            inner: Context::new(msg),
+            inner: anyhow!(msg),
         }
     }
 }
 
-impl From<Context<String>> for DecodeError {
-    fn from(inner: Context<String>) -> Self {
+impl From<anyhow::Error> for DecodeError {
+    fn from(inner: anyhow::Error) -> DecodeError {
         DecodeError { inner }
-    }
-}
-
-impl From<Context<&'static str>> for DecodeError {
-    fn from(inner: Context<&'static str>) -> Self {
-        DecodeError {
-            inner: inner.map(|s| s.to_string()),
-        }
     }
 }

--- a/netlink-packet-utils/src/nla.rs
+++ b/netlink-packet-utils/src/nla.rs
@@ -1,7 +1,7 @@
 use core::ops::Range;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::{
     traits::{Emitable, Parseable},

--- a/netlink-packet-utils/src/parsers.rs
+++ b/netlink-packet-utils/src/parsers.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 use crate::DecodeError;
 

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -15,7 +15,6 @@ description = "async netlink protocol"
 bytes = "0.5.3"
 log = "0.4.8"
 futures = "0.3.1"
-failure = "0.1.6"
 tokio = { version = "0.2.6", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.2.0", default-features = false, features = ["codec"] }
 netlink-packet-core = { path = "../netlink-packet-core", version = "0.1" }

--- a/netlink-proto/src/codecs.rs
+++ b/netlink-proto/src/codecs.rs
@@ -1,4 +1,3 @@
-use failure::Fail;
 use std::fmt::Debug;
 use std::io;
 use std::marker::PhantomData;
@@ -132,11 +131,7 @@ where
                     return Ok(Some(packet));
                 }
                 Err(e) => {
-                    let mut error_string = format!("failed to decode packet {:#x?}", &bytes);
-                    for cause in Fail::iter_chain(&e) {
-                        error_string += &format!(": {}", cause);
-                    }
-                    error!("{}", error_string);
+                    error!("failed to decode packet {:#x?}: {}", &bytes, e);
                     // continue looping, there may be more datagrams in the buffer
                 }
             }

--- a/netlink-proto/src/errors.rs
+++ b/netlink-proto/src/errors.rs
@@ -56,9 +56,9 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::ErrorKind::*;
         match self.kind() {
-            SocketIo(ref e) => write!(f, "{}: {}", self.description(), e),
-            ConnectionClosed => write!(f, "{}", self.description()),
-            NetlinkError(ref message) => write!(f, "{}: {:?}", self.description(), message),
+            SocketIo(ref e) => write!(f, "{}: {}", self, e),
+            ConnectionClosed => write!(f, "{}", self),
+            NetlinkError(ref message) => write!(f, "{}: {:?}", self, message),
         }
     }
 }

--- a/netlink-sys/examples/audit_events.rs
+++ b/netlink-sys/examples/audit_events.rs
@@ -11,12 +11,15 @@
 // ../target/debug/examples/audit_events
 // ```
 
+#[cfg(not(feature = "tokio_socket"))]
 use std::process;
 
+#[cfg(not(feature = "tokio_socket"))]
 use netlink_packet_audit::{
     AuditMessage, NetlinkBuffer, NetlinkMessage, StatusMessage, NLM_F_ACK, NLM_F_REQUEST,
 };
 
+#[cfg(not(feature = "tokio_socket"))]
 use netlink_sys::{Protocol, Socket, SocketAddr};
 
 pub const AUDIT_STATUS_ENABLED: u32 = 1;

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -14,8 +14,8 @@ description = "manipulate linux networking resources via netlink"
 [dependencies]
 futures = "0.3.1"
 log = "0.4.8"
-failure = "0.1.6"
-netlink-packet-route = { path = "../netlink-packet-route", version = "0.2"}
+thiserror = "1"
+netlink-packet-route = { path = "../netlink-packet-route", version = "0.2" }
 netlink-proto = { path = "../netlink-proto", version = "0.2" }
 
 [dev-dependencies]

--- a/rtnetlink/examples/flush_addresses.rs
+++ b/rtnetlink/examples/flush_addresses.rs
@@ -1,4 +1,3 @@
-use failure::Fail;
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::env;
@@ -16,7 +15,7 @@ async fn main() -> Result<(), ()> {
     tokio::spawn(connection);
 
     if let Err(e) = flush_addresses(handle, link_name.to_string()).await {
-        eprintln!("{}", format_failure_error(e));
+        eprintln!("{}", e);
     }
 
     Ok(())
@@ -41,15 +40,6 @@ async fn flush_addresses(handle: Handle, link: String) -> Result<(), Error> {
         eprintln!("link {} not found", link);
         Ok(())
     }
-}
-
-fn format_failure_error<E: Fail>(error: E) -> String {
-    let mut causes = Fail::iter_chain(&error);
-    let mut error_string = causes.next().unwrap().to_string();
-    for cause in causes {
-        error_string += &format!(": {}", cause);
-    }
-    error_string
 }
 
 fn usage() {

--- a/rtnetlink/src/addr/add.rs
+++ b/rtnetlink/src/addr/add.rs
@@ -6,7 +6,7 @@ use netlink_packet_route::{
     AF_INET6, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
 };
 
-use crate::{Error, ErrorKind, Handle};
+use crate::{Error, Handle};
 
 /// A request to create a new address. This is equivalent to the `ip address add` commands.
 pub struct AddressAddRequest {
@@ -73,7 +73,7 @@ impl AddressAddRequest {
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
             if let NetlinkPayload::Error(err) = message.payload {
-                return Err(ErrorKind::NetlinkError(err).into());
+                return Err(Error::NetlinkError(err));
             }
         }
         Ok(())

--- a/rtnetlink/src/addr/del.rs
+++ b/rtnetlink/src/addr/del.rs
@@ -4,7 +4,7 @@ use crate::{
     packet::{
         AddressMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST,
     },
-    Error, ErrorKind, Handle,
+    Error, Handle,
 };
 
 pub struct AddressDelRequest {
@@ -29,7 +29,7 @@ impl AddressDelRequest {
         let mut response = handle.request(req)?;
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
-                return Err(ErrorKind::NetlinkError(e).into());
+                return Err(Error::NetlinkError(e));
             }
         }
         Ok(())

--- a/rtnetlink/src/addr/get.rs
+++ b/rtnetlink/src/addr/get.rs
@@ -10,7 +10,7 @@ use netlink_packet_route::{
     NLM_F_REQUEST,
 };
 
-use crate::{Error, ErrorKind, Handle};
+use crate::{Error, Handle};
 
 pub struct AddressGetRequest {
     handle: Handle,
@@ -49,11 +49,10 @@ impl AddressGetRequest {
                         let (header, payload) = msg.into_parts();
                         match payload {
                             NetlinkPayload::InnerMessage(RtnlMessage::NewAddress(msg)) => Ok(msg),
-                            NetlinkPayload::Error(err) => Err(ErrorKind::NetlinkError(err).into()),
-                            _ => Err(ErrorKind::UnexpectedMessage(NetlinkMessage::new(
+                            NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                            _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
                                 header, payload,
-                            ))
-                            .into()),
+                            ))),
                         }
                     })
                     .try_filter(move |msg| future::ready(filter(msg))),

--- a/rtnetlink/src/errors.rs
+++ b/rtnetlink/src/errors.rs
@@ -1,73 +1,26 @@
-use std::fmt::{self, Display};
-
-use failure::{Backtrace, Context, Fail};
+use thiserror::Error;
 
 use crate::packet::{ErrorMessage, NetlinkMessage, RtnlMessage};
 
-#[derive(Debug)]
-pub struct Error {
-    inner: Context<ErrorKind>,
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
-pub enum ErrorKind {
-    #[fail(display = "Received an unexpected message {:?}", _0)]
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum Error {
+    #[error("Received an unexpected message {0:?}")]
     UnexpectedMessage(NetlinkMessage<RtnlMessage>),
 
-    #[fail(display = "Received a netlink error message {}", _0)]
+    #[error("Received a netlink error message {0}")]
     NetlinkError(ErrorMessage),
 
-    #[fail(display = "A netlink request failed")]
+    #[error("A netlink request failed")]
     RequestFailed,
 
-    #[fail(
-        display = "Received a link message (RTM_GETLINK, RTM_NEWLINK, RTM_SETLINK or RTMGETLINK) with an invalid hardware address attribute: {:?}.",
-        _0
+    #[error(
+        "Received a link message (RTM_GETLINK, RTM_NEWLINK, RTM_SETLINK or RTMGETLINK) with an invalid hardware address attribute: {0:?}."
     )]
     InvalidHardwareAddress(Vec<u8>),
 
-    #[fail(display = "Failed to parse an IP address: {:?}", _0)]
+    #[error("Failed to parse an IP address: {0:?}")]
     InvalidIp(Vec<u8>),
 
-    #[fail(
-        display = "Failed to parse a network address (IP and mask): {:?}/{:?}",
-        _0, _1
-    )]
+    #[error("Failed to parse a network address (IP and mask): {0:?}/{1:?}")]
     InvalidAddress(Vec<u8>, Vec<u8>),
-}
-
-impl Fail for Error {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
-}
-
-impl Error {
-    pub fn kind(&self) -> ErrorKind {
-        self.inner.get_context().clone()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            inner: Context::new(kind),
-        }
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Self {
-        Error { inner }
-    }
 }

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -1,9 +1,8 @@
-use failure::{Fail, ResultExt};
 use futures::Stream;
 
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
-    AddressHandle, Error, ErrorKind, LinkHandle, RouteHandle,
+    AddressHandle, Error, LinkHandle, RouteHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -21,13 +20,13 @@ impl Handle {
     ) -> Result<impl Stream<Item = NetlinkMessage<RtnlMessage>>, Error> {
         self.0
             .request(message, SocketAddr::new(0, 0))
-            .map_err(|e| e.context(ErrorKind::RequestFailed).into())
+            .map_err(|_| Error::RequestFailed)
     }
 
     pub fn notify(&mut self, msg: NetlinkMessage<RtnlMessage>) -> Result<(), Error> {
         self.0
             .notify(msg, SocketAddr::new(0, 0))
-            .context(ErrorKind::RequestFailed)?;
+            .map_err(|_| Error::RequestFailed)?;
         Ok(())
     }
 

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![allow(clippy::module_inception)]
 
-use failure;
-
 mod handle;
 pub use crate::handle::*;
 

--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -6,7 +6,7 @@ use crate::{
         LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, IFF_UP, NLM_F_ACK, NLM_F_CREATE,
         NLM_F_EXCL, NLM_F_REQUEST,
     },
-    Error, ErrorKind, Handle,
+    Error, Handle,
 };
 
 /// A request to create a new link. This is equivalent to the `ip link add` commands.
@@ -39,7 +39,7 @@ impl LinkAddRequest {
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
             if let NetlinkPayload::Error(err) = message.payload {
-                return Err(ErrorKind::NetlinkError(err).into());
+                return Err(Error::NetlinkError(err));
             }
         }
         Ok(())

--- a/rtnetlink/src/link/del.rs
+++ b/rtnetlink/src/link/del.rs
@@ -5,7 +5,7 @@ use crate::{
         LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_ACK, NLM_F_CREATE,
         NLM_F_EXCL, NLM_F_REQUEST,
     },
-    Error, ErrorKind, Handle,
+    Error, Handle,
 };
 
 pub struct LinkDelRequest {
@@ -32,7 +32,7 @@ impl LinkDelRequest {
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
             if let NetlinkPayload::Error(err) = message.payload {
-                return Err(ErrorKind::NetlinkError(err).into());
+                return Err(Error::NetlinkError(err));
             }
         }
         Ok(())

--- a/rtnetlink/src/link/get.rs
+++ b/rtnetlink/src/link/get.rs
@@ -9,7 +9,7 @@ use crate::{
         nlas::link::Nla, LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_DUMP,
         NLM_F_REQUEST,
     },
-    Error, ErrorKind, Handle,
+    Error, Handle,
 };
 
 pub struct LinkGetRequest {
@@ -59,11 +59,10 @@ impl LinkGetRequest {
                         let (header, payload) = msg.into_parts();
                         match payload {
                             NetlinkPayload::InnerMessage(RtnlMessage::NewLink(msg)) => Ok(msg),
-                            NetlinkPayload::Error(err) => Err(ErrorKind::NetlinkError(err).into()),
-                            _ => Err(ErrorKind::UnexpectedMessage(NetlinkMessage::new(
+                            NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                            _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
                                 header, payload,
-                            ))
-                            .into()),
+                            ))),
                         }
                     })
                     .try_filter(move |msg| future::ready(filter(msg))),

--- a/rtnetlink/src/link/set.rs
+++ b/rtnetlink/src/link/set.rs
@@ -3,7 +3,7 @@ use crate::{
         nlas::link::Nla, LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, IFF_UP,
         NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
     },
-    Error, ErrorKind, Handle,
+    Error, Handle,
 };
 use futures::stream::StreamExt;
 use std::os::unix::io::RawFd;
@@ -32,7 +32,7 @@ impl LinkSetRequest {
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
             if let NetlinkPayload::Error(err) = message.payload {
-                return Err(ErrorKind::NetlinkError(err).into());
+                return Err(Error::NetlinkError(err));
             }
         }
         Ok(())

--- a/rtnetlink/src/route/add.rs
+++ b/rtnetlink/src/route/add.rs
@@ -5,7 +5,7 @@ use netlink_packet_route::{
     constants::*, nlas::route::Nla, NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage,
 };
 
-use crate::{Error, ErrorKind, Handle};
+use crate::{Error, Handle};
 
 /// A request to create a new route. This is equivalent to the `ip route add` commands.
 struct RouteAddRequest {
@@ -81,7 +81,7 @@ impl RouteAddRequest {
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
             if let NetlinkPayload::Error(err) = message.payload {
-                return Err(ErrorKind::NetlinkError(err).into());
+                return Err(Error::NetlinkError(err));
             }
         }
         Ok(())

--- a/rtnetlink/src/route/del.rs
+++ b/rtnetlink/src/route/del.rs
@@ -2,7 +2,7 @@ use futures::stream::StreamExt;
 
 use crate::{
     packet::{NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST},
-    Error, ErrorKind, Handle,
+    Error, Handle,
 };
 
 pub struct RouteDelRequest {
@@ -27,7 +27,7 @@ impl RouteDelRequest {
         let mut response = handle.request(req)?;
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
-                return Err(ErrorKind::NetlinkError(e).into());
+                return Err(Error::NetlinkError(e));
             }
         }
         Ok(())

--- a/rtnetlink/src/route/get.rs
+++ b/rtnetlink/src/route/get.rs
@@ -8,7 +8,7 @@ use netlink_packet_route::{
     constants::*, NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage,
 };
 
-use crate::{Error, ErrorKind, Handle};
+use crate::{Error, Handle};
 
 pub struct RouteGetRequest {
     handle: Handle,
@@ -68,10 +68,10 @@ impl RouteGetRequest {
                 let (header, payload) = msg.into_parts();
                 match payload {
                     NetlinkPayload::InnerMessage(RtnlMessage::NewRoute(msg)) => Ok(msg),
-                    NetlinkPayload::Error(err) => Err(ErrorKind::NetlinkError(err).into()),
-                    _ => Err(
-                        ErrorKind::UnexpectedMessage(NetlinkMessage::new(header, payload)).into(),
-                    ),
+                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
+                        header, payload,
+                    ))),
                 }
             })),
             Err(e) => Either::Right(future::err::<RouteMessage, Error>(e).into_stream()),


### PR DESCRIPTION
- Use `anyhow` and `thiserror` instead of `failure`
- Unify `Error` and `ErrorKind`
- Use `thiserror::Error` instead of `failure::Fail`

Fixes #74
