### PR TITLE
rtnetlink: Add support of querying qdisc in traffic control

### DIFF
--- a/netlink-packet-route/src/rtnl/tc/message.rs
+++ b/netlink-packet-route/src/rtnl/tc/message.rs
@@ -24,14 +24,14 @@ impl TcMessage {
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct TcHeader {
-    family: u8,
+    pub family: u8,
     // Interface index
-    index: i32,
+    pub index: i32,
     // Qdisc handle
-    handle: u32,
+    pub handle: u32,
     // Parent Qdisc
-    parent: u32,
-    info: u32,
+    pub parent: u32,
+    pub info: u32,
 }
 
 impl Emitable for TcHeader {

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -2,7 +2,7 @@ use futures::Stream;
 
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
-    AddressHandle, Error, LinkHandle, RouteHandle,
+    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -43,5 +43,11 @@ impl Handle {
     /// Create a new handle, specifically for routing table requests (equivalent to `ip route` commands)
     pub fn route(&self) -> RouteHandle {
         RouteHandle::new(self.clone())
+    }
+
+    /// Create a new handle, specifically for traffic control qdisc requests
+    /// (equivalent to `tc qdisc show` commands)
+    pub fn qdisc(&self) -> QDiscHandle {
+        QDiscHandle::new(self.clone())
     }
 }

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -25,3 +25,6 @@ pub mod constants;
 
 pub use netlink_packet_route as packet;
 pub use netlink_proto::sys;
+
+mod traffic_control;
+pub use crate::traffic_control::*;

--- a/rtnetlink/src/traffic_control/get.rs
+++ b/rtnetlink/src/traffic_control/get.rs
@@ -1,0 +1,50 @@
+use futures::{
+    future::{self, Either},
+    stream::{StreamExt, TryStream},
+    FutureExt,
+};
+
+use crate::{
+    packet::{NetlinkMessage, NetlinkPayload, RtnlMessage, TcMessage, NLM_F_DUMP, NLM_F_REQUEST},
+    Error, Handle,
+};
+
+pub struct QDiscGetRequest {
+    handle: Handle,
+    message: TcMessage,
+}
+
+impl QDiscGetRequest {
+    pub(crate) fn new(handle: Handle) -> Self {
+        QDiscGetRequest {
+            handle,
+            message: TcMessage::default(),
+        }
+    }
+
+    /// Execute the request
+    pub fn execute(self) -> impl TryStream<Ok = TcMessage, Error = Error> {
+        let QDiscGetRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::GetQueueDiscipline(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        match handle.request(req) {
+            Ok(response) => Either::Left(response.map(move |msg| {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    // The kernel use RTM_NEWQDISC for returned message
+                    NetlinkPayload::InnerMessage(RtnlMessage::NewQueueDiscipline(msg)) => Ok(msg),
+                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
+                        header, payload,
+                    ))),
+                }
+            })),
+            Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
+        }
+    }
+}

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -1,0 +1,15 @@
+use super::QDiscGetRequest;
+use crate::Handle;
+
+pub struct QDiscHandle(Handle);
+
+impl QDiscHandle {
+    pub fn new(handle: Handle) -> Self {
+        QDiscHandle(handle)
+    }
+
+    /// Retrieve the list of qdisc (equivalent to `tc qdisc show`)
+    pub fn get(&mut self) -> QDiscGetRequest {
+        QDiscGetRequest::new(self.0.clone())
+    }
+}

--- a/rtnetlink/src/traffic_control/mod.rs
+++ b/rtnetlink/src/traffic_control/mod.rs
@@ -1,0 +1,8 @@
+mod handle;
+pub use self::handle::*;
+
+mod get;
+pub use self::get::*;
+
+#[cfg(test)]
+mod test;

--- a/rtnetlink/src/traffic_control/test.rs
+++ b/rtnetlink/src/traffic_control/test.rs
@@ -1,0 +1,31 @@
+use crate::new_connection;
+use futures::stream::TryStreamExt;
+use netlink_packet_route::{
+    rtnl::tc::nlas::Nla::{HwOffload, Kind},
+    TcMessage, AF_UNSPEC,
+};
+use tokio::runtime::Runtime;
+
+async fn _get_qdiscs() -> Vec<TcMessage> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+    let mut qdiscs_iter = handle.qdisc().get().execute();
+    let mut qdiscs = Vec::new();
+    while let Some(nl_msg) = qdiscs_iter.try_next().await.unwrap() {
+        qdiscs.push(nl_msg.clone());
+    }
+    qdiscs
+}
+
+#[test]
+fn test_get_qdiscs() {
+    let qdiscs = Runtime::new().unwrap().block_on(_get_qdiscs());
+    let qdisc_of_loopback_nic = &qdiscs[0];
+    assert_eq!(qdisc_of_loopback_nic.header.family, AF_UNSPEC as u8);
+    assert_eq!(qdisc_of_loopback_nic.header.index, 1);
+    assert_eq!(qdisc_of_loopback_nic.header.handle, 0);
+    assert_eq!(qdisc_of_loopback_nic.header.parent, u32::MAX);
+    assert_eq!(qdisc_of_loopback_nic.header.info, 2); // refcount
+    assert_eq!(qdisc_of_loopback_nic.nlas[0], Kind("noqueue".to_string()));
+    assert_eq!(qdisc_of_loopback_nic.nlas[1], HwOffload(0));
+}


### PR DESCRIPTION
New function `rtnetlink::Handle::qdisc()` with initial qdisc query
support.

Integration test case added which query the qdisc information of
loopback interface.