### PR TITLE
Tweak travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: rust
 matrix:
   fast_finish: true
-  allow_failure:
-      - rust: nightly
+  allow_failures:
+    - rust: nightly
   include:
     # =====================================================================
     # Stable
@@ -56,50 +56,15 @@ matrix:
     # Nightly
     # =====================================================================
     - rust: nightly
-      name: nightly netlink-sys
+      name: clippy
       before_script:
         - rustup component add clippy
       script:
-          - cargo clippy --all-features
-
-    - rust: nightly
-      name: nightly netlink-packet-core
-      before_script:
-        - rustup component add clippy
-      script:
-          - cargo clippy
-
-    - rust: nightly
-      name: nightly netlink-packet-audit
-      before_script:
-        - rustup component add clippy
-      script:
-          - cargo clippy
-
-    - rust: nightly
-      name: nightly netlink-packet-route
-      before_script:
-        - rustup component add clippy
-      script:
-          - cargo clippy
-
-    - rust: nightly
-      name: nightly netlink-proto
-      before_script:
-        - rustup component add clippy
-      script:
-          - cargo clippy
-
-    - rust: nightly
-      name: nightly netlink-proto
-      before_script:
-        - rustup component add clippy
-      script:
-          - cargo clippy
+        - cargo clippy --all-features --workspace
 
     - rust: nightly
       name: rustfmt
       before_script:
         - rustup component add rustfmt
       script:
-          - cargo fmt --all -- --check
+        - cargo fmt --all -- --check

--- a/audit/src/lib.rs
+++ b/audit/src/lib.rs
@@ -16,6 +16,7 @@ use packet::{AuditMessage, NetlinkMessage};
 use std::io;
 use sys::SocketAddr;
 
+#[allow(clippy::type_complexity)]
 pub fn new_connection() -> io::Result<(
     Connection<AuditMessage>,
     Handle,

--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -637,8 +637,7 @@ impl Nla for InfoBridge {
                 | VlanDefaultPvid(ref value)
                 => NativeEndian::write_u16(buffer, *value),
 
-            Priority(ref value)
-                | VlanProtocol(ref value)
+            VlanProtocol(ref value)
                 => BigEndian::write_u16(buffer, *value),
 
             RootId((ref priority, ref address))

--- a/netlink-sys/src/constants.rs
+++ b/netlink-sys/src/constants.rs
@@ -1,6 +1,5 @@
 #![allow(unused)]
 
-use libc;
 use libc::c_int as int;
 
 pub const TCA_ROOT_UNSPEC: int = 0;

--- a/netlink-sys/src/sys.rs
+++ b/netlink-sys/src/sys.rs
@@ -1,5 +1,4 @@
 //! Netlink socket related functions
-use libc;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::{Error, Result};

--- a/netlink-sys/src/tokio.rs
+++ b/netlink-sys/src/tokio.rs
@@ -5,7 +5,6 @@ use std::{
 
 use futures::{future::poll_fn, ready};
 use log::trace;
-use mio;
 use tokio::io::PollEvented;
 
 use crate::{


### PR DESCRIPTION
- clippy -> seems they're duplicate so shrunk to one
- rustfmt -> another option is to use stable one since nightly has unstable formatting
- allow nightlies to fail correctly
- fix/suppress warnings
