### PR TITLE
rtnetlink: Add support of querying filters in traffic control

### DIFF
--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -3,6 +3,7 @@ use futures::Stream;
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
     AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, TrafficClassHandle,
+    TrafficFilterHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -55,5 +56,11 @@ impl Handle {
     /// (equivalent to `tc class show` commands)
     pub fn traffic_class(&self, ifindex: i32) -> TrafficClassHandle {
         TrafficClassHandle::new(self.clone(), ifindex)
+    }
+
+    /// Create a new handle, specifically for traffic control filter requests
+    /// (equivalent to `tc filter show dev <interface_name>` commands)
+    pub fn traffic_filter(&self, ifindex: i32) -> TrafficFilterHandle {
+        TrafficFilterHandle::new(self.clone(), ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -1,4 +1,4 @@
-use super::{QDiscGetRequest, TrafficClassGetRequest};
+use super::{QDiscGetRequest, TrafficClassGetRequest, TrafficFilterGetRequest};
 use crate::Handle;
 
 pub struct QDiscHandle(Handle);
@@ -21,11 +21,28 @@ pub struct TrafficClassHandle {
 
 impl TrafficClassHandle {
     pub fn new(handle: Handle, ifindex: i32) -> Self {
-        TrafficClassHandle{handle, ifindex}
+        TrafficClassHandle { handle, ifindex }
     }
 
     /// Retrieve the list of qdisc (equivalent to `tc qdisc show`)
     pub fn get(&mut self) -> TrafficClassGetRequest {
         TrafficClassGetRequest::new(self.handle.clone(), self.ifindex)
+    }
+}
+
+pub struct TrafficFilterHandle {
+    handle: Handle,
+    ifindex: i32,
+}
+
+impl TrafficFilterHandle {
+    pub fn new(handle: Handle, ifindex: i32) -> Self {
+        TrafficFilterHandle { handle, ifindex }
+    }
+
+    /// Retrieve the list of filter (equivalent to
+    /// `tc filter show dev <iface_name>`)
+    pub fn get(&mut self) -> TrafficFilterGetRequest {
+        TrafficFilterGetRequest::new(self.handle.clone(), self.ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/test.rs
+++ b/rtnetlink/src/traffic_control/test.rs
@@ -7,6 +7,8 @@ use netlink_packet_route::{
 use std::process::Command;
 use tokio::runtime::Runtime;
 
+static TEST_DUMMY_NIC: &str = "netlink-test";
+
 async fn _get_qdiscs() -> Vec<TcMessage> {
     let (connection, handle, _) = new_connection().unwrap();
     tokio::spawn(connection);
@@ -42,53 +44,199 @@ async fn _get_tclasses(ifindex: i32) -> Vec<TcMessage> {
     tclasses
 }
 
-fn _add_test_tclass_to_lo() {
-    let output = Command::new("tc")
-        .args(&[
-            "qdisc", "add", "dev", "lo", "root", "handle", "1:", "htb", "default", "6",
-        ])
+// Return 0 for not found
+fn _get_test_dummy_interface_index() -> i32 {
+    let output = Command::new("ip")
+        .args(&["-o", "link", "show", TEST_DUMMY_NIC])
         .output()
-        .expect("failed to run tc command");
+        .expect("failed to run ip command");
     if !output.status.success() {
-        eprintln!("Failed to add qdisc to lo: {:?}", output);
+        0
+    } else {
+        let line = std::str::from_utf8(&output.stdout).unwrap();
+        line.split(": ").next().unwrap().parse::<i32>().unwrap()
     }
-    assert!(output.status.success());
-    let output = Command::new("tc")
-        .args(&[
-            "class", "add", "dev", "lo", "parent", "1:", "classid", "1:1", "htb", "rate", "10mbit",
-            "ceil", "10mbit",
-        ])
+}
+
+fn _add_test_dummy_interface() -> i32 {
+    if _get_test_dummy_interface_index() == 0 {
+        let output = Command::new("ip")
+            .args(&["link", "add", TEST_DUMMY_NIC, "type", "dummy"])
+            .output()
+            .expect("failed to run ip command");
+        if !output.status.success() {
+            eprintln!(
+                "Failed to create dummy interface {} : {:?}",
+                TEST_DUMMY_NIC, output
+            );
+        }
+        assert!(output.status.success());
+    }
+
+    _get_test_dummy_interface_index()
+}
+
+fn _remove_test_dummy_interface() {
+    let output = Command::new("ip")
+        .args(&["link", "del", TEST_DUMMY_NIC])
         .output()
-        .expect("failed to run tc command");
+        .expect("failed to run ip command");
     if !output.status.success() {
-        eprintln!("Failed to add traffic class to lo: {:?}", output);
+        eprintln!(
+            "Failed to remove dummy interface {} : {:?}",
+            TEST_DUMMY_NIC, output
+        );
     }
     assert!(output.status.success());
 }
 
-fn _remove_test_tclass_from_lo() {
-    Command::new("tc")
+fn _add_test_tclass_to_dummy() {
+    let output = Command::new("tc")
         .args(&[
-            "class", "del", "dev", "lo", "parent", "1:", "classid", "1:1",
+            "qdisc",
+            "add",
+            "dev",
+            TEST_DUMMY_NIC,
+            "root",
+            "handle",
+            "1:",
+            "htb",
+            "default",
+            "6",
         ])
-        .status()
-        .expect("failed to remove tclass from lo");
-    Command::new("tc")
-        .args(&["qdisc", "del", "dev", "lo", "root"])
-        .status()
-        .expect("failed to remove qdisc from lo");
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!(
+            "Failed to add qdisc to dummy interface {} : {:?}",
+            TEST_DUMMY_NIC, output
+        );
+    }
+    assert!(output.status.success());
+    let output = Command::new("tc")
+        .args(&[
+            "class",
+            "add",
+            "dev",
+            TEST_DUMMY_NIC,
+            "parent",
+            "1:",
+            "classid",
+            "1:1",
+            "htb",
+            "rate",
+            "10mbit",
+            "ceil",
+            "10mbit",
+        ])
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!(
+            "Failed to add traffic class to dummy interface {}: {:?}",
+            TEST_DUMMY_NIC, output
+        );
+    }
+    assert!(output.status.success());
 }
 
+fn _add_test_filter_to_dummy() {
+    let output = Command::new("tc")
+        .args(&[
+            "filter",
+            "add",
+            "dev",
+            TEST_DUMMY_NIC,
+            "parent",
+            "1:",
+            "basic",
+            "match",
+            "meta(priority eq 6)",
+            "classid",
+            "1:1",
+        ])
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!("Failed to add trafice filter to lo: {:?}", output);
+    }
+    assert!(output.status.success());
+}
+
+fn _remove_test_tclass_from_dummy() {
+    Command::new("tc")
+        .args(&[
+            "class",
+            "del",
+            "dev",
+            TEST_DUMMY_NIC,
+            "parent",
+            "1:",
+            "classid",
+            "1:1",
+        ])
+        .status()
+        .expect(&format!(
+            "failed to remove tclass from dummy interface {}",
+            TEST_DUMMY_NIC
+        ));
+    Command::new("tc")
+        .args(&["qdisc", "del", "dev", TEST_DUMMY_NIC, "root"])
+        .status()
+        .expect(&format!(
+            "failed to remove qdisc from dummy interface {}",
+            TEST_DUMMY_NIC
+        ));
+}
+
+fn _remove_test_filter_from_dummy() {
+    Command::new("tc")
+        .args(&["filter", "del", "dev", TEST_DUMMY_NIC])
+        .status()
+        .expect(&format!(
+            "failed to remove filter from dummy interface {}",
+            TEST_DUMMY_NIC
+        ));
+}
+
+async fn _get_filters(ifindex: i32) -> Vec<TcMessage> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+    let mut filters_iter = handle.traffic_filter(ifindex).get().execute();
+    let mut filters = Vec::new();
+    while let Some(nl_msg) = filters_iter.try_next().await.unwrap() {
+        filters.push(nl_msg.clone());
+    }
+    filters
+}
+
+// The `cargo test` by default run all tests in parallel, in stead
+// of create random named veth/dummy for test, just place class and filter
+// query test in one test case is much simpler.
 #[test]
 #[cfg_attr(not(feature = "test_as_root"), ignore)]
-fn test_get_traffic_classes() {
-    _add_test_tclass_to_lo();
-    let tclasses = Runtime::new().unwrap().block_on(_get_tclasses(1));
-    _remove_test_tclass_from_lo();
+fn test_get_traffic_classes_and_filters() {
+    let ifindex = _add_test_dummy_interface();
+    _add_test_tclass_to_dummy();
+    _add_test_filter_to_dummy();
+    let tclasses = Runtime::new().unwrap().block_on(_get_tclasses(ifindex));
+    let filters = Runtime::new().unwrap().block_on(_get_filters(ifindex));
+    _remove_test_filter_from_dummy();
+    _remove_test_tclass_from_dummy();
+    _remove_test_dummy_interface();
     assert_eq!(tclasses.len(), 1);
-    let tclass_of_loopback_nic = &tclasses[0];
-    assert_eq!(tclass_of_loopback_nic.header.family, AF_UNSPEC as u8);
-    assert_eq!(tclass_of_loopback_nic.header.index, 1);
-    assert_eq!(tclass_of_loopback_nic.header.parent, u32::MAX);
-    assert_eq!(tclass_of_loopback_nic.nlas[0], Kind("htb".to_string()));
+    let tclass = &tclasses[0];
+    assert_eq!(tclass.header.family, AF_UNSPEC as u8);
+    assert_eq!(tclass.header.index, ifindex);
+    assert_eq!(tclass.header.parent, u32::MAX);
+    assert_eq!(tclass.nlas[0], Kind("htb".to_string()));
+    assert_eq!(filters.len(), 2);
+    assert_eq!(filters[0].header.family, AF_UNSPEC as u8);
+    assert_eq!(filters[0].header.index, ifindex);
+    assert_eq!(filters[0].header.parent, u16::MAX as u32 + 1);
+    assert_eq!(filters[0].nlas[0], Kind("basic".to_string()));
+    assert_eq!(filters[1].header.family, AF_UNSPEC as u8);
+    assert_eq!(filters[1].header.index, ifindex);
+    assert_eq!(filters[1].header.parent, u16::MAX as u32 + 1);
+    assert_eq!(filters[1].nlas[0], Kind("basic".to_string()));
 }


### PR DESCRIPTION
New function `rtnetlink::Handle::traffic_filter()` with initial traffic
filter query support.

The `cargo test` will run in parallel, changing loopback interface might
cause `test_get_qdiscs` fail.
Hence changed the integration test case to use dummy interface instead
loopback.