### PR TITLE
sock_diag: wire up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "netlink-packet-utils",
     "netlink-packet-route",
     "netlink-packet-audit",
+    "netlink-packet-sock-diag",
     "netlink-proto",
     "rtnetlink",
     "audit",

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors = ["Flier Lu <flier.lu@gmail.com>", "Corentin Henry <corentinhenry@gmail.com>"]
+name = "netlink-packet-sock-diag"
+version = "0.1.0"
+edition = "2018"
+
+homepage = "https://github.com/little-dude/netlink"
+keywords = ["netlink", "linux", "sock_diag"]
+license = "MIT"
+readme = "../README.md"
+repository = "https://github.com/little-dude/netlink"
+description = "netlink packet types for the sock_diag subprotocol"
+
+[dependencies]
+failure = "0.1.5"
+byteorder = "1.3.2"
+netlink-packet-core = { path = "../netlink-packet-core", version = "0.1" }
+netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.1" }
+bitflags = "*"
+libc = "*"
+smallvec = "*"
+
+[dev-dependencies]
+lazy_static = "1.4.0"

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -22,3 +22,4 @@ smallvec = "*"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
+netlink-sys = { path = "../netlink-sys", version = "0.4" }

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Flier Lu <flier.lu@gmail.com>", "Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-sock-diag"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -12,10 +12,10 @@ repository = "https://github.com/little-dude/netlink"
 description = "netlink packet types for the sock_diag subprotocol"
 
 [dependencies]
-failure = "0.1.5"
+anyhow = "1.0.31"
 byteorder = "1.3.2"
-netlink-packet-core = { path = "../netlink-packet-core", version = "0.1" }
-netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.1" }
+netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }
+netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.2" }
 bitflags = "*"
 libc = "*"
 smallvec = "*"

--- a/netlink-packet-sock-diag/LICENSE-MIT
+++ b/netlink-packet-sock-diag/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/netlink-packet-sock-diag/examples/dump_ipv4.rs
+++ b/netlink-packet-sock-diag/examples/dump_ipv4.rs
@@ -1,0 +1,71 @@
+use netlink_packet_sock_diag::{
+    constants::*,
+    inet::{ExtensionFlags, InetRequest, SocketId, StateFlags},
+    NetlinkHeader, NetlinkMessage, NetlinkPayload, SockDiagMessage,
+};
+use netlink_sys::{Protocol, Socket, SocketAddr};
+
+fn main() {
+    let mut socket = Socket::new(Protocol::SockDiag).unwrap();
+    let _port_number = socket.bind_auto().unwrap().port_number();
+    socket.connect(&SocketAddr::new(0, 0)).unwrap();
+
+    let mut packet = NetlinkMessage {
+        header: NetlinkHeader {
+            flags: NLM_F_REQUEST | NLM_F_DUMP,
+            ..Default::default()
+        },
+        payload: SockDiagMessage::InetRequest(InetRequest {
+            family: AF_INET,
+            protocol: IPPROTO_TCP.into(),
+            extensions: ExtensionFlags::empty(),
+            states: StateFlags::all(),
+            socket_id: SocketId::new_v4(),
+        })
+        .into(),
+    };
+
+    packet.finalize();
+
+    let mut buf = vec![0; packet.header.length as usize];
+
+    // Before calling serialize, it is important to check that the buffer in which we're emitting is big
+    // enough for the packet, other `serialize()` panics.
+    assert_eq!(buf.len(), packet.buffer_len());
+
+    packet.serialize(&mut buf[..]);
+
+    println!(">>> {:?}", packet);
+    if let Err(e) = socket.send(&buf[..], 0) {
+        println!("SEND ERROR {}", e);
+        return;
+    }
+
+    let mut receive_buffer = vec![0; 4096];
+    let mut offset = 0;
+    while let Ok(size) = socket.recv(&mut receive_buffer[..], 0) {
+        loop {
+            let bytes = &receive_buffer[offset..];
+            let rx_packet = <NetlinkMessage<SockDiagMessage>>::deserialize(bytes).unwrap();
+            println!("<<< {:?}", rx_packet);
+
+            match rx_packet.payload {
+                NetlinkPayload::Noop | NetlinkPayload::Ack(_) => {}
+                NetlinkPayload::InnerMessage(SockDiagMessage::InetResponse(response)) => {
+                    println!("{:#?}", response);
+                }
+                NetlinkPayload::Done => {
+                    println!("Done!");
+                    return;
+                }
+                NetlinkPayload::Error(_) | NetlinkPayload::Overrun(_) | _ => return,
+            }
+
+            offset += rx_packet.header.length as usize;
+            if offset == size || rx_packet.header.length == 0 {
+                offset = 0;
+                break;
+            }
+        }
+    }
+}

--- a/netlink-packet-sock-diag/src/buffer.rs
+++ b/netlink-packet-sock-diag/src/buffer.rs
@@ -1,0 +1,89 @@
+use crate::{
+    constants::*,
+    inet,
+    traits::{Parseable, ParseableParametrized},
+    unix, DecodeError, SockDiagMessage,
+};
+use anyhow::Context;
+
+const BUF_MIN_LEN: usize = 2;
+
+pub struct SockDiagBuffer<T> {
+    buffer: T,
+}
+
+impl<T: AsRef<[u8]>> SockDiagBuffer<T> {
+    pub fn new(buffer: T) -> SockDiagBuffer<T> {
+        SockDiagBuffer { buffer }
+    }
+
+    pub fn length(&self) -> usize {
+        self.buffer.as_ref().len()
+    }
+
+    pub fn new_checked(buffer: T) -> Result<Self, DecodeError> {
+        let packet = Self::new(buffer);
+        packet.check_len()?;
+        Ok(packet)
+    }
+
+    pub(crate) fn check_len(&self) -> Result<(), DecodeError> {
+        let len = self.buffer.as_ref().len();
+        if len < BUF_MIN_LEN {
+            return Err(format!(
+                "invalid buffer: length is {} but packets are at least {} bytes",
+                len, BUF_MIN_LEN
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn family(&self) -> u8 {
+        self.buffer.as_ref()[0]
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> SockDiagBuffer<&'a T> {
+    pub fn inner(&self) -> &'a [u8] {
+        &self.buffer.as_ref()[..]
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> SockDiagBuffer<&'a mut T> {
+    pub fn inner_mut(&mut self) -> &mut [u8] {
+        &mut self.buffer.as_mut()[..]
+    }
+}
+
+impl<'a, T: AsRef<[u8]>> ParseableParametrized<SockDiagBuffer<&'a T>, u16> for SockDiagMessage {
+    fn parse_with_param(
+        buf: &SockDiagBuffer<&'a T>,
+        message_type: u16,
+    ) -> Result<Self, DecodeError> {
+        use self::SockDiagMessage::*;
+        buf.check_len()?;
+        let message = match (message_type, buf.family()) {
+            (SOCK_DIAG_BY_FAMILY, AF_INET) => {
+                let err = "invalid AF_INET response";
+                let buf = inet::InetResponseBuffer::new_checked(buf.inner()).context(err)?;
+                InetResponse(inet::InetResponse::parse(&buf).context(err)?)
+            }
+            (SOCK_DIAG_BY_FAMILY, AF_INET6) => {
+                let err = "invalid AF_INET6 response";
+                let buf = inet::InetResponseBuffer::new_checked(buf.inner()).context(err)?;
+                InetResponse(inet::InetResponse::parse(&buf).context(err)?)
+            }
+            (SOCK_DIAG_BY_FAMILY, AF_UNIX) => {
+                let err = "invalid AF_UNIX response";
+                let buf = unix::UnixResponseBuffer::new_checked(buf.inner()).context(err)?;
+                UnixResponse(unix::UnixResponse::parse(&buf).context(err)?)
+            }
+            (SOCK_DIAG_BY_FAMILY, af) => {
+                return Err(format!("unknown address family {}", af).into())
+            }
+            _ => return Err(format!("unknown message type {}", message_type).into()),
+        };
+        Ok(message)
+    }
+}

--- a/netlink-packet-sock-diag/src/constants.rs
+++ b/netlink-packet-sock-diag/src/constants.rs
@@ -1,0 +1,270 @@
+pub use netlink_packet_core::constants::*;
+
+pub const AF_UNSPEC: u8 = libc::AF_UNSPEC as u8;
+pub const AF_UNIX: u8 = libc::AF_UNIX as u8;
+// pub const AF_LOCAL: u8 = libc::AF_LOCAL as u8;
+pub const AF_INET: u8 = libc::AF_INET as u8;
+pub const AF_AX25: u8 = libc::AF_AX25 as u8;
+pub const AF_IPX: u8 = libc::AF_IPX as u8;
+pub const AF_APPLETALK: u8 = libc::AF_APPLETALK as u8;
+pub const AF_NETROM: u8 = libc::AF_NETROM as u8;
+pub const AF_BRIDGE: u8 = libc::AF_BRIDGE as u8;
+pub const AF_ATMPVC: u8 = libc::AF_ATMPVC as u8;
+pub const AF_X25: u8 = libc::AF_X25 as u8;
+pub const AF_INET6: u8 = libc::AF_INET6 as u8;
+pub const AF_ROSE: u8 = libc::AF_ROSE as u8;
+pub const AF_DECNET: u8 = libc::AF_DECnet as u8;
+pub const AF_NETBEUI: u8 = libc::AF_NETBEUI as u8;
+pub const AF_SECURITY: u8 = libc::AF_SECURITY as u8;
+pub const AF_KEY: u8 = libc::AF_KEY as u8;
+pub const AF_NETLINK: u8 = libc::AF_NETLINK as u8;
+// pub const AF_ROUTE: u8 = libc::AF_ROUTE as u8;
+pub const AF_PACKET: u8 = libc::AF_PACKET as u8;
+pub const AF_ASH: u8 = libc::AF_ASH as u8;
+pub const AF_ECONET: u8 = libc::AF_ECONET as u8;
+pub const AF_ATMSVC: u8 = libc::AF_ATMSVC as u8;
+pub const AF_RDS: u8 = libc::AF_RDS as u8;
+pub const AF_SNA: u8 = libc::AF_SNA as u8;
+pub const AF_IRDA: u8 = libc::AF_IRDA as u8;
+pub const AF_PPPOX: u8 = libc::AF_PPPOX as u8;
+pub const AF_WANPIPE: u8 = libc::AF_WANPIPE as u8;
+pub const AF_LLC: u8 = libc::AF_LLC as u8;
+pub const AF_CAN: u8 = libc::AF_CAN as u8;
+pub const AF_TIPC: u8 = libc::AF_TIPC as u8;
+pub const AF_BLUETOOTH: u8 = libc::AF_BLUETOOTH as u8;
+pub const AF_IUCV: u8 = libc::AF_IUCV as u8;
+pub const AF_RXRPC: u8 = libc::AF_RXRPC as u8;
+pub const AF_ISDN: u8 = libc::AF_ISDN as u8;
+pub const AF_PHONET: u8 = libc::AF_PHONET as u8;
+pub const AF_IEEE802154: u8 = libc::AF_IEEE802154 as u8;
+pub const AF_CAIF: u8 = libc::AF_CAIF as u8;
+pub const AF_ALG: u8 = libc::AF_ALG as u8;
+
+/// Dummy protocol for TCP
+pub const IPPROTO_IP: u8 = 0;
+/// Internet Control Message Protocol
+pub const IPPROTO_ICMP: u8 = 1;
+/// Internet Group Management Protocol
+pub const IPPROTO_IGMP: u8 = 2;
+/// IPIP tunnels (older KA9Q tunnels use 94)
+pub const IPPROTO_IPIP: u8 = 4;
+/// Transmission Control Protocol
+pub const IPPROTO_TCP: u8 = 6;
+/// Exterior Gateway Protocol
+pub const IPPROTO_EGP: u8 = 8;
+/// PUP protocol
+pub const IPPROTO_PUP: u8 = 12;
+/// User Datagram Protocol
+pub const IPPROTO_UDP: u8 = 17;
+/// XNS IDP protocol
+pub const IPPROTO_IDP: u8 = 22;
+/// SO Transport Protocol Class 4
+pub const IPPROTO_TP: u8 = 29;
+/// Datagram Congestion Control Protocol
+pub const IPPROTO_DCCP: u8 = 33;
+/// IPv6 header
+pub const IPPROTO_IPV6: u8 = 41;
+/// Reservation Protocol
+pub const IPPROTO_RSVP: u8 = 46;
+/// General Routing Encapsulation
+pub const IPPROTO_GRE: u8 = 47;
+/// encapsulating security payload
+pub const IPPROTO_ESP: u8 = 50;
+/// authentication header
+pub const IPPROTO_AH: u8 = 51;
+/// Multicast Transport Protocol
+pub const IPPROTO_MTP: u8 = 92;
+/// IP option pseudo header for BEET
+pub const IPPROTO_BEETPH: u8 = 94;
+/// Encapsulation Header
+pub const IPPROTO_ENCAP: u8 = 98;
+/// Protocol Independent Multicast
+pub const IPPROTO_PIM: u8 = 103;
+/// Compression Header Protocol
+pub const IPPROTO_COMP: u8 = 108;
+/// Stream Control Transmission Protocol
+pub const IPPROTO_SCTP: u8 = 132;
+/// UDP-Lite protocol
+pub const IPPROTO_UDPLITE: u8 = 136;
+/// MPLS in IP
+pub const IPPROTO_MPLS: u8 = 137;
+/// Raw IP packets
+pub const IPPROTO_RAW: u8 = 255;
+/// IPv6 Hop-by-Hop options
+pub const IPPROTO_HOPOPTS: u8 = 0;
+/// IPv6 routing header
+pub const IPPROTO_ROUTING: u8 = 43;
+/// IPv6 fragmentation header
+pub const IPPROTO_FRAGMENT: u8 = 44;
+/// ICMPv6
+pub const IPPROTO_ICMPV6: u8 = 58;
+/// IPv6 no next header
+pub const IPPROTO_NONE: u8 = 59;
+/// IPv6 destination options
+pub const IPPROTO_DSTOPTS: u8 = 60;
+/// IPv6 mobility header
+pub const IPPROTO_MH: u8 = 135;
+
+// Extensions for inet
+pub const INET_DIAG_NONE: u16 = 0;
+pub const INET_DIAG_MEMINFO: u16 = 1;
+pub const INET_DIAG_INFO: u16 = 2;
+pub const INET_DIAG_VEGASINFO: u16 = 3;
+pub const INET_DIAG_CONG: u16 = 4;
+pub const INET_DIAG_TOS: u16 = 5;
+pub const INET_DIAG_TCLASS: u16 = 6;
+pub const INET_DIAG_SKMEMINFO: u16 = 7;
+pub const INET_DIAG_SHUTDOWN: u16 = 8;
+
+pub const INET_DIAG_DCTCPINFO: u16 = 9;
+pub const INET_DIAG_PROTOCOL: u16 = 10;
+pub const INET_DIAG_SKV6ONLY: u16 = 11;
+pub const INET_DIAG_LOCALS: u16 = 12;
+pub const INET_DIAG_PEERS: u16 = 13;
+pub const INET_DIAG_PAD: u16 = 14;
+pub const INET_DIAG_MARK: u16 = 15;
+pub const INET_DIAG_BBRINFO: u16 = 16;
+pub const INET_DIAG_CLASS_ID: u16 = 17;
+pub const INET_DIAG_MD5SIG: u16 = 18;
+
+/// (both server and client) represents an open connection, data
+/// received can be delivered to the user. The normal state for the
+/// data transfer phase of the connection.
+pub const TCP_ESTABLISHED: u8 = 1;
+/// (client) represents waiting for a matching connection request
+/// after having sent a connection request.
+pub const TCP_SYN_SENT: u8 = 2;
+/// (server) represents waiting for a confirming connection request
+/// acknowledgment after having both received and sent a connection
+/// request.
+pub const TCP_SYN_RECV: u8 = 3;
+/// (both server and client) represents waiting for a connection
+/// termination request from the remote TCP, or an acknowledgment of
+/// the connection termination request previously sent.
+pub const TCP_FIN_WAIT1: u8 = 4;
+/// (both server and client) represents waiting for a connection
+/// termination request from the remote TCP.
+pub const TCP_FIN_WAIT2: u8 = 5;
+/// (either server or client) represents waiting for enough time to
+/// pass to be sure the remote TCP received the acknowledgment of its
+/// connection termination request.
+pub const TCP_TIME_WAIT: u8 = 6;
+/// (both server and client) represents no connection state at all.
+pub const TCP_CLOSE: u8 = 7;
+/// (both server and client) represents waiting for a connection
+/// termination request from the local user.
+pub const TCP_CLOSE_WAIT: u8 = 8;
+/// (both server and client) represents waiting for an acknowledgment
+/// of the connection termination request previously sent to the
+/// remote TCP (which includes an acknowledgment of its connection
+/// termination request).
+pub const TCP_LAST_ACK: u8 = 9;
+/// (server) represents waiting for a connection request from any
+/// remote TCP and port.
+pub const TCP_LISTEN: u8 = 10;
+/// (both server and client) represents waiting for a connection termination request acknowledgment from the remote TCP.
+pub const TCP_CLOSING: u8 = 11;
+
+/// The attribute reported in answer to this request is
+/// `UNIX_DIAG_NAME`. The payload associated with this attribute is
+/// the pathname to which the socket was bound (a se quence of bytes
+/// up to `UNIX_PATH_MAX` length).
+pub const UDIAG_SHOW_NAME: u32 = 1 << UNIX_DIAG_NAME;
+/// The attribute reported in answer to this request is
+/// `UNIX_DIAG_VFS`, which returns VFS information associated to the
+/// inode.
+pub const UDIAG_SHOW_VFS: u32 = 1 << UNIX_DIAG_VFS;
+/// The attribute reported in answer to this request is
+/// `UNIX_DIAG_PEER`, which carries the peer's inode number. This
+/// attribute is reported for connected sockets only.
+pub const UDIAG_SHOW_PEER: u32 = 1 << UNIX_DIAG_PEER;
+/// The attribute reported in answer to this request is
+/// `UNIX_DIAG_ICONS`, which information about pending
+/// connections. Specifically, it contains the inode numbers of the
+/// sockets that have passed the `connect(2)` call, but hasn't been
+/// processed with `accept(2) yet`. This attribute is reported for
+/// listening sockets only.
+pub const UDIAG_SHOW_ICONS: u32 = 1 << UNIX_DIAG_ICONS;
+/// The attribute reported in answer to this request is
+/// `UNIX_DIAG_RQLEN`, which reports:
+///
+/// - for listening socket: the number of pending connections, and the
+///   backlog length (which equals to the value passed as the second
+///   argument to `listen(2)`).
+/// - for established sockets: the amount of data in incoming queue,
+///   and the amount of memory available for sending
+pub const UDIAG_SHOW_RQLEN: u32 = 1 << UNIX_DIAG_RQLEN;
+/// The attribute reported in answer to this request is
+/// `UNIX_DIAG_MEMINFO` which shows memory information about the
+/// socket
+pub const UDIAG_SHOW_MEMINFO: u32 = 1 << UNIX_DIAG_MEMINFO;
+
+pub const UNIX_DIAG_NAME: u16 = 0;
+pub const UNIX_DIAG_VFS: u16 = 1;
+pub const UNIX_DIAG_PEER: u16 = 2;
+pub const UNIX_DIAG_ICONS: u16 = 3;
+pub const UNIX_DIAG_RQLEN: u16 = 4;
+pub const UNIX_DIAG_MEMINFO: u16 = 5;
+pub const UNIX_DIAG_SHUTDOWN: u16 = 6;
+
+/// Provides sequenced, reliable, two-way, connection-based byte
+/// streams. An out-of-band data transmission mechanism may be
+/// supported.
+pub const SOCK_STREAM: u8 = libc::SOCK_STREAM as u8;
+/// Supports datagrams (connectionless, unreliable messages of a fixed
+/// maximum length).
+pub const SOCK_DGRAM: u8 = libc::SOCK_DGRAM as u8;
+/// Provides a sequenced, reliable, two-way connection-based data
+/// transmission path for datagrams of fixed maximum length; a
+/// consumer is required to read an entire packet with each input
+/// system call.
+pub const SOCK_SEQPACKET: u8 = libc::SOCK_SEQPACKET as u8;
+/// Provides raw network protocol access.
+pub const SOCK_RAW: u8 = libc::SOCK_RAW as u8;
+/// Provides a reliable datagram layer that does not guarantee
+/// ordering.
+pub const SOCK_RDM: u8 = libc::SOCK_RDM as u8;
+/// Obsolete and should not be used in new programs; see `packet(7)`.
+pub const SOCK_PACKET: u8 = libc::SOCK_PACKET as u8;
+
+/// Nothing bad has been observed recently. No apparent reordering, packet loss, or ECN marks.
+pub const TCP_CA_OPEN: u8 = 0;
+pub const TCPF_CA_OPEN: u32 = 1 << TCP_CA_OPEN;
+
+/// The sender enters disordered state when it has received DUPACKs or
+/// SACKs in the last round of packets sent. This could be due to
+/// packet loss or reordering but needs further information to confirm
+/// packets have been lost.
+pub const TCP_CA_DISORDER: u8 = 1;
+pub const TCPF_CA_DISORDER: u32 = 1 << TCP_CA_DISORDER;
+/// The sender enters Congestion Window Reduction (CWR) state when it
+/// has received ACKs with ECN-ECE marks, or has experienced
+/// congestion or packet discard on the sender host (e.g. qdisc).
+pub const TCP_CA_CWR: u8 = 2;
+pub const TCPF_CA_CWR: u32 = 1 << TCP_CA_CWR;
+/// The sender is in fast recovery and retransmitting lost packets, typically triggered by ACK events.
+pub const TCP_CA_RECOVERY: u8 = 3;
+pub const TCPF_CA_RECOVERY: u32 = 1 << TCP_CA_RECOVERY;
+/// The sender is in loss recovery triggered by retransmission timeout.
+pub const TCP_CA_LOSS: u8 = 4;
+pub const TCPF_CA_LOSS: u32 = 1 << TCP_CA_LOSS;
+
+pub const TCPI_OPT_TIMESTAMPS: u8 = 1;
+pub const TCPI_OPT_SACK: u8 = 2;
+pub const TCPI_OPT_WSCALE: u8 = 4;
+/// ECN was negociated at TCP session init
+pub const TCPI_OPT_ECN: u8 = 8;
+/// We received at least one packet with ECT
+pub const TCPI_OPT_ECN_SEEN: u8 = 16;
+/// SYN-ACK acked data in SYN sent or rcvd
+pub const TCPI_OPT_SYN_DATA: u8 = 32;
+
+/// Shutdown state of a socket. A socket shut down with `SHUT_RD` can
+/// no longer receive data. See also `man 2 shutdown`.
+pub const SHUT_RD: u8 = 0;
+/// Shutdown state of a socket. A socket shut down with `SHUT_WR` can
+/// no longer send data. See also `man 2 shutdown`.
+pub const SHUT_WR: u8 = 1;
+/// Shutdown state of a socket. A socket shut down with `SHUT_RDWR`
+/// can no longer receive nor send data. See also `man 2 shutdown`.
+pub const SHUT_RDWR: u8 = 2;

--- a/netlink-packet-sock-diag/src/constants.rs
+++ b/netlink-packet-sock-diag/src/constants.rs
@@ -1,5 +1,8 @@
 pub use netlink_packet_core::constants::*;
 
+pub const SOCK_DIAG_BY_FAMILY: u16 = 20;
+pub const SOCK_DESTROY: u16 = 21;
+
 pub const AF_UNSPEC: u8 = libc::AF_UNSPEC as u8;
 pub const AF_UNIX: u8 = libc::AF_UNIX as u8;
 // pub const AF_LOCAL: u8 = libc::AF_LOCAL as u8;

--- a/netlink-packet-sock-diag/src/inet/mod.rs
+++ b/netlink-packet-sock-diag/src/inet/mod.rs
@@ -1,0 +1,13 @@
+mod socket_id;
+pub use self::socket_id::*;
+
+mod request;
+pub use self::request::*;
+
+mod response;
+pub use self::response::*;
+
+pub mod nlas;
+
+#[cfg(test)]
+mod tests;

--- a/netlink-packet-sock-diag/src/inet/nlas.rs
+++ b/netlink-packet-sock-diag/src/inet/nlas.rs
@@ -1,0 +1,529 @@
+use byteorder::{ByteOrder, NativeEndian};
+use failure::ResultExt;
+
+pub use crate::utils::nla::{DefaultNla, NlaBuffer, NlasIterator};
+
+use crate::{
+    constants::*,
+    parsers::{parse_string, parse_u32, parse_u8},
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+
+pub const LEGACY_MEM_INFO_LEN: usize = 16;
+
+buffer!(LegacyMemInfoBuffer(LEGACY_MEM_INFO_LEN) {
+    receive_queue: (u32, 0..4),
+    bottom_send_queue: (u32, 4..8),
+    cache: (u32, 8..12),
+    send_queue: (u32, 12..16)
+});
+
+/// In recent Linux kernels, this NLA is not used anymore to report
+/// AF_INET and AF_INET6 sockets memory information. See [`MemInfo`]
+/// instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyMemInfo {
+    /// Amount of data in the receive queue.
+    pub receive_queue: u32,
+    /// Amount of data that is queued by TCP but not yet sent.
+    pub bottom_send_queue: u32,
+    /// Amount of memory scheduled for future use (TCP only).
+    pub cache: u32,
+    /// Amount of data in the send queue.
+    pub send_queue: u32,
+}
+
+impl<T: AsRef<[u8]>> Parseable<LegacyMemInfoBuffer<T>> for LegacyMemInfo {
+    fn parse(buf: &LegacyMemInfoBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            receive_queue: buf.receive_queue(),
+            bottom_send_queue: buf.bottom_send_queue(),
+            cache: buf.cache(),
+            send_queue: buf.send_queue(),
+        })
+    }
+}
+
+impl Emitable for LegacyMemInfo {
+    fn buffer_len(&self) -> usize {
+        LEGACY_MEM_INFO_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = LegacyMemInfoBuffer::new(buf);
+        buf.set_receive_queue(self.receive_queue);
+        buf.set_bottom_send_queue(self.bottom_send_queue);
+        buf.set_cache(self.cache);
+        buf.set_send_queue(self.send_queue);
+    }
+}
+
+pub const MEM_INFO_LEN: usize = 36;
+
+// FIXME: the last 2 fields are not present on old linux kernels. We
+// should support optional fields in the `buffer!` macro.
+buffer!(MemInfoBuffer(MEM_INFO_LEN) {
+    receive_queue: (u32, 0..4),
+    receive_queue_max: (u32, 4..8),
+    bottom_send_queues: (u32, 8..12),
+    send_queue_max: (u32, 12..16),
+    cache: (u32, 16..20),
+    send_queue: (u32, 20..24),
+    options: (u32, 24..28),
+    backlog_queue_length: (u32, 28..32),
+    drops: (u32, 32..36),
+});
+
+/// Socket memory information. To understand this information, one
+/// must understand how the memory allocated for the send and receive
+/// queues of a socket is managed.
+///
+/// # Warning
+///
+/// This data structure is not well documented. The explanations given
+/// here are the results of my personal research on this topic, but I
+/// am by no mean an expert in Linux networking, so take this
+/// documentation with a huge grain of salt. Please report any error
+/// you may notice. Here are the references I used:
+///
+/// - [https://wiki.linuxfoundation.org/networking/sk_buff](a short introduction to `sk_buff`, the struct used in the kernel to store packets)
+/// - [vger.kernel.org has a lot of documentation about the low level network stack APIs](http://vger.kernel.org/~davem/skb_data.html)
+/// - [thorough high level explanation of buffering in the network stack](https://www.coverfire.com/articles/queueing-in-the-linux-network-stack/)
+/// - [understanding the backlog queue](http://veithen.io/2014/01/01/how-tcp-backlog-works-in-linux.html)
+/// - [high level explanation of packet reception](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-network-packet-reception)
+/// - [a StackExchange question about the different send queues used by a socket](https://unix.stackexchange.com/questions/551444/what-is-the-difference-between-sock-sk-wmem-alloc-and-sock-sk-wmem-queued)
+/// - other useful resources: [here](https://www.cl.cam.ac.uk/~pes20/Netsem/linuxnet.pdf) and [here](https://people.cs.clemson.edu/~westall/853/notes/skbuff.pdf)
+/// - [explanation of the socket backlog queue](https://medium.com/@c0ngwang/the-design-of-lock-sock-in-linux-kernel-69c3406e504b)
+///
+/// # Linux networking in a nutshell
+///
+/// The network stack uses multiple queues, both for sending an
+/// receiving data. Let's start with the simplest case: packet
+/// receptions.
+///
+/// When data is received, it is first handled by the device driver
+/// and put in the device driver queue. The kernel then move the
+/// packet to the socket receive queue (also called _receive
+/// buffer_). Finally, this application reads it (with `recv`, `read`
+/// or `recvfrom`) and the packet is dequeued.
+///
+/// Sending packet it slightly more complicated and the exact workflow
+/// may differ from one protocol to the other so we'll just give a
+/// high level overview. When an application sends data, a packet is
+/// created and stored in the socket send queue (also called _send
+/// buffer_). It is then passed down to the QDisc (Queuing
+/// Disciplines) queue. The QDisc facility enables quality of service:
+/// if some data is more urgent to transmit than other, QDisc will
+/// make sure it is sent in priority. Finally, the data is put on the
+/// device driver queue to be sent out.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MemInfo {
+    /// Memory currently allocated for the socket's receive
+    /// queue. This attribute is known as `sk_rmem_alloc` in the
+    /// kernel.
+    pub receive_queue: u32,
+    /// Maximum amount of memory that can be allocated for the
+    /// socket's receive queue. This is set by `SO_RCVBUF`. This is
+    /// _not_ the amount of memory currently allocated. This attribute
+    /// is known as `sk_rcvbuf` in the kernel.
+    pub receive_queue_max: u32,
+    /// Memory currently allocated for the socket send queue. This
+    /// attribute is known as `sk_wmem_queued` in the kernel. This
+    /// does does not account for data that have been passed down the
+    /// network stack (i.e. to the QDisc and device driver queues),
+    /// which is reported by the `bottow_send_queue` (known as
+    /// `sk_wmem_alloc` in the kernel).
+    ///
+    /// For a TCP socket, if the congestion window is small, the
+    /// kernel will move the data fron the socket send queue to the
+    /// QDisc queues more slowly. Thus, if the process sends of lot of
+    /// data, the socket send queue (which memory is tracked by
+    /// `sk_wmem_queued`) will grow while `sk_wmem_alloc` will remain
+    /// small.
+    pub send_queue: u32,
+    /// Maximum amount of memory (in bytes) that can be allocated for
+    /// this socket's send queue. This is set by `SO_SNDBUF`. This is
+    /// _not_ the amount of memory currently allocated. This attribute
+    /// is known as `sk_sndbuf` in the kernel.
+    pub send_queue_max: u32,
+    /// Memory used for packets that have been passed down the network
+    /// stack, i.e. that are either in the QDisc or device driver
+    /// queues. This attribute is known as `sk_wmem_alloc` in the
+    /// kernel. See also [`send_queue`].
+    pub bottom_send_queues: u32,
+    /// The amount of memory already allocated for this socket but
+    /// currently unused. When more memory is needed either for
+    /// sending or for receiving data, it will be taken from this
+    /// pool. This attribute is known as `sk_fwd_alloc` in the kernel.
+    pub cache: u32,
+    /// The amount of memory allocated for storing socket options, for
+    /// instance the key for TCP MD5 signature. This attribute is
+    /// known as `sk_optmem` in the kernel.
+    pub options: u32,
+    /// The length of the backlog queue. When the process is using the
+    /// socket, the socket is locked so the kernel cannot enqueue new
+    /// packets in the receive queue. To avoid blocking the bottom
+    /// half of network stack waiting for the process to release the
+    /// socket, the packets are enqueued in the backlog queue. Upon
+    /// releasing the socket, those packets are processed and put in
+    /// the regular receive queue.
+    // FIXME: this should be an Option because it's not present on old
+    // linux kernels.
+    pub backlog_queue_length: u32,
+    /// The amount of packets dropped. Depending on the kernel
+    /// version, this field may not be present.
+    // FIXME: this should be an Option because it's not present on old
+    // linux kernels.
+    pub drops: u32,
+}
+
+impl<T: AsRef<[u8]>> Parseable<MemInfoBuffer<T>> for MemInfo {
+    fn parse(buf: &MemInfoBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            receive_queue: buf.receive_queue(),
+            receive_queue_max: buf.receive_queue_max(),
+            bottom_send_queues: buf.bottom_send_queues(),
+            send_queue_max: buf.send_queue_max(),
+            cache: buf.cache(),
+            send_queue: buf.send_queue(),
+            options: buf.options(),
+            backlog_queue_length: buf.backlog_queue_length(),
+            drops: buf.drops(),
+        })
+    }
+}
+
+impl Emitable for MemInfo {
+    fn buffer_len(&self) -> usize {
+        MEM_INFO_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = MemInfoBuffer::new(buf);
+        buf.set_receive_queue(self.receive_queue);
+        buf.set_receive_queue_max(self.receive_queue_max);
+        buf.set_bottom_send_queues(self.bottom_send_queues);
+        buf.set_send_queue_max(self.send_queue_max);
+        buf.set_cache(self.cache);
+        buf.set_send_queue(self.send_queue);
+        buf.set_options(self.options);
+        buf.set_backlog_queue_length(self.backlog_queue_length);
+        buf.set_drops(self.drops);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nla {
+    /// The memory information of the socket. This attribute is
+    /// similar to `Nla::MemInfo` but provides less information. On
+    /// recent kernels, `Nla::MemInfo` is used instead.
+    // ref: https://patchwork.ozlabs.org/patch/154816/
+    LegacyMemInfo(LegacyMemInfo),
+    /// the TCP information
+    // TODO: parse tcp_info properly
+    TcpInfo(Vec<u8>),
+    /// the congestion control algorithm used
+    Congestion(String),
+    /// the TOS of the socket.
+    Tos(u8),
+    /// the traffic class of the socket.
+    Tc(u8),
+    /// The memory information of the socket
+    MemInfo(MemInfo),
+    /// Shutown state: one of [`SHUT_RD`], [`SHUT_WR`] or [`SHUT_RDWR`]
+    Shutdown(u8),
+    /// The protocol
+    Protocol(u8),
+    /// Whether the socket is IPv6 only
+    SkV6Only(bool),
+    /// The mark of the socket.
+    Mark(u32),
+    /// The class ID of the socket.
+    ClassId(u32),
+    /// other attribute
+    Other(DefaultNla),
+}
+
+impl crate::utils::nla::Nla for Nla {
+    fn value_len(&self) -> usize {
+        use self::Nla::*;
+        match *self {
+            LegacyMemInfo(_) => LEGACY_MEM_INFO_LEN,
+            TcpInfo(ref bytes) => bytes.len(),
+            // +1 because we need to append a null byte
+            Congestion(ref s) => s.as_bytes().len() + 1,
+            Tos(_) | Tc(_) | Shutdown(_) | Protocol(_) | SkV6Only(_) => 1,
+            MemInfo(_) => MEM_INFO_LEN,
+            Mark(_) | ClassId(_) => 4,
+            Other(ref attr) => attr.value_len(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        use self::Nla::*;
+        match *self {
+            LegacyMemInfo(ref value) => value.emit(buffer),
+            TcpInfo(ref bytes) => buffer[..bytes.len()].copy_from_slice(&bytes[..]),
+            Congestion(ref s) => {
+                buffer[..s.len()].copy_from_slice(s.as_bytes());
+                buffer[s.len()] = 0;
+            }
+            Tos(b) | Tc(b) | Shutdown(b) | Protocol(b) => buffer[0] = b,
+            SkV6Only(value) => buffer[0] = value.into(),
+            MemInfo(ref value) => value.emit(buffer),
+            Mark(value) | ClassId(value) => NativeEndian::write_u32(buffer, value),
+            Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        use self::Nla::*;
+        match *self {
+            LegacyMemInfo(_) => INET_DIAG_MEMINFO,
+            TcpInfo(_) => INET_DIAG_INFO,
+            Congestion(_) => INET_DIAG_CONG,
+            Tos(_) => INET_DIAG_TOS,
+            Tc(_) => INET_DIAG_TCLASS,
+            MemInfo(_) => INET_DIAG_SKMEMINFO,
+            Shutdown(_) => INET_DIAG_SHUTDOWN,
+            Protocol(_) => INET_DIAG_PROTOCOL,
+            SkV6Only(_) => INET_DIAG_SKV6ONLY,
+            Mark(_) => INET_DIAG_MARK,
+            ClassId(_) => INET_DIAG_CLASS_ID,
+            Other(ref attr) => attr.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            INET_DIAG_MEMINFO => {
+                let err = "invalid INET_DIAG_MEMINFO value";
+                let buf = LegacyMemInfoBuffer::new_checked(payload).context(err)?;
+                Self::LegacyMemInfo(LegacyMemInfo::parse(&buf).context(err)?)
+            }
+            INET_DIAG_INFO => Self::TcpInfo(payload.to_vec()),
+            INET_DIAG_CONG => {
+                Self::Congestion(parse_string(payload).context("invalid INET_DIAG_CONG value")?)
+            }
+            INET_DIAG_TOS => Self::Tos(parse_u8(payload).context("invalid INET_DIAG_TOS value")?),
+            INET_DIAG_TCLASS => {
+                Self::Tc(parse_u8(payload).context("invalid INET_DIAG_TCLASS value")?)
+            }
+            INET_DIAG_SKMEMINFO => {
+                let err = "invalid INET_DIAG_SKMEMINFO value";
+                let buf = MemInfoBuffer::new_checked(payload).context(err)?;
+                Self::MemInfo(MemInfo::parse(&buf).context(err)?)
+            }
+            INET_DIAG_SHUTDOWN => {
+                Self::Shutdown(parse_u8(payload).context("invalid INET_DIAG_SHUTDOWN value")?)
+            }
+            INET_DIAG_PROTOCOL => {
+                Self::Protocol(parse_u8(payload).context("invalid INET_DIAG_PROTOCOL value")?)
+            }
+            INET_DIAG_SKV6ONLY => {
+                Self::SkV6Only(parse_u8(payload).context("invalid INET_DIAG_SKV6ONLY value")? != 0)
+            }
+            INET_DIAG_MARK => {
+                Self::Mark(parse_u32(payload).context("invalid INET_DIAG_MARK value")?)
+            }
+            INET_DIAG_CLASS_ID => {
+                Self::ClassId(parse_u32(payload).context("invalid INET_DIAG_CLASS_ID value")?)
+            }
+            kind => {
+                Self::Other(DefaultNla::parse(buf).context(format!("unknown NLA type {}", kind))?)
+            }
+        })
+    }
+}
+
+// buffer!(TcpInfoBuffer(TCP_INFO_LEN) {
+//     // State of the TCP connection. This should be set to one of the
+//     // `TCP_*` constants: `TCP_ESTABLISHED`, `TCP_SYN_SENT`, etc. This
+//     // attribute is known as `tcpi_state` in the kernel.
+//     state: (u8, 0),
+//     // State of congestion avoidance. Sender's congestion state
+//     // indicating normal or abnormal situations in the last round of
+//     // packets sent. The state is driven by the ACK information and
+//     // timer events. This should be set to one of the `TCP_CA_*`
+//     // constants. This attribute is known as `tcpi_ca_state` in the
+//     // kernel.
+//     congestion_avoidance_state: (u8, 1),
+//     // Number of retranmissions on timeout invoked. This attribute is
+//     // known as `tcpi_retransmits` in the kernel.
+//     retransmits: (u8, 2),
+//     // Number of window or keep alive probes sent. This attribute is
+//     // known as `tcpi_probes`.
+//     probes: (u8, 3),
+//     // Number of times the retransmission backoff timer invoked
+//     backoff: (u8, 4),
+
+//     //
+//     options: (u8, 5),
+//     wscale: (u8, 6),
+//     delivery_rate_app_limited: (u8, 7),
+//     rto: (u32, 8..12),
+//     ato: (u32, 12..16),
+//     snd_mss: (u32, 16..20),
+//     rcv_mss: (u32, 20..24),
+//     unacked: (u32, 24..28),
+//     sacked: (u32, 28..32),
+//     lost: (u32, 32..36),
+//     retrans: (u32, 36..40),
+//     fackets: (u32, 40..44),
+//     last_data_sent: (u32, 44..48),
+//     last_ack_sent: (u32, 48..52),
+//     last_data_recv: (u32, 52..56),
+//     last_ack_recv: (u32, 56..60),
+//     pmtu: (u32, 60..64),
+//     rcv_ssthresh: (u32, 64..68),
+//     rtt: (u32, 68..72),
+//     rttvar: (u32, 72..76),
+//     snd_ssthresh: (u32, 76..80),
+//     snd_cwnd: (u32, 80..84),
+//     advmss: (u32, 84..88),
+//     reordering: (u32, 88..92),
+//     rcv_rtt: (u32, 92..96),
+//     rcv_space: (u32, 96..100),
+//     total_retrans: (u32, 100..104),
+//     pacing_rate: (u64, 104..112),
+//     max_pacing_rate: (u64, 112..120),
+//     bytes_acked: (u64, 120..128),
+//     bytes_received: (u64, 128..136),
+//     segs_out: (u32, 136..140),
+//     segs_in: (u32, 140..144),
+//     notsent_bytes: (u32, 144..148),
+//     min_rtt: (u32, 148..152),
+//     data_segs_in: (u32, 152..156),
+//     data_segs_out: (u32, 156..160),
+//     delivery_rate: (u64, 160..168),
+//     busy_time: (u64, 168..176),
+//     rwnd_limited: (u64, 176..184),
+//     sndbuf_limited: (u64, 184..192),
+//     delivered: (u32, 192..196),
+//     delivered_ce: (u32, 196..200),
+//     bytes_sent: (u64, 200..208),
+//     bytes_retrans: (u64, 208..216),
+//     dsack_dups: (u32,   216..220),
+//     reord_seen: (u32,   220..224),
+//     // These are pretty recent addition, we should hide them behing
+//     // `#[cfg]` flag
+//     rcv_ooopack: (u32, 224..228),
+//     snd_wnd: (u32, 228..232),
+// });
+
+// // https://unix.stackexchange.com/questions/542712/detailed-output-of-ss-command
+
+// #[derive(Debug, Clone, PartialEq, Eq)]
+// pub struct TcpInfo {
+//     /// State of the TCP connection: one of `TCP_ESTABLISHED`,
+//     /// `TCP_SYN_SENT`, `TP_SYN_RECV`, `TCP_FIN_WAIT1`,
+//     /// `TCP_FIN_WAIT2` `TCP_TIME_WAIT`, `TCP_CLOSE`,
+//     /// `TCP_CLOSE_WAIT`, `TCP_LAST_ACK` `TCP_LISTEN`, `TCP_CLOSING`.
+//     pub state: u8,
+//     /// Congestion algorithm state: one of `TCP_CA_OPEN`,
+//     /// `TCP_CA_DISORDER`, `TCP_CA_CWR`, `TCP_CA_RECOVERY`,
+//     /// `TCP_CA_LOSS`
+//     pub ca_state: u8,
+//     ///
+//     pub retransmits: u8,
+//     pub probes: u8,
+//     pub backoff: u8,
+//     pub options: u8,
+//     pub wscale: u8,
+//     /// A boolean indicating if the goodput was measured when the
+//     /// socket's throughput was limited by the sending application.
+//     pub delivery_rate_app_limited: u8,
+
+//     /// Value of the RTO (Retransmission TimeOut) timer. This value is
+//     /// calculated using the RTT.
+//     pub rto: u32,
+//     /// Value of the ATO (ACK TimeOut) timer.
+//     pub ato: u32,
+//     /// MSS (Maximum Segment Size). Not shure how it differs from
+//     /// `advmss`.
+//     pub snd_mss: u32,
+//     /// MSS (Maximum Segment Size) advertised by peer
+//     pub rcv_mss: u32,
+
+//     /// Number of segments that have not been ACKnowledged yet, ie the
+//     /// number of in-flight segments.
+//     pub unacked: u32,
+//     /// Number of segments that have been SACKed
+//     pub sacked: u32,
+//     /// Number of segments that have been lost
+//     pub lost: u32,
+//     /// Number of segments that have been retransmitted
+//     pub retrans: u32,
+//     /// Number of segments that have been FACKed
+//     pub fackets: u32,
+
+//     pub last_data_sent: u32,
+//     pub last_ack_sent: u32,
+//     pub last_data_recv: u32,
+//     pub last_ack_recv: u32,
+
+//     pub pmtu: u32,
+//     pub rcv_ssthresh: u32,
+//     /// RTT (Round Trip Time). There RTT is the time between the
+//     /// moment a segment is sent out and the moment it is
+//     /// acknowledged. There are different kinds of RTT values, and I
+//     /// don't know which one this value corresponds to: mRTT (measured
+//     /// RTT), sRTT (smoothed RTT), RTTd (deviated RTT), etc.
+//     pub rtt: u32,
+//     /// RTT variance (or variation?)
+//     pub rttvar: u32,
+//     /// Slow-Start Threshold
+//     pub snd_ssthresh: u32,
+//     /// Size of the congestion window
+//     pub snd_cwnd: u32,
+//     /// MSS advertised by this peer
+//     pub advmss: u32,
+
+//     pub reordering: u32,
+
+//     pub rcv_rtt: u32,
+//     pub rcv_space: u32,
+
+//     pub total_retrans: u32,
+
+//     pub pacing_rate: u64,
+//     pub max_pacing_rate: u64,
+//     pub bytes_acked: u64,    // RFC4898 tcpEStatsAppHCThruOctetsAcked
+//     pub bytes_received: u64, // RFC4898 tcpEStatsAppHCThruOctetsReceived
+//     pub segs_out: u32,       // RFC4898 tcpEStatsPerfSegsOut
+//     pub segs_in: u32,        // RFC4898 tcpEStatsPerfSegsIn
+
+//     pub notsent_bytes: u32,
+//     pub min_rtt: u32,
+//     pub data_segs_in: u32,  // RFC4898 tcpEStatsDataSegsIn
+//     pub data_segs_out: u32, // RFC4898 tcpEStatsDataSegsOut
+
+//     /// The most recent goodput, as measured by tcp_rate_gen(). If the
+//     /// socket is limited by the sending application (e.g., no data to
+//     /// send), it reports the highest measurement instead of the most
+//     /// recent. The unit is bytes per second (like other rate fields
+//     /// in tcp_info).
+//     pub delivery_rate: u64,
+
+//     pub busy_time: u64,      // Time (usec) busy sending data
+//     pub rwnd_limited: u64,   // Time (usec) limited by receive window
+//     pub sndbuf_limited: u64, // Time (usec) limited by send buffer
+
+//     pub delivered: u32,
+//     pub delivered_ce: u32,
+
+//     pub bytes_sent: u64,    // RFC4898 tcpEStatsPerfHCDataOctetsOut
+//     pub bytes_retrans: u64, // RFC4898 tcpEStatsPerfOctetsRetrans
+//     pub dsack_dups: u32,    // RFC4898 tcpEStatsStackDSACKDups
+//     /// reordering events seen
+//     pub reord_seen: u32,
+
+//     /// Out-of-order packets received
+//     pub rcv_ooopack: u32,
+//     /// peer's advertised receive window after scaling (bytes)
+//     pub snd_wnd: u32,
+// }

--- a/netlink-packet-sock-diag/src/inet/nlas.rs
+++ b/netlink-packet-sock-diag/src/inet/nlas.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 pub use crate::utils::nla::{DefaultNla, NlaBuffer, NlasIterator};
 

--- a/netlink-packet-sock-diag/src/inet/request.rs
+++ b/netlink-packet-sock-diag/src/inet/request.rs
@@ -30,7 +30,7 @@ pub struct InetRequest {
     /// report. Each requested kind of information is reported back as
     /// a netlink attribute.
     pub extensions: ExtensionFlags,
-    /// Bitmask that defines a fiter of TCP socket states
+    /// Bitmask that defines a filter of TCP socket states
     pub states: StateFlags,
     /// A socket ID object that is used in dump requests, in queries
     /// about individual sockets, and is reported back in each

--- a/netlink-packet-sock-diag/src/inet/request.rs
+++ b/netlink-packet-sock-diag/src/inet/request.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::{
     constants::*,

--- a/netlink-packet-sock-diag/src/inet/request.rs
+++ b/netlink-packet-sock-diag/src/inet/request.rs
@@ -1,0 +1,139 @@
+use failure::ResultExt;
+
+use crate::{
+    constants::*,
+    inet::{SocketId, SocketIdBuffer},
+    traits::{Emitable, Parseable, ParseableParametrized},
+    DecodeError,
+};
+
+pub const REQUEST_LEN: usize = 56;
+
+buffer!(InetRequestBuffer(REQUEST_LEN) {
+    family: (u8, 0),
+    protocol: (u8, 1),
+    extensions: (u8, 2),
+    pad: (u8, 3),
+    states: (u32, 4..8),
+    socket_id: (slice, 8..56),
+});
+
+/// A request for Ipv4 and Ipv6 sockets
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InetRequest {
+    /// The address family, either `AF_INET` or `AF_INET6`
+    pub family: u8,
+    /// The IP protocol. This field should be set to one of the
+    /// `IPPROTO_*` constants
+    pub protocol: u8,
+    /// Set of flags defining what kind of extended information to
+    /// report. Each requested kind of information is reported back as
+    /// a netlink attribute.
+    pub extensions: ExtensionFlags,
+    /// Bitmask that defines a fiter of TCP socket states
+    pub states: StateFlags,
+    /// A socket ID object that is used in dump requests, in queries
+    /// about individual sockets, and is reported back in each
+    /// response.
+    ///
+    /// Unlike UNIX domain sockets, IPv4 and IPv6 sockets are
+    /// identified using addresses and ports.
+    pub socket_id: SocketId,
+}
+
+bitflags! {
+    /// Bitmask that defines a filter of TCP socket states
+    pub struct StateFlags: u32 {
+        /// (server and client) represents an open connection,
+        /// data received can be delivered to the user. The normal
+        /// state for the data transfer phase of the connection.
+        const ESTABLISHED = 1 << TCP_ESTABLISHED ;
+        /// (client) represents waiting for a matching connection
+        /// request after having sent a connection request.
+        const SYN_SENT = 1 <<TCP_SYN_SENT ;
+        /// (server) represents waiting for a confirming connection
+        /// request acknowledgment after having both received and sent
+        /// a connection request.
+        const SYN_RECV = 1 << TCP_SYN_RECV ;
+        /// (both server and client) represents waiting for a
+        /// connection termination request from the remote TCP, or an
+        /// acknowledgment of the connection termination request
+        /// previously sent.
+        const FIN_WAIT1 = 1 << TCP_FIN_WAIT1 ;
+        /// (both server and client) represents waiting for a
+        /// connection termination request from the remote TCP.
+        const FIN_WAIT2 = 1 << TCP_FIN_WAIT2 ;
+        /// (either server or client) represents waiting for enough
+        /// time to pass to be sure the remote TCP received the
+        /// acknowledgment of its connection termination request.
+        const TIME_WAIT = 1 << TCP_TIME_WAIT ;
+        /// (both server and client) represents no connection state at
+        /// all.
+        const CLOSE = 1 << TCP_CLOSE ;
+        /// (both server and client) represents waiting for a
+        /// connection termination request from the local user.
+        const CLOSE_WAIT = 1 << TCP_CLOSE_WAIT ;
+        /// (both server and client) represents waiting for an
+        /// acknowledgment of the connection termination request
+        /// previously sent to the remote TCP (which includes an
+        /// acknowledgment of its connection termination request).
+        const LAST_ACK = 1 << TCP_LAST_ACK ;
+        /// (server) represents waiting for a connection request from
+        /// any remote TCP and port.
+        const LISTEN = 1 << TCP_LISTEN ;
+        /// (both server and client) represents waiting for a
+        /// connection termination request acknowledgment from the
+        /// remote TCP.
+        const CLOSING = 1 << TCP_CLOSING ;
+    }
+}
+
+bitflags! {
+    /// This is a set of flags defining what kind of extended
+    /// information to report.
+    pub struct ExtensionFlags: u8 {
+        const MEMINFO = 1 << (INET_DIAG_MEMINFO as u16 - 1);
+        const INFO = 1 << (INET_DIAG_INFO as u16 - 1);
+        const VEGASINFO = 1 << (INET_DIAG_VEGASINFO as u16 - 1);
+        const CONF = 1 << (INET_DIAG_CONG as u16 - 1);
+        const TOS = 1 << (INET_DIAG_TOS as u16 - 1);
+        const TCLASS = 1 << (INET_DIAG_TCLASS as u16 - 1);
+        const SKMEMINFO = 1 << (INET_DIAG_SKMEMINFO as u16 - 1);
+        const SHUTDOWN = 1 << (INET_DIAG_SHUTDOWN as u16 - 1);
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetRequestBuffer<&'a T>> for InetRequest {
+    fn parse(buf: &InetRequestBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let err = "invalid socket_id value";
+        let socket_id = SocketId::parse_with_param(
+            &SocketIdBuffer::new_checked(&buf.socket_id()).context(err)?,
+            buf.family(),
+        )
+        .context(err)?;
+
+        Ok(Self {
+            family: buf.family(),
+            protocol: buf.protocol(),
+            extensions: ExtensionFlags::from_bits_truncate(buf.extensions()),
+            states: StateFlags::from_bits_truncate(buf.states()),
+            socket_id,
+        })
+    }
+}
+
+impl Emitable for InetRequest {
+    fn buffer_len(&self) -> usize {
+        REQUEST_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = InetRequestBuffer::new(buf);
+        buf.set_family(self.family);
+        buf.set_protocol(self.protocol);
+        buf.set_extensions(self.extensions.bits());
+        buf.set_pad(0);
+        buf.set_states(self.states.bits());
+        self.socket_id.emit(buf.socket_id_mut())
+    }
+}

--- a/netlink-packet-sock-diag/src/inet/response.rs
+++ b/netlink-packet-sock-diag/src/inet/response.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 use smallvec::SmallVec;
 use std::time::Duration;
 
@@ -72,7 +72,7 @@ pub struct InetResponseHeader {
     pub inode: u32,
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for InetResponseHeader {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for InetResponseHeader {
     fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let err = "invalid socket_id value";
         let socket_id = SocketId::parse_with_param(
@@ -168,7 +168,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> InetResponseBuffer<&'a T> {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
     fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = smallvec![];
         for nla_buf in buf.nlas() {
@@ -178,7 +178,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for SmallVec<
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for InetResponse {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for InetResponse {
     fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let header =
             InetResponseHeader::parse(&buf).context("failed to parse inet response header")?;

--- a/netlink-packet-sock-diag/src/inet/response.rs
+++ b/netlink-packet-sock-diag/src/inet/response.rs
@@ -1,0 +1,202 @@
+use failure::ResultExt;
+use smallvec::SmallVec;
+use std::time::Duration;
+
+use crate::{
+    inet::{
+        nlas::{Nla, NlaBuffer, NlasIterator},
+        SocketId, SocketIdBuffer,
+    },
+    traits::{Emitable, Parseable, ParseableParametrized},
+    DecodeError,
+};
+
+/// The type of timer that is currently active for a TCP socket.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Timer {
+    /// A retransmit timer
+    Retransmit(Duration, u8),
+    /// A keep-alive timer
+    KeepAlive(Duration),
+    /// A `TIME_WAIT` timer
+    TimeWait,
+    /// A zero window probe timer
+    Probe(Duration),
+}
+
+pub const RESPONSE_LEN: usize = 72;
+
+buffer!(InetResponseBuffer(RESPONSE_LEN) {
+    family: (u8, 0),
+    state: (u8, 1),
+    timer: (u8, 2),
+    retransmits: (u8, 3),
+    socket_id: (slice, 4..52),
+    expires: (u32, 52..56),
+    recv_queue: (u32, 56..60),
+    send_queue: (u32, 60..64),
+    uid: (u32, 64..68),
+    inode: (u32, 68..72),
+    payload: (slice, RESPONSE_LEN..),
+});
+
+/// The response to a query for IPv4 or IPv6 sockets
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InetResponseHeader {
+    /// This should be set to either `AF_INET` or `AF_INET6` for IPv4
+    /// or IPv6 sockets respectively.
+    pub family: u8,
+
+    /// The socket state.
+    pub state: u8,
+
+    /// For TCP sockets, this field describes the type of timer
+    /// that is currently active for the socket.
+    pub timer: Option<Timer>,
+
+    /// The socket ID object.
+    pub socket_id: SocketId,
+
+    /// For listening sockets: the number of pending connections. For
+    /// other sockets: the amount of data in the incoming queue.
+    pub recv_queue: u32,
+
+    /// For listening sockets: the backlog length. For other sockets:
+    /// the amount of memory available for sending.
+    pub send_queue: u32,
+
+    /// Socket owner UID.
+    pub uid: u32,
+
+    /// Socket inode number.
+    pub inode: u32,
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for InetResponseHeader {
+    fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let err = "invalid socket_id value";
+        let socket_id = SocketId::parse_with_param(
+            &SocketIdBuffer::new_checked(&buf.socket_id()).context(err)?,
+            buf.family(),
+        )
+        .context(err)?;
+
+        let timer = match buf.timer() {
+            1 => {
+                let expires = Duration::from_millis(buf.expires() as u64);
+                let retransmits = buf.retransmits();
+                Some(Timer::Retransmit(expires, retransmits))
+            }
+            2 => {
+                let expires = Duration::from_millis(buf.expires() as u64);
+                Some(Timer::KeepAlive(expires))
+            }
+            3 => Some(Timer::TimeWait),
+            4 => {
+                let expires = Duration::from_millis(buf.expires() as u64);
+                Some(Timer::Probe(expires))
+            }
+            _ => None,
+        };
+
+        Ok(Self {
+            family: buf.family(),
+            state: buf.state(),
+            timer,
+            socket_id,
+            recv_queue: buf.recv_queue(),
+            send_queue: buf.send_queue(),
+            uid: buf.uid(),
+            inode: buf.inode(),
+        })
+    }
+}
+
+impl Emitable for InetResponseHeader {
+    fn buffer_len(&self) -> usize {
+        RESPONSE_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = InetResponseBuffer::new(buf);
+        buf.set_family(self.family);
+        buf.set_state(self.state);
+        match self.timer {
+            Some(Timer::Retransmit(expires, retransmits)) => {
+                buf.set_timer(1);
+                buf.set_expires((expires.as_millis() & 0xffff_ffff) as u32);
+                buf.set_retransmits(retransmits);
+            }
+            Some(Timer::KeepAlive(expires)) => {
+                buf.set_timer(2);
+                buf.set_expires((expires.as_millis() & 0xffff_ffff) as u32);
+                buf.set_retransmits(0);
+            }
+            Some(Timer::TimeWait) => {
+                buf.set_timer(3);
+                buf.set_expires(0);
+                buf.set_retransmits(0);
+            }
+            Some(Timer::Probe(expires)) => {
+                buf.set_timer(4);
+                buf.set_expires((expires.as_millis() & 0xffff_ffff) as u32);
+                buf.set_retransmits(0);
+            }
+            None => {
+                buf.set_timer(0);
+                buf.set_expires(0);
+                buf.set_retransmits(0);
+            }
+        }
+        buf.set_recv_queue(self.recv_queue);
+        buf.set_send_queue(self.send_queue);
+        buf.set_uid(self.uid);
+        buf.set_inode(self.inode);
+        self.socket_id.emit(buf.socket_id_mut())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InetResponse {
+    pub header: InetResponseHeader,
+    pub nlas: SmallVec<[Nla; 8]>,
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> InetResponseBuffer<&'a T> {
+    pub fn nlas(&self) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+        NlasIterator::new(self.payload())
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
+    fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let mut nlas = smallvec![];
+        for nla_buf in buf.nlas() {
+            nlas.push(Nla::parse(&nla_buf?)?);
+        }
+        Ok(nlas)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetResponseBuffer<&'a T>> for InetResponse {
+    fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let header =
+            InetResponseHeader::parse(&buf).context("failed to parse inet response header")?;
+        let nlas =
+            SmallVec::<[Nla; 8]>::parse(buf).context("failed to parse inet response NLAs")?;
+        Ok(InetResponse { header, nlas })
+    }
+}
+
+impl Emitable for InetResponse {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len() + self.nlas.as_slice().buffer_len()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        self.nlas
+            .as_slice()
+            .emit(&mut buffer[self.header.buffer_len()..]);
+    }
+}

--- a/netlink-packet-sock-diag/src/inet/socket_id.rs
+++ b/netlink-packet-sock-diag/src/inet/socket_id.rs
@@ -1,0 +1,131 @@
+use std::convert::{TryFrom, TryInto};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::{
+    constants::*,
+    traits::{Emitable, ParseableParametrized},
+    DecodeError,
+};
+
+pub const SOCKET_ID_LEN: usize = 48;
+
+buffer!(SocketIdBuffer(SOCKET_ID_LEN) {
+    source_port: (u16, 0..2),
+    destination_port: (u16, 2..4),
+    source_address: (slice, 4..20),
+    destination_address: (slice, 20..36),
+    interface_id: (u32, 36..40),
+    cookie: (slice, 40..48),
+});
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SocketId {
+    pub source_port: u16,
+    pub destination_port: u16,
+    pub source_address: IpAddr,
+    pub destination_address: IpAddr,
+    pub interface_id: u32,
+    /// An array of opaque identifiers that could be used along with
+    /// other fields of this structure to specify an individual
+    /// socket. It is ignored when querying for a list of sockets, as
+    /// well as when all its elements are set to `0xff`.
+    pub cookie: [u8; 8],
+}
+
+impl SocketId {
+    pub fn new_v4() -> Self {
+        Self {
+            source_port: 0,
+            destination_port: 0,
+            source_address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            destination_address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            interface_id: 0,
+            cookie: [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+    }
+    pub fn new_v6() -> Self {
+        Self {
+            source_port: 0,
+            destination_port: 0,
+            source_address: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+            destination_address: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+            interface_id: 0,
+            cookie: [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> ParseableParametrized<SocketIdBuffer<&'a T>, u8> for SocketId {
+    fn parse_with_param(buf: &SocketIdBuffer<&'a T>, af: u8) -> Result<Self, DecodeError> {
+        let (source_address, destination_address) = match af {
+            AF_INET => {
+                let s = &buf.source_address()[..4];
+                let source = IpAddr::V4(Ipv4Addr::new(s[0], s[1], s[2], s[3]));
+
+                let s = &buf.destination_address()[..4];
+                let destination = IpAddr::V4(Ipv4Addr::new(s[0], s[1], s[2], s[3]));
+
+                (source, destination)
+            }
+            AF_INET6 => {
+                let bytes: [u8; 16] = buf.source_address().try_into().unwrap();
+                let source = IpAddr::V6(Ipv6Addr::from(bytes));
+
+                let bytes: [u8; 16] = buf.destination_address().try_into().unwrap();
+                let destination = IpAddr::V6(Ipv6Addr::from(bytes));
+                (source, destination)
+            }
+            _ => {
+                return Err(DecodeError::from(format!(
+                    "unsupported address family {}: expected AF_INET ({}) or AF_INET6 ({})",
+                    af, AF_INET, AF_INET6
+                )));
+            }
+        };
+
+        Ok(Self {
+            source_port: buf.source_port(),
+            destination_port: buf.destination_port(),
+            source_address,
+            destination_address,
+            interface_id: buf.interface_id(),
+            // Unwrapping is safe because SocketIdBuffer::cookie()
+            // returns a slice of exactly 8 bytes.
+            cookie: TryFrom::try_from(buf.cookie()).unwrap(),
+        })
+    }
+}
+
+impl Emitable for SocketId {
+    fn buffer_len(&self) -> usize {
+        SOCKET_ID_LEN
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let mut buffer = SocketIdBuffer::new(buffer);
+        buffer.set_source_port(self.source_port);
+        buffer.set_destination_port(self.destination_port);
+        let mut address_buf: [u8; 16] = [0; 16];
+        match self.source_address {
+            IpAddr::V4(ip) => (&mut address_buf[0..4]).copy_from_slice(&ip.octets()[..]),
+            IpAddr::V6(ip) => address_buf.copy_from_slice(&ip.octets()[..]),
+        }
+
+        buffer
+            .source_address_mut()
+            .copy_from_slice(&address_buf[..]);
+
+        address_buf = [0; 16];
+        match self.destination_address {
+            IpAddr::V4(ip) => (&mut address_buf[0..4]).copy_from_slice(&ip.octets()[..]),
+            IpAddr::V6(ip) => address_buf.copy_from_slice(&ip.octets()[..]),
+        }
+
+        buffer
+            .destination_address_mut()
+            .copy_from_slice(&address_buf[..]);
+
+        buffer.set_interface_id(self.interface_id);
+        buffer.cookie_mut().copy_from_slice(&self.cookie[..]);
+    }
+}

--- a/netlink-packet-sock-diag/src/inet/socket_id.rs
+++ b/netlink-packet-sock-diag/src/inet/socket_id.rs
@@ -40,7 +40,7 @@ impl SocketId {
             source_address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             destination_address: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             interface_id: 0,
-            cookie: [0, 0, 0, 0, 0, 0, 0, 0],
+            cookie: [0; 8],
         }
     }
     pub fn new_v6() -> Self {
@@ -50,7 +50,7 @@ impl SocketId {
             source_address: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
             destination_address: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
             interface_id: 0,
-            cookie: [0, 0, 0, 0, 0, 0, 0, 0],
+            cookie: [0; 8],
         }
     }
 }

--- a/netlink-packet-sock-diag/src/inet/tests.rs
+++ b/netlink-packet-sock-diag/src/inet/tests.rs
@@ -69,8 +69,8 @@ lazy_static! {
             uid: 1000,
             inode: 0x0029_daa8,
             socket_id: SocketId {
-                source_port: 5355,
-                destination_port: 47873,
+                source_port: 60180,
+                destination_port: 443,
                 source_address: IpAddr::V4(Ipv4Addr::new(192, 168, 178, 60)),
                 destination_address: IpAddr::V4(Ipv4Addr::new(172, 217, 23, 131)),
                 interface_id: 0,

--- a/netlink-packet-sock-diag/src/inet/tests.rs
+++ b/netlink-packet-sock-diag/src/inet/tests.rs
@@ -1,0 +1,129 @@
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
+
+use crate::{
+    constants::*,
+    inet::{
+        nlas::Nla, ExtensionFlags, InetRequest, InetRequestBuffer, InetResponse,
+        InetResponseBuffer, InetResponseHeader, SocketId, StateFlags, Timer,
+    },
+    traits::{Emitable, Parseable},
+};
+
+lazy_static! {
+    static ref REQ_UDP: InetRequest = InetRequest {
+        family: AF_INET as u8,
+        protocol: IPPROTO_UDP,
+        extensions: ExtensionFlags::empty(),
+        states: StateFlags::ESTABLISHED,
+        socket_id: SocketId::new_v4(),
+    };
+}
+
+#[rustfmt::skip]
+static REQ_UDP_BUF: [u8; 56] = [
+    0x02, // family (AF_INET)
+    0x11, // protocol (IPPROTO_UDP)
+    0x00, // extensions
+    0x00, // padding
+    0x02, 0x00, 0x00, 0x00, // states
+
+    // socket id
+    0x00, 0x00, // source port
+    0x00, 0x00, // destination port
+    // source address
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // destination address
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, // interface id
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // cookie
+];
+
+#[test]
+fn parse_udp_req() {
+    let parsed =
+        InetRequest::parse(&InetRequestBuffer::new_checked(&&REQ_UDP_BUF[..]).unwrap()).unwrap();
+    assert_eq!(parsed, *REQ_UDP);
+}
+
+#[test]
+fn emit_udp_req() {
+    assert_eq!(REQ_UDP.buffer_len(), 56);
+    let mut buf = vec![0; REQ_UDP.buffer_len()];
+    REQ_UDP.emit(&mut buf);
+    assert_eq!(&buf[..], &REQ_UDP_BUF[..]);
+}
+
+lazy_static! {
+    static ref RESP_TCP: InetResponse = InetResponse {
+        header: InetResponseHeader {
+            family: AF_INET as u8,
+            state: TCP_ESTABLISHED,
+            timer: Some(Timer::KeepAlive(Duration::from_millis(0x0000_6080))),
+            recv_queue: 0,
+            send_queue: 0,
+            uid: 1000,
+            inode: 0x0029_daa8,
+            socket_id: SocketId {
+                source_port: 5355,
+                destination_port: 47873,
+                source_address: IpAddr::V4(Ipv4Addr::new(192, 168, 178, 60)),
+                destination_address: IpAddr::V4(Ipv4Addr::new(172, 217, 23, 131)),
+                interface_id: 0,
+                cookie: [0x52, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            },
+        },
+        nlas: smallvec![Nla::Shutdown(0)],
+    };
+}
+
+#[rustfmt::skip]
+static RESP_TCP_BUF: [u8; 80] = [
+    0x02, // family (AF_INET)
+    0x01, // state (ESTABLISHED)
+    0x02, // timer
+    0x00, // retransmits
+
+    // socket id
+    0xeb, 0x14, // source port (60180)
+    0x01, 0xbb, // destination port (443)
+    // source ip (192.168.178.60)
+    0xc0, 0xa8, 0xb2, 0x3c, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // destination ip (172.217.23.131)
+    0xac, 0xd9, 0x17, 0x83, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, // interface id
+    0x52, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // cookie
+
+    0x80, 0x60, 0x00, 0x00, // expires
+    0x00, 0x00, 0x00, 0x00, // receive queue
+    0x00, 0x00, 0x00, 0x00, // send queue
+    0xe8, 0x03, 0x00, 0x00, // uid
+    0xa8, 0xda, 0x29, 0x00, // inode
+
+    // nlas
+    0x05, 0x00, // length = 5
+    0x08, 0x00, // type = 8
+    0x00, // value (0)
+    0x00, 0x00, 0x00
+];
+
+#[test]
+fn parse_tcp_resp() {
+    let parsed =
+        InetResponse::parse(&InetResponseBuffer::new_checked(&&RESP_TCP_BUF[..]).unwrap()).unwrap();
+    assert_eq!(parsed, *RESP_TCP);
+}
+
+#[test]
+fn emit_tcp_resp() {
+    assert_eq!(RESP_TCP.buffer_len(), 80);
+    let mut buf = vec![0; RESP_TCP.buffer_len()];
+    RESP_TCP.emit(&mut buf);
+    assert_eq!(&buf[..], &RESP_TCP_BUF[..]);
+}

--- a/netlink-packet-sock-diag/src/lib.rs
+++ b/netlink-packet-sock-diag/src/lib.rs
@@ -8,7 +8,8 @@ pub use self::utils::{traits, DecodeError};
 pub use netlink_packet_core::{
     ErrorMessage, NetlinkBuffer, NetlinkHeader, NetlinkMessage, NetlinkPayload,
 };
-// pub(crate) use netlink_packet_core::{NetlinkDeserializable, NetlinkSerializable};
+pub(crate) use netlink_packet_core::{NetlinkDeserializable, NetlinkSerializable};
+
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
@@ -16,7 +17,11 @@ extern crate lazy_static;
 #[macro_use]
 extern crate smallvec;
 
+pub mod buffer;
 pub mod constants;
 pub mod inet;
+pub mod message;
 pub mod unix;
+pub use self::buffer::*;
 pub use self::constants::*;
+pub use self::message::*;

--- a/netlink-packet-sock-diag/src/lib.rs
+++ b/netlink-packet-sock-diag/src/lib.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate bitflags;
+
+#[macro_use]
+pub(crate) extern crate netlink_packet_utils as utils;
+pub(crate) use self::utils::parsers;
+pub use self::utils::{traits, DecodeError};
+pub use netlink_packet_core::{
+    ErrorMessage, NetlinkBuffer, NetlinkHeader, NetlinkMessage, NetlinkPayload,
+};
+// pub(crate) use netlink_packet_core::{NetlinkDeserializable, NetlinkSerializable};
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
+extern crate smallvec;
+
+pub mod constants;
+pub mod inet;
+pub mod unix;
+pub use self::constants::*;

--- a/netlink-packet-sock-diag/src/message.rs
+++ b/netlink-packet-sock-diag/src/message.rs
@@ -1,0 +1,44 @@
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Message {
+    InetRequest(inet::Request),
+    InetResponse(inet::Response),
+    UnixRequest(unix::Request),
+    UnixResponse(unix::Response),
+}
+
+impl Emitable for Message {
+    fn buffer_len(&self) -> usize {
+        use Message::*;
+
+        match self {
+            InetRequest(ref msg) => msg.buffer_len(),
+            InetResponse(ref msg) => msg.buffer_len(),
+            UnixRequest(ref msg) => msg.buffer_len(),
+            UnixResponse(ref msg) => msg.buffer_len(),
+        }
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        use Message::*;
+
+        match self {
+            InetRequest(ref msg) => msg.emit(),
+            InetResponse(ref msg) => msg.emit(),
+            UnixRequest(ref msg) => msg.emit(),
+            UnixResponse(ref msg) => msg.emit(),
+        }
+    }
+}
+
+buffer!(MessageBuffer(1) {
+    family: (u8, 0),
+});
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<MessageBuffer<&'a T>> for Message {
+    fn parse_with_param(
+        message_type: u16,
+        buf: &MessageBuffer<&'a T>,
+    ) -> Result<Self, DecodeError> {
+        unimplemented!()
+    }
+}

--- a/netlink-packet-sock-diag/src/message.rs
+++ b/netlink-packet-sock-diag/src/message.rs
@@ -1,14 +1,58 @@
+use crate::{
+    inet,
+    traits::{Emitable, ParseableParametrized},
+    unix, DecodeError, NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
+    SockDiagBuffer, SOCK_DIAG_BY_FAMILY,
+};
+
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum Message {
-    InetRequest(inet::Request),
-    InetResponse(inet::Response),
-    UnixRequest(unix::Request),
-    UnixResponse(unix::Response),
+pub enum SockDiagMessage {
+    InetRequest(inet::InetRequest),
+    InetResponse(inet::InetResponse),
+    UnixRequest(unix::UnixRequest),
+    UnixResponse(unix::UnixResponse),
 }
 
-impl Emitable for Message {
+impl SockDiagMessage {
+    pub fn is_inet_request(&self) -> bool {
+        if let SockDiagMessage::InetRequest(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_inet_response(&self) -> bool {
+        if let SockDiagMessage::InetResponse(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+    pub fn is_unix_request(&self) -> bool {
+        if let SockDiagMessage::UnixRequest(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_unix_response(&self) -> bool {
+        if let SockDiagMessage::UnixResponse(_) = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn message_type(&self) -> u16 {
+        SOCK_DIAG_BY_FAMILY
+    }
+}
+
+impl Emitable for SockDiagMessage {
     fn buffer_len(&self) -> usize {
-        use Message::*;
+        use SockDiagMessage::*;
 
         match self {
             InetRequest(ref msg) => msg.buffer_len(),
@@ -18,27 +62,45 @@ impl Emitable for Message {
         }
     }
 
-    fn emit(&self, buf: &mut [u8]) {
-        use Message::*;
+    fn emit(&self, buffer: &mut [u8]) {
+        use SockDiagMessage::*;
 
         match self {
-            InetRequest(ref msg) => msg.emit(),
-            InetResponse(ref msg) => msg.emit(),
-            UnixRequest(ref msg) => msg.emit(),
-            UnixResponse(ref msg) => msg.emit(),
+            InetRequest(ref msg) => msg.emit(buffer),
+            InetResponse(ref msg) => msg.emit(buffer),
+            UnixRequest(ref msg) => msg.emit(buffer),
+            UnixResponse(ref msg) => msg.emit(buffer),
         }
     }
 }
 
-buffer!(MessageBuffer(1) {
-    family: (u8, 0),
-});
+impl NetlinkSerializable<SockDiagMessage> for SockDiagMessage {
+    fn message_type(&self) -> u16 {
+        self.message_type()
+    }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<MessageBuffer<&'a T>> for Message {
-    fn parse_with_param(
-        message_type: u16,
-        buf: &MessageBuffer<&'a T>,
-    ) -> Result<Self, DecodeError> {
-        unimplemented!()
+    fn buffer_len(&self) -> usize {
+        <Self as Emitable>::buffer_len(self)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.emit(buffer)
+    }
+}
+
+impl NetlinkDeserializable<SockDiagMessage> for SockDiagMessage {
+    type Error = DecodeError;
+    fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
+        let buffer = SockDiagBuffer::new_checked(&payload)?;
+        Ok(SockDiagMessage::parse_with_param(
+            &buffer,
+            header.message_type,
+        )?)
+    }
+}
+
+impl From<SockDiagMessage> for NetlinkPayload<SockDiagMessage> {
+    fn from(message: SockDiagMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
     }
 }

--- a/netlink-packet-sock-diag/src/unix/mod.rs
+++ b/netlink-packet-sock-diag/src/unix/mod.rs
@@ -1,0 +1,10 @@
+mod request;
+pub use self::request::*;
+
+mod response;
+pub use self::response::*;
+
+pub mod nlas;
+
+#[cfg(test)]
+mod tests;

--- a/netlink-packet-sock-diag/src/unix/nlas.rs
+++ b/netlink-packet-sock-diag/src/unix/nlas.rs
@@ -1,0 +1,344 @@
+use byteorder::{ByteOrder, NativeEndian};
+use failure::ResultExt;
+
+pub use crate::utils::nla::{DefaultNla, NlaBuffer, NlasIterator};
+
+use crate::{
+    constants::*,
+    parsers::{parse_string, parse_u32, parse_u8},
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Nla {
+    /// Path to which the socket was bound. This attribute is known as
+    /// `UNIX_DIAG_NAME` in the kernel.
+    Name(String),
+    /// VFS information for this socket. This attribute is known as
+    /// `UNIX_DIAG_VFS` in the kernel.
+    Vfs(Vfs),
+    /// Inode number of the socket's peer. This attribute is reported
+    /// for connected socket only. This attribute is known as
+    /// `UNIX_DIAG_PEER` in the kernel.
+    Peer(u32),
+    /// The payload associated with this attribute is an array of
+    /// inode numbers of sockets that have passed the `connect(2)`
+    /// call, but haven't been processed with `accept(2)` yet. This
+    /// attribute is reported for listening sockets only. This
+    /// attribute is known as `UNIX_DIAG_ICONS` in the kernel.
+    PendingConnections(Vec<u32>),
+    /// This attribute corresponds to the `UNIX_DIAG_RQLEN`. It
+    /// reports the length of the socket receive queue, and the queue
+    /// size limit. Note that for **listening** sockets the receive
+    /// queue is used to store actual data sent by other sockets. It
+    /// is used to store pending connections. So the meaning of this
+    /// attribute differs for listening sockets.
+    ///
+    /// For **listening** sockets:
+    ///
+    /// - the first the number is the number of pending
+    ///   connections. It should be equal to `Nla::PendingConnections`
+    ///   value's length.
+    /// - the second number is the backlog queue maximum length, which
+    ///   equals to the value passed as the second argument to
+    ///   `listen(2)`
+    ///
+    /// For other sockets:
+    ///
+    /// - the first number is the amount of data in receive queue
+    ///   (**note**: I am not sure if it is the actual amount of data
+    ///   or the amount of memory allocated. The two might differ
+    ///   because of memory allocation strategies: more memory than
+    ///   strictly necessary may be allocated for a given `sk_buff`)
+    /// - the second number is the memory used by outgoing data. Note
+    ///   that strictly UNIX sockets don't have a send queue, since
+    ///   the data they send is directly written into the destination
+    ///   socket receive queue. But the memory allocated for this data
+    ///   is still counted from the sender point of view.
+    ReceiveQueueLength(u32, u32),
+    /// Socket memory information. See [`MemInfo`] for more details.
+    MemInfo(MemInfo),
+    /// Shutown state: one of [`SHUT_RD`], [`SHUT_WR`] or [`SHUT_RDWR`]
+    Shutdown(u8),
+    /// Unknown attribute
+    Other(DefaultNla),
+}
+
+pub const VFS_LEN: usize = 8;
+
+buffer!(VfsBuffer(8) {
+    inode: (u32, 0..4),
+    device: (u32, 4..8),
+});
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct Vfs {
+    /// Inode number
+    inode: u32,
+    /// Device number
+    device: u32,
+}
+
+impl<T: AsRef<[u8]>> Parseable<VfsBuffer<T>> for Vfs {
+    fn parse(buf: &VfsBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            inode: buf.inode(),
+            device: buf.device(),
+        })
+    }
+}
+
+impl Emitable for Vfs {
+    fn buffer_len(&self) -> usize {
+        VFS_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = VfsBuffer::new(buf);
+        buf.set_inode(self.inode);
+        buf.set_device(self.device);
+    }
+}
+
+pub const MEM_INFO_LEN: usize = 36;
+
+buffer!(MemInfoBuffer(MEM_INFO_LEN) {
+    unused_sk_rmem_alloc: (u32, 0..4),
+    so_rcvbuf: (u32, 4..8),
+    unused_sk_wmem_queued: (u32, 8..12),
+    max_datagram_size: (u32, 12..16),
+    unused_sk_fwd_alloc: (u32, 16..20),
+    alloc: (u32, 20..24),
+    unused_sk_optmem: (u32, 24..28),
+    unused_backlog: (u32, 28..32),
+    unused_drops: (u32, 32..36),
+});
+
+/// # Warning
+///
+/// I don't have a good understanding of the Unix Domain Sockets, thus
+/// take the following documentation with a *huge* grain of salt.
+///
+/// # Documentation
+///
+/// ## `UNIX_DIAG_MEMINFO` vs `INET_DIAG_SK_MEMINFO`
+///
+/// `MemInfo` represent an `UNIX_DIAG_MEMINFO` NLA. This NLA has the
+/// same structure than `INET_DIAG_SKMEMINFO`, but since Unix sockets
+/// don't actually use the network stack, many fields are not relevant
+/// and are always set to 0. According to iproute2 commit
+/// [51ff9f2453d066933f24170f0106a7deeefa02d9](https://patchwork.ozlabs.org/patch/222700/), only three attributes can have non-zero values.
+///
+/// ## Particularities of UNIX sockets
+///
+/// One particularity of UNIX sockets is that they don't really have a
+/// send queue: when sending data, the kernel finds the destination
+/// socket and enqueues the data directly in its receive queue (which
+/// [see also this StackOverflow
+/// answer](https://stackoverflow.com/questions/9644251/how-do-unix-domain-sockets-differentiate-between-multiple-clients)). For
+/// instance in `unix_dgram_sendmsg()` in `net/unix/af_unix.c` we
+/// have:
+///
+/// ```c
+/// // `other` refers to the peer socket here
+/// skb_queue_tail(&other->sk_receive_queue, skb);
+/// ```
+///
+/// Another particularity is that the kernel keeps track of the memory
+/// using the sender's `sock.sk_wmem_alloc` attribute. The receiver's
+/// `sock.sk_rmem_alloc` is always zero. Memory is allocated when data
+/// is written to a socket, and is reclaimed when the data is read
+/// from the peer's socket.
+///
+/// Last but not least, the way unix sockets handle incoming
+/// connection differs from the TCP sockets. For TCP sockets, the
+/// queue used to store pending connections is
+/// `sock.sk_ack_backlog`. But UNIX sockets use the receive queue to
+/// store them. They can do that because a listening socket only
+/// receive connections, they do not receive actual data from other
+/// socket, so there is no ambiguity about the nature of the data
+/// stored in the receive queue.
+// /// We can see that in `unix_stream_sendmsg()` for instance we have
+// /// the follownig function calls:
+// ///
+// /// ```
+// /// unix_stream_sendmsg()
+// ///     -> sock_alloc_send_pskb()
+// ///     -> skb_set_owner_w()
+// ///     -> refcount_add(size, &sk->sk_wmem_alloc);
+/// ```
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct MemInfo {
+    /// Value of `SO_RCVBUF`, although it does not have any effect on
+    /// Unix Domain Sockets. As per `man unix(7)`:
+    ///
+    /// > The `SO_SNDBUF` socket option does have an effect for UNIX
+    /// > domain sockets, but the `SO_RCVBUF` option does not.
+    ///
+    /// This attribute corresponds to `sock.sk_rcvbuf` in the kernel.
+    pub so_rcvbuf: u32,
+    /// Maximum size in in bytes of a datagram, as set by
+    /// `SO_SNDBUF`. As per `man unix(7)`:
+    ///
+    /// > For datagram sockets, the `SO_SNDBUF` value imposes an upper
+    /// > limit on the size of outgoing datagrams. This limit is
+    /// > calculated as the doubled (see `socket(7)`) option value
+    /// > less 32 bytes used for overhead.
+    ///
+    /// This attribute corresponds to `sock.sk_sndbuf` in the kernel.
+    pub max_datagram_size: u32,
+    /// Memory currently allocated for the data sent but not yet read
+    /// from the receiving socket(s). The memory is tracked using the
+    /// sending socket `sock.sk_wmem_queued` attribute in the kernel.
+    ///
+    /// Note that this quantity is a little larger than the actual
+    /// data being sent because it takes into account the overhead of
+    /// the `sk_buff`s used internally:
+    ///
+    /// ```c
+    /// /* in net/core/sock.c, sk_wmem_alloc is set in
+    ///    skb_set_owner_w() with: */
+    /// refcount_add(skb->truesize, &sk->sk_wmem_alloc);
+    ///
+    /// /* truesize is set by __alloc_skb() in net/core/skbuff.c
+    ///    by: */
+    /// skb->truesize = SKB_TRUESIZE(size);
+    ///
+    /// /* and SKB_TRUESIZE is defined as: */
+    /// #define SKB_TRUESIZE(X) ((X) +                        \
+    ///     SKB_DATA_ALIGN(sizeof(struct sk_buff)) +          \
+    ///     SKB_DATA_ALIGN(sizeof(struct skb_shared_info)))
+    /// ```
+    pub alloc: u32,
+}
+
+impl<T: AsRef<[u8]>> Parseable<MemInfoBuffer<T>> for MemInfo {
+    fn parse(buf: &MemInfoBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            so_rcvbuf: buf.so_rcvbuf(),
+            max_datagram_size: buf.max_datagram_size(),
+            alloc: buf.alloc(),
+        })
+    }
+}
+
+impl Emitable for MemInfo {
+    fn buffer_len(&self) -> usize {
+        MEM_INFO_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = MemInfoBuffer::new(buf);
+        buf.set_unused_sk_rmem_alloc(0);
+        buf.set_so_rcvbuf(self.so_rcvbuf);
+        buf.set_unused_sk_wmem_queued(0);
+        buf.set_max_datagram_size(self.max_datagram_size);
+        buf.set_unused_sk_fwd_alloc(0);
+        buf.set_alloc(self.alloc);
+        buf.set_unused_sk_optmem(0);
+        buf.set_unused_backlog(0);
+        buf.set_unused_drops(0);
+    }
+}
+
+impl crate::utils::nla::Nla for Nla {
+    fn value_len(&self) -> usize {
+        use self::Nla::*;
+        match *self {
+            // +1 because we need to append a null byte
+            Name(ref s) => s.as_bytes().len() + 1,
+            Vfs(_) => VFS_LEN,
+            Peer(_) => 4,
+            PendingConnections(ref v) => 4 * v.len(),
+            ReceiveQueueLength(_, _) => 8,
+            MemInfo(_) => MEM_INFO_LEN,
+            Shutdown(_) => 1,
+            Other(ref attr) => attr.value_len(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        use self::Nla::*;
+        match *self {
+            Name(ref s) => {
+                buffer[..s.len()].copy_from_slice(s.as_bytes());
+                buffer[s.len()] = 0;
+            }
+            Vfs(ref value) => value.emit(buffer),
+            Peer(value) => NativeEndian::write_u32(buffer, value),
+            PendingConnections(ref values) => {
+                for (i, v) in values.iter().enumerate() {
+                    NativeEndian::write_u32(&mut buffer[i * 4..], *v);
+                }
+            }
+            ReceiveQueueLength(v1, v2) => {
+                NativeEndian::write_u32(buffer, v1);
+                NativeEndian::write_u32(&mut buffer[4..], v2);
+            }
+            MemInfo(ref value) => value.emit(buffer),
+            Shutdown(value) => buffer[0] = value,
+            Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        use self::Nla::*;
+        match *self {
+            Name(_) => UNIX_DIAG_NAME,
+            Vfs(_) => UNIX_DIAG_VFS,
+            Peer(_) => UNIX_DIAG_PEER,
+            PendingConnections(_) => UNIX_DIAG_ICONS,
+            ReceiveQueueLength(_, _) => UNIX_DIAG_RQLEN,
+            MemInfo(_) => UNIX_DIAG_MEMINFO,
+            Shutdown(_) => UNIX_DIAG_SHUTDOWN,
+            Other(ref attr) => attr.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            UNIX_DIAG_NAME => {
+                let err = "invalid UNIX_DIAG_NAME value";
+                Self::Name(parse_string(payload).context(err)?)
+            }
+            UNIX_DIAG_VFS => {
+                let err = "invalid UNIX_DIAG_VFS value";
+                let buf = VfsBuffer::new_checked(payload).context(err)?;
+                Self::Vfs(Vfs::parse(&buf).context(err)?)
+            }
+            UNIX_DIAG_PEER => {
+                Self::Peer(parse_u32(payload).context("invalid UNIX_DIAG_PEER value")?)
+            }
+            UNIX_DIAG_ICONS => {
+                if payload.len() % 4 != 0 {
+                    return Err(DecodeError::from("invalid UNIX_DIAG_ICONS"));
+                }
+                Self::PendingConnections(payload.chunks(4).map(NativeEndian::read_u32).collect())
+            }
+            UNIX_DIAG_RQLEN => {
+                if payload.len() != 8 {
+                    return Err(DecodeError::from("invalid UNIX_DIAG_RQLEN"));
+                }
+                Self::ReceiveQueueLength(
+                    NativeEndian::read_u32(&payload[..4]),
+                    NativeEndian::read_u32(&payload[4..]),
+                )
+            }
+            UNIX_DIAG_MEMINFO => {
+                let err = "invalid UNIX_DIAG_MEMINFO value";
+                let buf = MemInfoBuffer::new_checked(payload).context(err)?;
+                Self::MemInfo(MemInfo::parse(&buf).context(err)?)
+            }
+            UNIX_DIAG_SHUTDOWN => {
+                Self::Shutdown(parse_u8(payload).context("invalid UNIX_DIAG_SHUTDOWN value")?)
+            }
+            kind => {
+                Self::Other(DefaultNla::parse(buf).context(format!("unknown NLA type {}", kind))?)
+            }
+        })
+    }
+}

--- a/netlink-packet-sock-diag/src/unix/nlas.rs
+++ b/netlink-packet-sock-diag/src/unix/nlas.rs
@@ -1,5 +1,5 @@
+use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use failure::ResultExt;
 
 pub use crate::utils::nla::{DefaultNla, NlaBuffer, NlasIterator};
 

--- a/netlink-packet-sock-diag/src/unix/request.rs
+++ b/netlink-packet-sock-diag/src/unix/request.rs
@@ -1,0 +1,110 @@
+use std::convert::TryFrom;
+
+use crate::{
+    constants::*,
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+
+pub const UNIX_REQUEST_LEN: usize = 24;
+
+buffer!(UnixRequestBuffer(UNIX_REQUEST_LEN) {
+    // The address family; it should be set to `AF_UNIX`
+    family: (u8, 0),
+    // This field should be set to `0`
+    protocol: (u8, 1),
+    // This field should be set to `0`
+    pad: (u16, 2..4),
+    // This is a bit mask that defines a filter of sockets
+    // states. Only those sockets whose states are in this mask will
+    // be reported. Ignored when querying for an individual
+    // socket. Supported values are:
+    //
+    // ```no_rust
+    // 1 << UNIX_ESTABLISHED
+    // 1 << UNIX_LISTEN
+    // ```
+    state_flags: (u32, 4..8),
+    // This is an inode number when querying for an individual
+    // socket. Ignored when querying for a list of sockets.
+    inode: (u32, 8..12),
+    // This is a set of flags defining what kind of information to
+    // report. Supported values are the `UDIAG_SHOW_*` constants.
+    show_flags: (u32, 12..16),
+    // This is an array of opaque identifiers that could be used
+    // along with udiag_ino to specify an individual socket. It is
+    // ignored when querying for a list of sockets, as well as when
+    // all its elements are set to `0xff`.
+    cookie: (slice, 16..UNIX_REQUEST_LEN),
+});
+
+/// The request for UNIX domain sockets
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct UnixRequest {
+    /// This is a bit mask that defines a filter of sockets states.
+    ///
+    /// Only those sockets whose states are in this mask will be reported.
+    /// Ignored when querying for an individual socket.
+    pub state_flags: StateFlags,
+    /// This is an inode number when querying for an individual socket.
+    ///
+    /// Ignored when querying for a list of sockets.
+    pub inode: u32,
+    /// This is a set of flags defining what kind of information to report.
+    ///
+    /// Each requested kind of information is reported back as a netlink attribute
+    pub show_flags: ShowFlags,
+    /// This is an opaque identifiers that could be used to specify an individual socket.
+    pub cookie: [u8; 8],
+}
+
+bitflags! {
+    /// Bitmask that defines a filter of UNIX socket states
+    pub struct StateFlags: u32 {
+        const ESTABLISHED = 1 << TCP_ESTABLISHED;
+        const LISTEN = 1 << TCP_LISTEN;
+    }
+}
+
+bitflags! {
+    /// Bitmask that defines what kind of information to
+    /// report. Supported values are the `UDIAG_SHOW_*` constants.
+    pub struct ShowFlags: u32 {
+        const NAME = UDIAG_SHOW_NAME;
+        const VFS = UDIAG_SHOW_VFS;
+        const PEER = UDIAG_SHOW_PEER;
+        const ICONS = UDIAG_SHOW_ICONS;
+        const RQLEN = UDIAG_SHOW_RQLEN;
+        const MEMINFO = UDIAG_SHOW_MEMINFO;
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixRequestBuffer<&'a T>> for UnixRequest {
+    fn parse(buf: &UnixRequestBuffer<&'a T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            state_flags: StateFlags::from_bits_truncate(buf.state_flags()),
+            inode: buf.inode(),
+            show_flags: ShowFlags::from_bits_truncate(buf.show_flags()),
+            // Unwrapping is safe because UnixRequestBuffer::cookie()
+            // returns a slice of exactly 8 bytes.
+            cookie: TryFrom::try_from(buf.cookie()).unwrap(),
+        })
+    }
+}
+
+impl Emitable for UnixRequest {
+    fn buffer_len(&self) -> usize {
+        UNIX_REQUEST_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buffer = UnixRequestBuffer::new(buf);
+        buffer.set_family(0);
+        buffer.set_protocol(0);
+        buffer.set_state_flags(self.state_flags.bits());
+        buffer.set_inode(self.inode);
+        buffer.set_pad(0);
+        buffer.set_show_flags(self.show_flags.bits());
+        buffer.cookie_mut().copy_from_slice(&self.cookie[..]);
+    }
+}

--- a/netlink-packet-sock-diag/src/unix/response.rs
+++ b/netlink-packet-sock-diag/src/unix/response.rs
@@ -1,4 +1,4 @@
-use failure::ResultExt;
+use anyhow::Context;
 use smallvec::SmallVec;
 use std::convert::TryFrom;
 

--- a/netlink-packet-sock-diag/src/unix/response.rs
+++ b/netlink-packet-sock-diag/src/unix/response.rs
@@ -1,0 +1,214 @@
+use failure::ResultExt;
+use smallvec::SmallVec;
+use std::convert::TryFrom;
+
+use crate::{
+    constants::*,
+    traits::{Emitable, Parseable},
+    unix::nlas::{MemInfo, Nla, NlaBuffer, NlasIterator},
+    DecodeError,
+};
+
+pub const UNIX_RESPONSE_HEADER_LEN: usize = 16;
+
+buffer!(UnixResponseBuffer(UNIX_RESPONSE_HEADER_LEN) {
+    family: (u8, 0),
+    kind: (u8, 1),
+    state: (u8, 2),
+    pad: (u8, 3),
+    inode: (u32, 4..8),
+    cookie: (slice, 8..UNIX_RESPONSE_HEADER_LEN),
+    payload: (slice, UNIX_RESPONSE_HEADER_LEN..),
+});
+
+/// The response to a query for IPv4 or IPv6 sockets
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct UnixResponseHeader {
+    /// One of `SOCK_PACKET`, `SOCK_STREAM`, or `SOCK_SEQPACKET`
+    pub kind: u8,
+    /// State of the socket. According to `man 7 sock_diag` it can be
+    /// either `TCP_ESTABLISHED` or `TCP_LISTEN`. However datagram
+    /// UNIX sockets are not connection oriented so I would assume
+    /// that this field can also take other value (maybe `0`) for
+    /// these sockets.
+    pub state: u8,
+    /// Socket inode number.
+    pub inode: u32,
+    pub cookie: [u8; 8],
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for UnixResponseHeader {
+    fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            kind: buf.kind(),
+            state: buf.state(),
+            inode: buf.inode(),
+            // Unwrapping is safe because UnixResponseBuffer::cookie()
+            // returns a slice of exactly 8 bytes.
+            cookie: TryFrom::try_from(buf.cookie()).unwrap(),
+        })
+    }
+}
+
+impl Emitable for UnixResponseHeader {
+    fn buffer_len(&self) -> usize {
+        UNIX_RESPONSE_HEADER_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = UnixResponseBuffer::new(buf);
+        buf.set_family(AF_UNIX as u8);
+        buf.set_kind(self.kind);
+        buf.set_state(self.state);
+        buf.set_pad(0);
+        buf.set_inode(self.inode);
+        buf.cookie_mut().copy_from_slice(&self.cookie[..]);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct UnixResponse {
+    pub header: UnixResponseHeader,
+    pub nlas: SmallVec<[Nla; 8]>,
+}
+
+impl UnixResponse {
+    pub fn peer(&self) -> Option<u32> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::Peer(inode) = nla {
+                Some(*inode)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn name(&self) -> Option<&String> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::Name(name) = nla {
+                Some(name)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn pending_connections(&self) -> Option<&[u32]> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::PendingConnections(connections) = nla {
+                Some(&connections[..])
+            } else {
+                None
+            }
+        })
+    }
+
+    fn mem_info(&self) -> Option<MemInfo> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::MemInfo(mem_info) = nla {
+                Some(*mem_info)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn shutdown_state(&self) -> Option<u8> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::Shutdown(shutdown_state) = nla {
+                Some(*shutdown_state)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn receive_queue_length(&self) -> Option<(u32, u32)> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::ReceiveQueueLength(x, y) = nla {
+                Some((*x, *y))
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn number_of_pending_connection(&self) -> Option<u32> {
+        if self.header.state == TCP_LISTEN {
+            self.receive_queue_length().map(|(n, _)| n)
+        } else {
+            None
+        }
+    }
+
+    pub fn max_number_of_pending_connection(&self) -> Option<u32> {
+        if self.header.state == TCP_LISTEN {
+            self.receive_queue_length().map(|(_, n)| n)
+        } else {
+            None
+        }
+    }
+
+    pub fn receive_queue_size(&self) -> Option<u32> {
+        if self.header.state == TCP_LISTEN {
+            None
+        } else {
+            self.receive_queue_length().map(|(n, _)| n)
+        }
+    }
+
+    pub fn send_queue_size(&self) -> Option<u32> {
+        if self.header.state == TCP_LISTEN {
+            self.receive_queue_length().map(|(n, _)| n)
+        } else {
+            None
+        }
+    }
+
+    pub fn max_datagram_size(&self) -> Option<u32> {
+        self.mem_info().map(|mem_info| mem_info.max_datagram_size)
+    }
+
+    pub fn memory_used_for_outgoing_data(&self) -> Option<u32> {
+        self.mem_info().map(|mem_info| mem_info.alloc)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> UnixResponseBuffer<&'a T> {
+    pub fn nlas(&self) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+        NlasIterator::new(self.payload())
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
+    fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let mut nlas = smallvec![];
+        for nla_buf in buf.nlas() {
+            nlas.push(Nla::parse(&nla_buf?)?);
+        }
+        Ok(nlas)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for UnixResponse {
+    fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let header =
+            UnixResponseHeader::parse(&buf).context("failed to parse inet response header")?;
+        let nlas =
+            SmallVec::<[Nla; 8]>::parse(buf).context("failed to parse inet response NLAs")?;
+        Ok(UnixResponse { header, nlas })
+    }
+}
+
+impl Emitable for UnixResponse {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len() + self.nlas.as_slice().buffer_len()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        self.nlas
+            .as_slice()
+            .emit(&mut buffer[self.header.buffer_len()..]);
+    }
+}

--- a/netlink-packet-sock-diag/src/unix/response.rs
+++ b/netlink-packet-sock-diag/src/unix/response.rs
@@ -37,7 +37,7 @@ pub struct UnixResponseHeader {
     pub cookie: [u8; 8],
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for UnixResponseHeader {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for UnixResponseHeader {
     fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self {
             kind: buf.kind(),
@@ -180,7 +180,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> UnixResponseBuffer<&'a T> {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
     fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = smallvec![];
         for nla_buf in buf.nlas() {
@@ -190,7 +190,7 @@ impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for SmallVec<
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixResponseBuffer<&'a T>> for UnixResponse {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for UnixResponse {
     fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let header =
             UnixResponseHeader::parse(&buf).context("failed to parse inet response header")?;

--- a/netlink-packet-sock-diag/src/unix/tests.rs
+++ b/netlink-packet-sock-diag/src/unix/tests.rs
@@ -1,0 +1,131 @@
+use crate::{
+    constants::*,
+    traits::{Emitable, Parseable},
+    unix::{nlas::Nla, UnixResponse, UnixResponseBuffer, UnixResponseHeader},
+};
+
+lazy_static! {
+    static ref LISTENING: UnixResponse = UnixResponse {
+        header: UnixResponseHeader {
+            kind: SOCK_STREAM,
+            state: TCP_LISTEN,
+            inode: 20238,
+            cookie: [0xa0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        },
+        nlas: smallvec![
+            Nla::Name("/tmp/.ICE-unix/1151".to_string()),
+            Nla::ReceiveQueueLength(0, 128),
+            Nla::Shutdown(0),
+        ]
+    };
+}
+
+#[rustfmt::skip]
+static LISTENING_BUF: [u8; 60] = [
+    0x01, // family: AF_UNIX
+    0x01, // type: SOCK_STREAM
+    0x0a, // state: TCP_LISTEN
+    0x00, // padding
+    0x0e, 0x4f, 0x00, 0x00, // inode number
+    0xa0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // cookie
+
+    // NLAs
+    0x18, 0x00, // length: 24
+    0x00, 0x00, // type: UNIX_DIAG_NAME
+    // value: /tmp/.ICE-unix/1151
+    0x2f, 0x74, 0x6d, 0x70, 0x2f, 0x2e, 0x49, 0x43, 0x45, 0x2d, 0x75, 0x6e, 0x69, 0x78, 0x2f, 0x31, 0x31, 0x35, 0x31, 0x00,
+
+    0x0c, 0x00, // length: 12
+    0x04, 0x00, // type: UNIX_DIAG_RQLEN
+    // value: ReceiveQueueLength(0, 128)
+    0x00, 0x00, 0x00, 0x00,
+    0x80, 0x00, 0x00, 0x00,
+
+    0x05, 0x00, // length: 5
+    0x06, 0x00, // type: UNIX_DIAG_SHUTDOWN
+    0x00, // value: 0
+    0x00, 0x00, 0x00 // padding
+];
+
+#[test]
+fn parse_listening() {
+    let parsed =
+        UnixResponse::parse(&UnixResponseBuffer::new_checked(&&LISTENING_BUF[..]).unwrap())
+            .unwrap();
+    assert_eq!(parsed, *LISTENING);
+}
+
+#[test]
+fn emit_listening() {
+    assert_eq!(LISTENING.buffer_len(), 60);
+    // Initialize the buffer with 0xff to check that padding bytes are
+    // set to 0
+    let mut buf = vec![0xff; LISTENING.buffer_len()];
+    LISTENING.emit(&mut buf);
+    assert_eq!(&buf[..], &LISTENING_BUF[..]);
+}
+
+lazy_static! {
+    static ref ESTABLISHED: UnixResponse = UnixResponse {
+        header: UnixResponseHeader {
+            kind: SOCK_STREAM,
+            state: TCP_ESTABLISHED,
+            inode: 31927,
+            cookie: [0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        },
+        nlas: smallvec![
+            Nla::Name("/run/user/1000/bus".to_string()),
+            Nla::Peer(31062),
+            Nla::ReceiveQueueLength(0, 0),
+            Nla::Shutdown(0),
+        ]
+    };
+}
+
+#[rustfmt::skip]
+static ESTABLISHED_BUF: [u8; 68] = [
+    0x01, // family: AF_LOCAL
+    0x01, // kind: SOCK_STREAM,
+    0x01, // state: TCP_ESTABLISHED
+    0x00, // padding
+    0xb7, 0x7c, 0x00, 0x00, // inode: 31927
+    0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // cookie
+
+    // NLAs
+
+    0x17, 0x00, // length: 23
+    0x00, 0x00, // type: UNIX_DIAG_NAME
+    // value: /run/user/1000/bus
+    0x2f, 0x72, 0x75, 0x6e, 0x2f, 0x75, 0x73, 0x65, 0x72, 0x2f, 0x31, 0x30, 0x30, 0x30, 0x2f, 0x62, 0x75, 0x73, 0x00,
+    0x00, // padding
+
+    0x08, 0x00, // length: 8
+    0x02, 0x00, // type: UNIX_DIAG_PEER
+    0x56, 0x79, 0x00, 0x00, // value: 31062
+
+    0x0c, 0x00, // length: 12
+    0x04, 0x00, // type: UNIX_DIAG_RQLEN
+    // value: ReceiveQueueLength(0, 0)
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+
+    0x05, 0x00, // length: 5
+    0x06, 0x00, // type: UNIX_DIAG_SHUTDOWN
+    0x00, 0x00, 0x00, 0x00 // value: 0
+];
+
+#[test]
+fn parse_established() {
+    let parsed =
+        UnixResponse::parse(&UnixResponseBuffer::new_checked(&&ESTABLISHED_BUF[..]).unwrap())
+            .unwrap();
+    assert_eq!(parsed, *ESTABLISHED);
+}
+
+#[test]
+fn emit_established() {
+    assert_eq!(ESTABLISHED.buffer_len(), 68);
+    let mut buf = vec![0xff; ESTABLISHED.buffer_len()];
+    ESTABLISHED.emit(&mut buf);
+    assert_eq!(&buf[..], &ESTABLISHED_BUF[..]);
+}

--- a/netlink-packet-utils/src/macros.rs
+++ b/netlink-packet-utils/src/macros.rs
@@ -65,7 +65,7 @@ macro_rules! setter {
     ($buffer: ident, $name:ident, slice, $offset:expr) => {
         impl<'a, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> $buffer<&'a mut T> {
             $crate::paste::item! {
-                pub fn [<$name _mut>](&'a mut self) -> &'a mut [u8] {
+                pub fn [<$name _mut>](&mut self) -> &mut [u8] {
                     &mut self.buffer.as_mut()[$offset]
                 }
             }


### PR DESCRIPTION
As I needed to quickly diagnose some sockets, I took the liberty to finish up your work in #56. Specifically, I added a buffer for the messages and an example. Other than a small fix of the serialization of port numbers, it's just a rebased version of your implementation. I'm happy to close this PR and rebase my fixes on your work in case you'd like to keep working on it.