### PR TITLE
rtnetlink: Add support of querying chain in traffic control

### DIFF
--- a/netlink-packet-route/src/rtnl/buffer.rs
+++ b/netlink-packet-route/src/rtnl/buffer.rs
@@ -138,7 +138,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<RtnlMessageBuffer<&'a T>
             // TC Messages
             RTM_NEWQDISC | RTM_DELQDISC | RTM_GETQDISC |
             RTM_NEWTCLASS | RTM_DELTCLASS | RTM_GETTCLASS |
-            RTM_NEWTFILTER | RTM_DELTFILTER | RTM_GETTFILTER => {
+            RTM_NEWTFILTER | RTM_DELTFILTER | RTM_GETTFILTER |
+            RTM_NEWCHAIN | RTM_DELCHAIN | RTM_GETCHAIN => {
                 let err = "invalid tc message";
                 let msg = TcMessage::parse(&TcMessageBuffer::new_checked(&buf.inner()).context(err)?).context(err)?;
                 match message_type {
@@ -151,6 +152,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<RtnlMessageBuffer<&'a T>
                     RTM_NEWTFILTER => NewTrafficFilter(msg),
                     RTM_DELTFILTER => DelTrafficFilter(msg),
                     RTM_GETTFILTER => GetTrafficFilter(msg),
+                    RTM_NEWCHAIN => NewTrafficChain(msg),
+                    RTM_DELCHAIN => DelTrafficChain(msg),
+                    RTM_GETCHAIN => GetTrafficChain(msg),
                     _ => unreachable!(),
                 }
             }

--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -53,6 +53,9 @@ pub const RTM_GETNSID: u16 = 90;
 pub const RTM_NEWSTATS: u16 = 92;
 pub const RTM_GETSTATS: u16 = 94;
 pub const RTM_NEWCACHEREPORT: u16 = 96;
+pub const RTM_NEWCHAIN: u16 = 100;
+pub const RTM_DELCHAIN: u16 = 101;
+pub const RTM_GETCHAIN: u16 = 102;
 
 /// Unknown route
 pub const RTN_UNSPEC: u8 = 0;

--- a/netlink-packet-route/src/rtnl/message.rs
+++ b/netlink-packet-route/src/rtnl/message.rs
@@ -33,6 +33,9 @@ pub enum RtnlMessage {
     NewTrafficFilter(TcMessage),
     DelTrafficFilter(TcMessage),
     GetTrafficFilter(TcMessage),
+    NewTrafficChain(TcMessage),
+    DelTrafficChain(TcMessage),
+    GetTrafficChain(TcMessage),
     NewNsId(NsidMessage),
     DelNsId(NsidMessage),
     GetNsId(NsidMessage),
@@ -242,6 +245,30 @@ impl RtnlMessage {
         }
     }
 
+    pub fn is_new_chain(&self) -> bool {
+        if let RtnlMessage::NewTrafficChain(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_del_chain(&self) -> bool {
+        if let RtnlMessage::DelTrafficChain(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_get_chain(&self) -> bool {
+        if let RtnlMessage::GetTrafficChain(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn is_new_nsid(&self) -> bool {
         if let RtnlMessage::NewNsId(_) = *self {
             true
@@ -319,6 +346,9 @@ impl RtnlMessage {
             NewTrafficFilter(_) => RTM_NEWTFILTER,
             DelTrafficFilter(_) => RTM_DELTFILTER,
             GetTrafficFilter(_) => RTM_GETTFILTER,
+            NewTrafficChain(_) => RTM_NEWCHAIN,
+            DelTrafficChain(_) => RTM_DELCHAIN,
+            GetTrafficChain(_) => RTM_GETCHAIN,
             GetNsId(_) => RTM_GETNSID,
             NewNsId(_) => RTM_NEWNSID,
             DelNsId(_) => RTM_DELNSID,
@@ -369,6 +399,9 @@ impl Emitable for RtnlMessage {
             | NewTrafficFilter(ref msg)
             | DelTrafficFilter(ref msg)
             | GetTrafficFilter(ref msg)
+            | NewTrafficChain(ref msg)
+            | DelTrafficChain(ref msg)
+            | GetTrafficChain(ref msg)
             => msg.buffer_len(),
 
             | NewNsId(ref msg)
@@ -422,6 +455,9 @@ impl Emitable for RtnlMessage {
             | NewTrafficFilter(ref msg)
             | DelTrafficFilter(ref msg)
             | GetTrafficFilter(ref msg)
+            | NewTrafficChain(ref msg)
+            | DelTrafficChain(ref msg)
+            | GetTrafficChain(ref msg)
             => msg.emit(buffer),
 
             | NewNsId(ref msg)

--- a/netlink-packet-route/src/rtnl/tc/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/tc/nlas/mod.rs
@@ -32,6 +32,7 @@ pub enum Nla {
     Fcnt(Vec<u8>),
     Stats2(Vec<Stats2>),
     Stab(Vec<u8>),
+    Chain(Vec<u8>),
     HwOffload(u8),
     Other(DefaultNla),
 }
@@ -47,7 +48,8 @@ impl nlas::Nla for Nla {
                 | XStats(ref bytes)
                 | Rate(ref bytes)
                 | Fcnt(ref bytes)
-                | Stab(ref bytes) => bytes.len(),
+                | Stab(ref bytes)
+                | Chain(ref bytes) => bytes.len(),
             HwOffload(_) => 1,
             Stats2(ref thing) => thing.as_slice().buffer_len(),
             Stats(_) => STATS_LEN,
@@ -68,7 +70,8 @@ impl nlas::Nla for Nla {
                 | XStats(ref bytes)
                 | Rate(ref bytes)
                 | Fcnt(ref bytes)
-                | Stab(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+                | Stab(ref bytes)
+                | Chain(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
 
             HwOffload(ref val) => buffer[0] = *val,
             Stats2(ref stats) => stats.as_slice().emit(buffer),
@@ -96,6 +99,7 @@ impl nlas::Nla for Nla {
             Fcnt(_) => TCA_FCNT,
             Stats2(_) => TCA_STATS2,
             Stab(_) => TCA_STAB,
+            Chain(_) => TCA_CHAIN,
             HwOffload(_) => TCA_HW_OFFLOAD,
             Other(ref nla) => nla.kind(),
         }
@@ -121,6 +125,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
                 Self::Stats2(nlas)
             }
             TCA_STAB => Self::Stab(payload.to_vec()),
+            TCA_CHAIN => Self::Chain(payload.to_vec()),
             TCA_HW_OFFLOAD => Self::HwOffload(parse_u8(payload)?),
             _ => Self::Other(DefaultNla::parse(buf)?),
         })

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -3,6 +3,7 @@ use futures::Stream;
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
     AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, TrafficClassHandle,
+    TrafficFilterHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -55,5 +56,11 @@ impl Handle {
     /// (equivalent to `tc class show` commands)
     pub fn traffic_class(&self, ifindex: i32) -> TrafficClassHandle {
         TrafficClassHandle::new(self.clone(), ifindex)
+    }
+
+    /// Create a new handle, specifically for traffic control filter requests
+    /// (equivalent to `tc filter show dev <interface_name>` commands)
+    pub fn traffic_filter(&self, ifindex: i32) -> TrafficFilterHandle {
+        TrafficFilterHandle::new(self.clone(), ifindex)
     }
 }

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -52,8 +52,8 @@ impl Handle {
         QDiscHandle::new(self.clone())
     }
 
-    /// Create a new handle, specifically for traffic control qdisc requests
-    /// (equivalent to `tc class show` commands)
+    /// Create a new handle, specifically for traffic control class requests
+    /// (equivalent to `tc class show dev <interface_name>` commands)
     pub fn traffic_class(&self, ifindex: i32) -> TrafficClassHandle {
         TrafficClassHandle::new(self.clone(), ifindex)
     }

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -2,8 +2,8 @@ use futures::Stream;
 
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
-    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, TrafficClassHandle,
-    TrafficFilterHandle,
+    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, TrafficChainHandle,
+    TrafficClassHandle, TrafficFilterHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -62,5 +62,11 @@ impl Handle {
     /// (equivalent to `tc filter show dev <interface_name>` commands)
     pub fn traffic_filter(&self, ifindex: i32) -> TrafficFilterHandle {
         TrafficFilterHandle::new(self.clone(), ifindex)
+    }
+
+    /// Create a new handle, specifically for traffic control chain requests
+    /// (equivalent to `tc chain show dev <interface_name>` commands)
+    pub fn traffic_chain(&self, ifindex: i32) -> TrafficChainHandle {
+        TrafficChainHandle::new(self.clone(), ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/get.rs
+++ b/rtnetlink/src/traffic_control/get.rs
@@ -126,3 +126,42 @@ impl TrafficFilterGetRequest {
         }
     }
 }
+
+pub struct TrafficChainGetRequest {
+    handle: Handle,
+    message: TcMessage,
+}
+
+impl TrafficChainGetRequest {
+    pub(crate) fn new(handle: Handle, ifindex: i32) -> Self {
+        let mut message = TcMessage::default();
+        message.header.index = ifindex;
+        TrafficChainGetRequest { handle, message }
+    }
+
+    /// Execute the request
+    pub fn execute(self) -> impl TryStream<Ok = TcMessage, Error = Error> {
+        let TrafficChainGetRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::GetTrafficChain(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        match handle.request(req) {
+            Ok(response) => Either::Left(response.map(move |msg| {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    // The kernel use RTM_NEWCHAIN for returned message
+                    NetlinkPayload::InnerMessage(RtnlMessage::NewTrafficChain(msg)) => Ok(msg),
+                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
+                        header, payload,
+                    ))),
+                }
+            })),
+            Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
+        }
+    }
+}

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -24,7 +24,8 @@ impl TrafficClassHandle {
         TrafficClassHandle { handle, ifindex }
     }
 
-    /// Retrieve the list of qdisc (equivalent to `tc qdisc show`)
+    /// Retrieve the list of traffic class (equivalent to
+    /// `tc class show dev <interface_name>`)
     pub fn get(&mut self) -> TrafficClassGetRequest {
         TrafficClassGetRequest::new(self.handle.clone(), self.ifindex)
     }

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -1,4 +1,4 @@
-use super::{QDiscGetRequest, TrafficClassGetRequest};
+use super::{QDiscGetRequest, TrafficClassGetRequest, TrafficFilterGetRequest};
 use crate::Handle;
 
 pub struct QDiscHandle(Handle);
@@ -21,11 +21,28 @@ pub struct TrafficClassHandle {
 
 impl TrafficClassHandle {
     pub fn new(handle: Handle, ifindex: i32) -> Self {
-        TrafficClassHandle{handle, ifindex}
+        TrafficClassHandle { handle, ifindex }
     }
 
     /// Retrieve the list of qdisc (equivalent to `tc qdisc show`)
     pub fn get(&mut self) -> TrafficClassGetRequest {
         TrafficClassGetRequest::new(self.handle.clone(), self.ifindex)
+    }
+}
+
+pub struct TrafficFilterHandle {
+    handle: Handle,
+    ifindex: i32,
+}
+
+impl TrafficFilterHandle {
+    pub fn new(handle: Handle, ifindex: i32) -> Self {
+        TrafficFilterHandle { handle, ifindex }
+    }
+
+    /// Retrieve the list of filter (equivalent to
+    /// `tc filter show dev <iface_name>`)
+    pub fn get(&mut self) -> TrafficFilterGetRequest {
+        TrafficFilterGetRequest::new(self.handle.clone(), self.ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -1,4 +1,6 @@
-use super::{QDiscGetRequest, TrafficClassGetRequest, TrafficFilterGetRequest};
+use super::{
+    QDiscGetRequest, TrafficChainGetRequest, TrafficClassGetRequest, TrafficFilterGetRequest,
+};
 use crate::Handle;
 
 pub struct QDiscHandle(Handle);
@@ -45,5 +47,22 @@ impl TrafficFilterHandle {
     /// `tc filter show dev <iface_name>`)
     pub fn get(&mut self) -> TrafficFilterGetRequest {
         TrafficFilterGetRequest::new(self.handle.clone(), self.ifindex)
+    }
+}
+
+pub struct TrafficChainHandle {
+    handle: Handle,
+    ifindex: i32,
+}
+
+impl TrafficChainHandle {
+    pub fn new(handle: Handle, ifindex: i32) -> Self {
+        TrafficChainHandle { handle, ifindex }
+    }
+
+    /// Retrieve the list of chain (equivalent to
+    /// `tc chain show dev <iface_name>`)
+    pub fn get(&mut self) -> TrafficChainGetRequest {
+        TrafficChainGetRequest::new(self.handle.clone(), self.ifindex)
     }
 }

--- a/rtnetlink/src/traffic_control/test.rs
+++ b/rtnetlink/src/traffic_control/test.rs
@@ -7,6 +7,8 @@ use netlink_packet_route::{
 use std::process::Command;
 use tokio::runtime::Runtime;
 
+static TEST_DUMMY_NIC: &str = "netlink-test";
+
 async fn _get_qdiscs() -> Vec<TcMessage> {
     let (connection, handle, _) = new_connection().unwrap();
     tokio::spawn(connection);
@@ -42,53 +44,199 @@ async fn _get_tclasses(ifindex: i32) -> Vec<TcMessage> {
     tclasses
 }
 
-fn _add_test_tclass_to_lo() {
-    let output = Command::new("tc")
-        .args(&[
-            "qdisc", "add", "dev", "lo", "root", "handle", "1:", "htb", "default", "6",
-        ])
+// Return 0 for not found
+fn _get_test_dummy_interface_index() -> i32 {
+    let output = Command::new("ip")
+        .args(&["-o", "link", "show", TEST_DUMMY_NIC])
         .output()
-        .expect("failed to run tc command");
+        .expect("failed to run ip command");
     if !output.status.success() {
-        eprintln!("Failed to add qdisc to lo: {:?}", output);
+        0
+    } else {
+        let line = std::str::from_utf8(&output.stdout).unwrap();
+        line.split(": ").next().unwrap().parse::<i32>().unwrap()
     }
-    assert!(output.status.success());
-    let output = Command::new("tc")
-        .args(&[
-            "class", "add", "dev", "lo", "parent", "1:", "classid", "1:1", "htb", "rate", "10mbit",
-            "ceil", "10mbit",
-        ])
+}
+
+fn _add_test_dummy_interface() -> i32 {
+    if _get_test_dummy_interface_index() == 0 {
+        let output = Command::new("ip")
+            .args(&["link", "add", TEST_DUMMY_NIC, "type", "dummy"])
+            .output()
+            .expect("failed to run ip command");
+        if !output.status.success() {
+            eprintln!(
+                "Failed to create dummy interface {} : {:?}",
+                TEST_DUMMY_NIC, output
+            );
+        }
+        assert!(output.status.success());
+    }
+
+    _get_test_dummy_interface_index()
+}
+
+fn _remove_test_dummy_interface() {
+    let output = Command::new("ip")
+        .args(&["link", "del", TEST_DUMMY_NIC])
         .output()
-        .expect("failed to run tc command");
+        .expect("failed to run ip command");
     if !output.status.success() {
-        eprintln!("Failed to add traffic class to lo: {:?}", output);
+        eprintln!(
+            "Failed to remove dummy interface {} : {:?}",
+            TEST_DUMMY_NIC, output
+        );
     }
     assert!(output.status.success());
 }
 
-fn _remove_test_tclass_from_lo() {
-    Command::new("tc")
+fn _add_test_tclass_to_dummy() {
+    let output = Command::new("tc")
         .args(&[
-            "class", "del", "dev", "lo", "parent", "1:", "classid", "1:1",
+            "qdisc",
+            "add",
+            "dev",
+            TEST_DUMMY_NIC,
+            "root",
+            "handle",
+            "1:",
+            "htb",
+            "default",
+            "6",
         ])
-        .status()
-        .expect("failed to remove tclass from lo");
-    Command::new("tc")
-        .args(&["qdisc", "del", "dev", "lo", "root"])
-        .status()
-        .expect("failed to remove qdisc from lo");
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!(
+            "Failed to add qdisc to dummy interface {} : {:?}",
+            TEST_DUMMY_NIC, output
+        );
+    }
+    assert!(output.status.success());
+    let output = Command::new("tc")
+        .args(&[
+            "class",
+            "add",
+            "dev",
+            TEST_DUMMY_NIC,
+            "parent",
+            "1:",
+            "classid",
+            "1:1",
+            "htb",
+            "rate",
+            "10mbit",
+            "ceil",
+            "10mbit",
+        ])
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!(
+            "Failed to add traffic class to dummy interface {}: {:?}",
+            TEST_DUMMY_NIC, output
+        );
+    }
+    assert!(output.status.success());
 }
 
+fn _add_test_filter_to_dummy() {
+    let output = Command::new("tc")
+        .args(&[
+            "filter",
+            "add",
+            "dev",
+            TEST_DUMMY_NIC,
+            "parent",
+            "1:",
+            "basic",
+            "match",
+            "meta(priority eq 6)",
+            "classid",
+            "1:1",
+        ])
+        .output()
+        .expect("failed to run tc command");
+    if !output.status.success() {
+        eprintln!("Failed to add trafice filter to lo: {:?}", output);
+    }
+    assert!(output.status.success());
+}
+
+fn _remove_test_tclass_from_dummy() {
+    Command::new("tc")
+        .args(&[
+            "class",
+            "del",
+            "dev",
+            TEST_DUMMY_NIC,
+            "parent",
+            "1:",
+            "classid",
+            "1:1",
+        ])
+        .status()
+        .expect(&format!(
+            "failed to remove tclass from dummy interface {}",
+            TEST_DUMMY_NIC
+        ));
+    Command::new("tc")
+        .args(&["qdisc", "del", "dev", TEST_DUMMY_NIC, "root"])
+        .status()
+        .expect(&format!(
+            "failed to remove qdisc from dummy interface {}",
+            TEST_DUMMY_NIC
+        ));
+}
+
+fn _remove_test_filter_from_dummy() {
+    Command::new("tc")
+        .args(&["filter", "del", "dev", TEST_DUMMY_NIC])
+        .status()
+        .expect(&format!(
+            "failed to remove filter from dummy interface {}",
+            TEST_DUMMY_NIC
+        ));
+}
+
+async fn _get_filters(ifindex: i32) -> Vec<TcMessage> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+    let mut filters_iter = handle.traffic_filter(ifindex).get().execute();
+    let mut filters = Vec::new();
+    while let Some(nl_msg) = filters_iter.try_next().await.unwrap() {
+        filters.push(nl_msg.clone());
+    }
+    filters
+}
+
+// The `cargo test` by default run all tests in parallel, in stead
+// of create random named veth/dummy for test, just place class and filter
+// query test in one test case is much simpler.
 #[test]
 #[cfg_attr(not(feature = "test_as_root"), ignore)]
-fn test_get_traffic_classes() {
-    _add_test_tclass_to_lo();
-    let tclasses = Runtime::new().unwrap().block_on(_get_tclasses(1));
-    _remove_test_tclass_from_lo();
+fn test_get_traffic_classes_and_filters() {
+    let ifindex = _add_test_dummy_interface();
+    _add_test_tclass_to_dummy();
+    _add_test_filter_to_dummy();
+    let tclasses = Runtime::new().unwrap().block_on(_get_tclasses(ifindex));
+    let filters = Runtime::new().unwrap().block_on(_get_filters(ifindex));
+    _remove_test_filter_from_dummy();
+    _remove_test_tclass_from_dummy();
+    _remove_test_dummy_interface();
     assert_eq!(tclasses.len(), 1);
-    let tclass_of_loopback_nic = &tclasses[0];
-    assert_eq!(tclass_of_loopback_nic.header.family, AF_UNSPEC as u8);
-    assert_eq!(tclass_of_loopback_nic.header.index, 1);
-    assert_eq!(tclass_of_loopback_nic.header.parent, u32::MAX);
-    assert_eq!(tclass_of_loopback_nic.nlas[0], Kind("htb".to_string()));
+    let tclass = &tclasses[0];
+    assert_eq!(tclass.header.family, AF_UNSPEC as u8);
+    assert_eq!(tclass.header.index, ifindex);
+    assert_eq!(tclass.header.parent, u32::MAX);
+    assert_eq!(tclass.nlas[0], Kind("htb".to_string()));
+    assert_eq!(filters.len(), 2);
+    assert_eq!(filters[0].header.family, AF_UNSPEC as u8);
+    assert_eq!(filters[0].header.index, ifindex);
+    assert_eq!(filters[0].header.parent, u16::MAX as u32 + 1);
+    assert_eq!(filters[0].nlas[0], Kind("basic".to_string()));
+    assert_eq!(filters[1].header.family, AF_UNSPEC as u8);
+    assert_eq!(filters[1].header.index, ifindex);
+    assert_eq!(filters[1].header.parent, u16::MAX as u32 + 1);
+    assert_eq!(filters[1].nlas[0], Kind("basic".to_string()));
 }


### PR DESCRIPTION
New function `rtnetlink::Handle::traffic_chain()` with initial traffic
chain query support.

Integration test case updated to test query traffic chain.

Waiting on PR #91 and #92