### PR TITLE
netlink-packet-utils: Increase paste crate to 1.0

### DIFF
--- a/netlink-packet-utils/Cargo.toml
+++ b/netlink-packet-utils/Cargo.toml
@@ -12,5 +12,5 @@ description = "macros and helpers for parsing netlink messages"
 [dependencies]
 anyhow = "1.0.31"
 byteorder = "1.3.2"
-paste = "0.1.6"
+paste = "1.0"
 thiserror = "1"


### PR DESCRIPTION
The paste crate has released 1.0.0 without any API changes, better
use the stable version of a crate as dependent.