### PR TITLE
netlink-packet-route: Implement IPvlan LinkInfo NLA

### DIFF
--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -443,6 +443,9 @@ pub const IFLA_VLAN_FLAGS: u16 = 2;
 pub const IFLA_VLAN_EGRESS_QOS: u16 = 3;
 pub const IFLA_VLAN_INGRESS_QOS: u16 = 4;
 pub const IFLA_VLAN_PROTOCOL: u16 = 5;
+pub const IFLA_IPVLAN_UNSPEC: u16 = 0;
+pub const IFLA_IPVLAN_MODE: u16 = 1;
+pub const IFLA_IPVLAN_FLAGS: u16 = 2;
 pub const VETH_INFO_UNSPEC: u16 = 0;
 pub const VETH_INFO_PEER: u16 = 1;
 


### PR DESCRIPTION
Tried my hand at implementing IPvlan LinkInfo handling.
I had wanted to add the ipvlan_mode enum and IPvlan flag constants defined in linux/include/uapi/linux/if_link.h but I wasn't sure where to put them.

As an aside, the tests I added ended up uncovering a bug in my iproute2 as it was sending link info where the info kind field length was 1 byte shorter than it should be compared to both this library and the kernel's response. Not sure if this is fixed upstream (found in v 5.8.0).