### PR TITLE
netlink-packet-route: support IP over Infiniband interface

### DIFF
--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -446,6 +446,10 @@ pub const IFLA_VLAN_PROTOCOL: u16 = 5;
 pub const IFLA_IPVLAN_UNSPEC: u16 = 0;
 pub const IFLA_IPVLAN_MODE: u16 = 1;
 pub const IFLA_IPVLAN_FLAGS: u16 = 2;
+pub const IFLA_IPOIB_UNSPEC: u16 = 0;
+pub const IFLA_IPOIB_PKEY: u16 = 1;
+pub const IFLA_IPOIB_MODE: u16 = 2;
+pub const IFLA_IPOIB_UMCAST: u16 = 4;
 pub const VETH_INFO_UNSPEC: u16 = 0;
 pub const VETH_INFO_PEER: u16 = 1;
 


### PR DESCRIPTION
This patch is introducing IP over Infiniband interface support. In addition, it is providing the InfoIpoib Nla. This Nla is gathering all the IFLA_IPOIB_ netlink attributes.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>