### PR TITLE
rtnetlink: support adding, getting and deleting route rules

### DIFF
--- a/rtnetlink/examples/add_rule.rs
+++ b/rtnetlink/examples/add_rule.rs
@@ -1,0 +1,53 @@
+use std::env;
+
+use ipnetwork::Ipv4Network;
+use rtnetlink::{new_connection, Error, Handle};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+
+    let dest: Ipv4Network = args[1].parse().unwrap_or_else(|_| {
+        eprintln!("invalid destination");
+        std::process::exit(1);
+    });
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    if let Err(e) = add_rule(&dest, handle.clone()).await {
+        eprintln!("{}", e);
+    }
+    Ok(())
+}
+
+async fn add_rule(dest: &Ipv4Network, handle: Handle) -> Result<(), Error> {
+    let rule = handle.rule();
+    rule
+        .add_v4()
+        .destination_prefix(dest.ip(), dest.prefix())
+        .execute()
+        .await?;
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example add_rule -- <destination>/<prefix_length> <gateway>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example add_rule
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./add_rule <destination>/<prefix_length> <gateway>"
+    );
+}
+

--- a/rtnetlink/examples/get_rule.rs
+++ b/rtnetlink/examples/get_rule.rs
@@ -1,0 +1,30 @@
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle, IpVersion};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    println!("dumping rules for IPv4");
+    if let Err(e) = dump_addresses(handle.clone(), IpVersion::V4).await {
+        eprintln!("{}", e);
+    }
+    println!();
+
+    println!("dumping rules for IPv6");
+    if let Err(e) = dump_addresses(handle.clone(), IpVersion::V6).await {
+        eprintln!("{}", e);
+    }
+    println!();
+
+    Ok(())
+}
+
+async fn dump_addresses(handle: Handle, ip_version: IpVersion) -> Result<(), Error> {
+    let mut rules = handle.rule().get(ip_version).execute();
+    while let Some(rule) = rules.try_next().await? {
+        println!("{:?}", rule);
+    }
+    Ok(())
+}

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -2,8 +2,8 @@ use futures::Stream;
 
 use crate::{
     packet::{NetlinkMessage, RtnlMessage},
-    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, TrafficChainHandle,
-    TrafficClassHandle, TrafficFilterHandle,
+    AddressHandle, Error, LinkHandle, QDiscHandle, RouteHandle, RuleHandle,
+    TrafficChainHandle, TrafficClassHandle, TrafficFilterHandle,
 };
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
@@ -44,6 +44,11 @@ impl Handle {
     /// Create a new handle, specifically for routing table requests (equivalent to `ip route` commands)
     pub fn route(&self) -> RouteHandle {
         RouteHandle::new(self.clone())
+    }
+
+    /// Create a new handle, specifically for routing rule requests (equivalent to `ip rule` commands)
+    pub fn rule(&self) -> RuleHandle {
+        RuleHandle::new(self.clone())
     }
 
     /// Create a new handle, specifically for traffic control qdisc requests

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -18,6 +18,9 @@ pub use crate::addr::*;
 mod route;
 pub use crate::route::*;
 
+mod rule;
+pub use crate::rule::*;
+
 mod connection;
 pub use crate::connection::*;
 

--- a/rtnetlink/src/rule/add.rs
+++ b/rtnetlink/src/rule/add.rs
@@ -1,0 +1,199 @@
+use futures::stream::StreamExt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use netlink_packet_route::{
+    constants::*, nlas::rule::Nla, NetlinkMessage, NetlinkPayload, RuleMessage, RtnlMessage,
+};
+
+use crate::{Error, Handle};
+
+/// A request to create a new rule. This is equivalent to the `ip rule add` command.
+struct RuleAddRequest {
+    handle: Handle,
+    message: RuleMessage,
+}
+
+impl RuleAddRequest {
+    fn new(handle: Handle) -> Self {
+        let mut message = RuleMessage::default();
+
+        message.header.table = RT_TABLE_MAIN;
+        message.header.action = FR_ACT_UNSPEC;
+
+        RuleAddRequest { handle, message }
+    }
+
+    /// Sets the input interface name.
+    fn input_interface(mut self, ifname: String) -> Self {
+        self.message.nlas.push(Nla::Iifname(ifname));
+        self
+    }
+
+    /// Sets the output interface name.
+    fn output_interface(mut self, ifname: String) -> Self {
+        self.message.nlas.push(Nla::OifName(ifname));
+        self
+    }
+
+    /// Sets the rule table.
+    ///
+    /// Default is main rule table.
+    fn table(mut self, table: u8) -> Self {
+        self.message.header.table = table;
+        self
+    }
+
+    /// Set the tos.
+    fn tos(mut self, tos: u8) -> Self {
+        self.message.header.tos = tos;
+        self
+    }
+
+    /// Set action.
+    fn action(mut self, action: u8) -> Self {
+        self.message.header.action = action;
+        self
+    }
+
+    /// Execute the request.
+    pub async fn execute(self) -> Result<(), Error> {
+        let RuleAddRequest {
+            mut handle,
+            message,
+        } = self;
+        let mut req = NetlinkMessage::from(RtnlMessage::NewRule(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+
+        let mut response = handle.request(req)?;
+        while let Some(message) = response.next().await {
+            if let NetlinkPayload::Error(err) = message.payload {
+                return Err(Error::NetlinkError(err));
+            }
+        }
+        Ok(())
+    }
+
+    fn message_mut(&mut self) -> &mut RuleMessage {
+        &mut self.message
+    }
+}
+
+pub struct RuleAddIpv4Request(RuleAddRequest);
+
+impl RuleAddIpv4Request {
+    pub fn new(handle: Handle) -> Self {
+        let mut req = RuleAddRequest::new(handle);
+        req.message_mut().header.family = AF_INET as u8;
+        Self(req)
+    }
+
+    /// Sets the input interface name.
+    pub fn input_interface(self, ifname: String) -> Self {
+        Self(self.0.input_interface(ifname))
+    }
+
+    /// Sets the output interface name.
+    pub fn output_interface(self, ifname: String) -> Self {
+        Self(self.0.output_interface(ifname))
+    }
+
+    /// Sets the source address prefix.
+    pub fn source_prefix(mut self, addr: Ipv4Addr, prefix_length: u8) -> Self {
+        self.0.message.header.src_len = prefix_length;
+        self.0.message.nlas.push(Nla::Source(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the destination address prefix.
+    pub fn destination_prefix(mut self, addr: Ipv4Addr, prefix_length: u8) -> Self {
+        self.0.message.header.dst_len = prefix_length;
+        self.0.message.nlas.push(Nla::Destination(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the rule table.
+    ///
+    /// Default is main rule table.
+    pub fn table(self, table: u8) -> Self {
+        Self(self.0.table(table))
+    }
+
+    /// Set the tos.
+    pub fn tos(self, tos: u8) -> Self {
+        Self(self.0.tos(tos))
+    }
+
+    /// Set action.
+    pub fn action(self, action: u8) -> Self {
+        Self(self.0.action(action))
+    }
+
+    /// Execute the request.
+    pub async fn execute(self) -> Result<(), Error> {
+        self.0.execute().await
+    }
+
+    pub fn message_mut(&mut self) -> &mut RuleMessage {
+        self.0.message_mut()
+    }
+}
+
+pub struct RuleAddIpv6Request(RuleAddRequest);
+
+impl RuleAddIpv6Request {
+    pub fn new(handle: Handle) -> Self {
+        let mut req = RuleAddRequest::new(handle);
+        req.message_mut().header.family = AF_INET6 as u8;
+        Self(req)
+    }
+
+    /// Sets the input interface name.
+    pub fn input_interface(self, ifname: String) -> Self {
+        Self(self.0.input_interface(ifname))
+    }
+
+    /// Sets the output interface name.
+    pub fn output_interface(self, ifname: String) -> Self {
+        Self(self.0.output_interface(ifname))
+    }
+
+    /// Sets the source address prefix.
+    pub fn source_prefix(mut self, addr: Ipv6Addr, prefix_length: u8) -> Self {
+        self.0.message.header.src_len = prefix_length;
+        self.0.message.nlas.push(Nla::Source(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the destination address prefix.
+    pub fn destination_prefix(mut self, addr: Ipv6Addr, prefix_length: u8) -> Self {
+        self.0.message.header.dst_len = prefix_length;
+        self.0.message.nlas.push(Nla::Destination(addr.octets().to_vec()));
+        self
+    }
+
+    /// Sets the rule table.
+    ///
+    /// Default is main rule table.
+    pub fn table(self, table: u8) -> Self {
+        Self(self.0.table(table))
+    }
+
+    /// Set the tos.
+    pub fn tos(self, tos: u8) -> Self {
+        Self(self.0.tos(tos))
+    }
+
+    /// Set action.
+    pub fn action(self, action: u8) -> Self {
+        Self(self.0.action(action))
+    }
+
+    /// Execute the request.
+    pub async fn execute(self) -> Result<(), Error> {
+        self.0.execute().await
+    }
+
+    pub fn message_mut(&mut self) -> &mut RuleMessage {
+        self.0.message_mut()
+    }
+}

--- a/rtnetlink/src/rule/del.rs
+++ b/rtnetlink/src/rule/del.rs
@@ -1,0 +1,39 @@
+use futures::stream::StreamExt;
+
+use crate::{
+    packet::{NetlinkMessage, NetlinkPayload, RuleMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST},
+    Error, Handle,
+};
+
+pub struct RuleDelRequest {
+    handle: Handle,
+    message: RuleMessage,
+}
+
+impl RuleDelRequest {
+    pub(crate) fn new(handle: Handle, message: RuleMessage) -> Self {
+        RuleDelRequest { handle, message }
+    }
+
+    /// Execute the request
+    pub async fn execute(self) -> Result<(), Error> {
+        let RuleDelRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::DelRule(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        let mut response = handle.request(req)?;
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                return Err(Error::NetlinkError(e));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn message_mut(&mut self) -> &mut RuleMessage {
+        &mut self.message
+    }
+}

--- a/rtnetlink/src/rule/get.rs
+++ b/rtnetlink/src/rule/get.rs
@@ -1,0 +1,63 @@
+use crate::IpVersion;
+use futures::{
+    future::{self, Either},
+    stream::{StreamExt, TryStream},
+    FutureExt,
+};
+
+use netlink_packet_route::{
+    constants::*, NetlinkMessage, NetlinkPayload, RuleMessage, RtnlMessage
+};
+
+use crate::{Error, Handle};
+
+pub struct RuleGetRequest {
+    handle: Handle,
+    message: RuleMessage,
+}
+
+impl RuleGetRequest {
+    pub(crate) fn new(handle: Handle, ip_version: IpVersion) -> Self {
+        let mut message = RuleMessage::default();
+        message.header.family = match ip_version {
+            IpVersion::V4 => AF_INET as u8,
+            IpVersion::V6 => AF_INET6 as u8,
+        };
+
+        message.header.dst_len = 0;
+        message.header.src_len = 0;
+        message.header.tos = 0;
+        message.header.action = FR_ACT_UNSPEC;
+        message.header.table = RT_TABLE_UNSPEC;
+
+        RuleGetRequest { handle, message }
+    }
+
+    pub fn message_mut(&mut self) -> &mut RuleMessage {
+        &mut self.message
+    }
+
+    pub fn execute(self) -> impl TryStream<Ok = RuleMessage, Error = Error> {
+        let RuleGetRequest {
+            mut handle,
+            message,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::GetRule(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+        match handle.request(req) {
+            Ok(response) => Either::Left(response.map(move |msg| {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    NetlinkPayload::InnerMessage(RtnlMessage::NewRule(msg)) => Ok(msg),
+                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
+                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
+                        header, payload
+                    ))),
+                }
+            })),
+            Err(e) => Either::Right(future::err::<RuleMessage, Error>(e).into_stream()),
+        }
+    }
+}

--- a/rtnetlink/src/rule/handle.rs
+++ b/rtnetlink/src/rule/handle.rs
@@ -1,0 +1,31 @@
+use super::{RuleAddIpv4Request, RuleAddIpv6Request};
+use crate::{Handle, IpVersion, RuleDelRequest, RuleGetRequest};
+use netlink_packet_route::RuleMessage;
+
+pub struct RuleHandle(Handle);
+
+impl RuleHandle {
+    pub fn new(handle: Handle) -> Self {
+        RuleHandle(handle)
+    }
+
+    /// Retrieve the list of route rule entries (equivalent to `ip rule show`)
+    pub fn get(&self, ip_version: IpVersion) -> RuleGetRequest {
+        RuleGetRequest::new(self.0.clone(), ip_version)
+    }
+
+    /// Add a route rule entry (equivalent to `ip rule add`)
+    pub fn add_v4(&self) -> RuleAddIpv4Request {
+        RuleAddIpv4Request::new(self.0.clone())
+    }
+
+    /// Add a route rule entry (equivalent to `ip rule add`)
+    pub fn add_v6(&self) -> RuleAddIpv6Request {
+        RuleAddIpv6Request::new(self.0.clone())
+    }
+
+    /// Delete the given route rule entry (equivalent to `ip rule del`)
+    pub fn del(&self, rule: RuleMessage) -> RuleDelRequest {
+        RuleDelRequest::new(self.0.clone(), rule)
+    }
+}

--- a/rtnetlink/src/rule/mod.rs
+++ b/rtnetlink/src/rule/mod.rs
@@ -1,0 +1,11 @@
+mod handle;
+pub use self::handle::*;
+
+mod add;
+pub use self::add::*;
+
+mod del;
+pub use self::del::*;
+
+mod get;
+pub use self::get::*;


### PR DESCRIPTION
This patch is supporting add, del and get operations on route rules.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>