### PR TITLE
Allowing dumping link with filter mask

### DIFF
--- a/netlink-sys/src/constants.rs
+++ b/netlink-sys/src/constants.rs
@@ -511,9 +511,9 @@ pub const RTAX_FEATURE_MASK: int = 15;
 #[allow(overflowing_literals)]
 pub const TCM_IFINDEX_MAGIC_BLOCK: int = 0xffff_ffff;
 pub const TCA_FLAG_LARGE_DUMP_ON: int = 1;
-pub const RTEXT_FILTER_VF: int = 1;
-pub const RTEXT_FILTER_BRVLAN: int = 2;
-pub const RTEXT_FILTER_BRVLAN_COMPRESSED: int = 4;
-pub const RTEXT_FILTER_SKIP_STATS: int = 8;
+pub const RTEXT_FILTER_VF: u32 = 1;
+pub const RTEXT_FILTER_BRVLAN: u32 = 2;
+pub const RTEXT_FILTER_BRVLAN_COMPRESSED: u32 = 4;
+pub const RTEXT_FILTER_SKIP_STATS: u32 = 8;
 pub const ARPOP_REQUEST: int = 1;
 pub const ARPOP_REPLY: int = 2;

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -22,3 +22,4 @@ netlink-proto = { path = "../netlink-proto", version = "0.2" }
 env_logger = "0.7.1"
 ipnetwork = "0.15.1"
 tokio = { version = "0.2.6", features = ["macros", "rt-core"] }
+netlink-sys = {path = "../netlink-sys", version = "0.2" }

--- a/rtnetlink/src/link/get.rs
+++ b/rtnetlink/src/link/get.rs
@@ -6,8 +6,8 @@ use futures::{
 
 use crate::{
     packet::{
-        nlas::link::Nla, LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_DUMP,
-        NLM_F_REQUEST,
+        nlas::link::Nla, LinkHeader, LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage,
+        NLM_F_DUMP, NLM_F_REQUEST,
     },
     Error, Handle,
 };
@@ -32,6 +32,13 @@ impl LinkGetRequest {
             dump: true,
             filter_builder: LinkFilterBuilder::new(),
         }
+    }
+
+    /// Setting filter mask(e.g. RTEXT_FILTER_BRVLAN and etc)
+    pub fn set_filter_mask(mut self, family: u8, filter_mask: u32) -> Self {
+        self.message.header.interface_family = family;
+        self.message.nlas.push(Nla::ExtMask(filter_mask));
+        self
     }
 
     /// Execute the request


### PR DESCRIPTION
The linux bridge vlan filter information is only available when
`RTEXT_FILTER_BRVLAN` set in `Nla::ExtMask`.

This patch introduce `LinkGetRequest::set_filter_mask()` method allowing
such usage via:

    let (connection, handle, _) = rtnetlink::new_connection().unwrap();
    tokio::spawn(connection);
    let mut links = handle.link().get().set_filter_mask(RTEXT_FILTER_BRVLAN)
        .execute();

The similar libnetlink function is `rtnl_linkdump_req_filter()`.

Also changed these constants to u32 in compliance of libnetlink and
kernel codes:

 * `RTEXT_FILTER_VF`
 * `RTEXT_FILTER_BRVLAN`
 * `RTEXT_FILTER_BRVLAN_COMPRESSED`
 * `RTEXT_FILTER_SKIP_STATS`

Example code for query linux bridge vlan information is included in
`rtnetlink/examples/get_links.rs` as `dump_bridge_filter_info()`.