### PR TITLE
rtnetlink: Add support of querying classes in traffic control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ matrix:
       script:
         - cd rtnetlink
         - cargo test
+        - sudo env PATH=${TRAVIS_HOME}/.cargo/bin:$PATH
+          cargo test --features test_as_root
+        - sudo chown -R travis:travis $HOME/.cargo
+        - sudo chown -R travis:travis $TRAVIS_BUILD_DIR/target
 
     - rust: stable
       name: audit

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -11,6 +11,10 @@ readme = "../README.md"
 repository = "https://github.com/little-dude/netlink"
 description = "manipulate linux networking resources via netlink"
 
+[features]
+test_as_root = []
+
+
 [dependencies]
 futures = "0.3.1"
 log = "0.4.8"

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -2,7 +2,7 @@ use futures::Stream;
 
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
-    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle,
+    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, TrafficClassHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -49,5 +49,11 @@ impl Handle {
     /// (equivalent to `tc qdisc show` commands)
     pub fn qdisc(&self) -> QDiscHandle {
         QDiscHandle::new(self.clone())
+    }
+
+    /// Create a new handle, specifically for traffic control qdisc requests
+    /// (equivalent to `tc class show` commands)
+    pub fn traffic_class(&self, ifindex: i32) -> TrafficClassHandle {
+        TrafficClassHandle::new(self.clone(), ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/get.rs
+++ b/rtnetlink/src/traffic_control/get.rs
@@ -48,3 +48,45 @@ impl QDiscGetRequest {
         }
     }
 }
+
+pub struct TrafficClassGetRequest {
+    handle: Handle,
+    message: TcMessage,
+}
+
+impl TrafficClassGetRequest {
+    pub(crate) fn new(handle: Handle, ifindex: i32) -> Self {
+        let mut message = TcMessage::default();
+        message.header.index = ifindex;
+        TrafficClassGetRequest {
+            handle,
+            message,
+        }
+    }
+
+    /// Execute the request
+    pub fn execute(self) -> impl TryStream<Ok = TcMessage, Error = Error> {
+        let TrafficClassGetRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::GetTrafficClass(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        match handle.request(req) {
+            Ok(response) => Either::Left(response.map(move |msg| {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    // The kernel use RTM_NEWTCLASS for returned message
+                    NetlinkPayload::InnerMessage(RtnlMessage::NewTrafficClass(msg)) => Ok(msg),
+                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
+                        header, payload,
+                    ))),
+                }
+            })),
+            Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
+        }
+    }
+}

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -1,4 +1,4 @@
-use super::QDiscGetRequest;
+use super::{QDiscGetRequest, TrafficClassGetRequest};
 use crate::Handle;
 
 pub struct QDiscHandle(Handle);
@@ -11,5 +11,21 @@ impl QDiscHandle {
     /// Retrieve the list of qdisc (equivalent to `tc qdisc show`)
     pub fn get(&mut self) -> QDiscGetRequest {
         QDiscGetRequest::new(self.0.clone())
+    }
+}
+
+pub struct TrafficClassHandle {
+    handle: Handle,
+    ifindex: i32,
+}
+
+impl TrafficClassHandle {
+    pub fn new(handle: Handle, ifindex: i32) -> Self {
+        TrafficClassHandle{handle, ifindex}
+    }
+
+    /// Retrieve the list of qdisc (equivalent to `tc qdisc show`)
+    pub fn get(&mut self) -> TrafficClassGetRequest {
+        TrafficClassGetRequest::new(self.handle.clone(), self.ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/test.rs
+++ b/rtnetlink/src/traffic_control/test.rs
@@ -4,6 +4,7 @@ use netlink_packet_route::{
     rtnl::tc::nlas::Nla::{HwOffload, Kind},
     TcMessage, AF_UNSPEC,
 };
+use std::process::Command;
 use tokio::runtime::Runtime;
 
 async fn _get_qdiscs() -> Vec<TcMessage> {
@@ -28,4 +29,66 @@ fn test_get_qdiscs() {
     assert_eq!(qdisc_of_loopback_nic.header.info, 2); // refcount
     assert_eq!(qdisc_of_loopback_nic.nlas[0], Kind("noqueue".to_string()));
     assert_eq!(qdisc_of_loopback_nic.nlas[1], HwOffload(0));
+}
+
+async fn _get_tclasses(ifindex: i32) -> Vec<TcMessage> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+    let mut tclasses_iter = handle.traffic_class(ifindex).get().execute();
+    let mut tclasses = Vec::new();
+    while let Some(nl_msg) = tclasses_iter.try_next().await.unwrap() {
+        tclasses.push(nl_msg.clone());
+    }
+    tclasses
+}
+
+fn _add_test_tclass_to_lo() {
+    let output = Command::new("tc")
+        .args(&[
+            "qdisc", "add", "dev", "lo", "root", "handle", "1:", "htb", "default", "6",
+        ])
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!("Failed to add qdisc to lo: {:?}", output);
+    }
+    assert!(output.status.success());
+    let output = Command::new("tc")
+        .args(&[
+            "class", "add", "dev", "lo", "parent", "1:", "classid", "1:1", "htb", "rate", "10mbit",
+            "ceil", "10mbit",
+        ])
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!("Failed to add traffic class to lo: {:?}", output);
+    }
+    assert!(output.status.success());
+}
+
+fn _remove_test_tclass_from_lo() {
+    Command::new("tc")
+        .args(&[
+            "class", "del", "dev", "lo", "parent", "1:", "classid", "1:1",
+        ])
+        .status()
+        .expect("failed to remove tclass from lo");
+    Command::new("tc")
+        .args(&["qdisc", "del", "dev", "lo", "root"])
+        .status()
+        .expect("failed to remove qdisc from lo");
+}
+
+#[test]
+#[cfg_attr(not(feature = "test_as_root"), ignore)]
+fn test_get_traffic_classes() {
+    _add_test_tclass_to_lo();
+    let tclasses = Runtime::new().unwrap().block_on(_get_tclasses(1));
+    _remove_test_tclass_from_lo();
+    assert_eq!(tclasses.len(), 1);
+    let tclass_of_loopback_nic = &tclasses[0];
+    assert_eq!(tclass_of_loopback_nic.header.family, AF_UNSPEC as u8);
+    assert_eq!(tclass_of_loopback_nic.header.index, 1);
+    assert_eq!(tclass_of_loopback_nic.header.parent, u32::MAX);
+    assert_eq!(tclass_of_loopback_nic.nlas[0], Kind("htb".to_string()));
 }


### PR DESCRIPTION
New function `rtnetlink::Handle::traffic_class()` with initial traffic
class query support.

Integration test case added which query the traffic class information of
loopback interface.
By default, there is no traffic class on any NICs, to test it, we need
to add one and do the query. So `cargo test` need to be run as root or
user with enough privilege for `tc class add` command.