### PR TITLE
Include license file in the crate

### DIFF
--- a/audit/LICENSE-MIT
+++ b/audit/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/netlink-packet-audit/LICENSE-MIT
+++ b/netlink-packet-audit/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/netlink-packet-core/LICENSE-MIT
+++ b/netlink-packet-core/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/netlink-packet-route/LICENSE-MIT
+++ b/netlink-packet-route/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/netlink-packet-utils/LICENSE-MIT
+++ b/netlink-packet-utils/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/netlink-sys/LICENSE-MIT
+++ b/netlink-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/rtnetlink/LICENSE-MIT
+++ b/rtnetlink/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
The crate file created by `cargo package` does not contains
license file.

Create soft-link to each crate and `cargo package` will include the
real license file in the crate file.