### PR TITLE
Implementing network namespace addition and removal a la ip netns

### DIFF
--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -23,6 +23,7 @@ netlink-packet-route = { path = "../netlink-packet-route", version = "0.6" }
 netlink-proto = { path = "../netlink-proto", version = "0.5" }
 byteordered = "0.5.0"
 nix = "0.19.0"
+tokio = { version = "0.2.6", features = ["full"] }
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1"
 netlink-packet-route = { path = "../netlink-packet-route", version = "0.6" }
 netlink-proto = { path = "../netlink-proto", version = "0.5" }
 byteordered = "0.5.0"
+nix = "0.19.0"
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/rtnetlink/examples/add_netns.rs
+++ b/rtnetlink/examples/add_netns.rs
@@ -1,0 +1,33 @@
+use rtnetlink::NetworkNamespace;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    env_logger::init();
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let ns_name = &args[1];
+
+    NetworkNamespace::add(ns_name.to_string())
+        .await
+        .map_err(|e| format!("{}", e))
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example add_netns -- <ns_name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd netlink-ip ; cargo build --example add_netns
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./add_netns <ns_name>"
+    );
+}

--- a/rtnetlink/examples/del_netns.rs
+++ b/rtnetlink/examples/del_netns.rs
@@ -1,0 +1,32 @@
+use rtnetlink::NetworkNamespace;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let ns_name = &args[1];
+
+    NetworkNamespace::del(ns_name.to_string())
+        .await
+        .map_err(|e| format!("{}", e))
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example del_netns -- <ns_name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd netlink-ip ; cargo build --example del_netns
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./del_netns <ns_name>"
+    );
+}

--- a/rtnetlink/src/errors.rs
+++ b/rtnetlink/src/errors.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[error("A netlink request failed")]
     RequestFailed,
 
+    #[error("Namespace error {0}")]
+    NamespaceError(String),
+
     #[error(
         "Received a link message (RTM_GETLINK, RTM_NEWLINK, RTM_SETLINK or RTMGETLINK) with an invalid hardware address attribute: {0:?}."
     )]

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -6,7 +6,6 @@
 mod handle;
 pub use crate::handle::*;
 
-
 mod ns;
 pub use crate::ns::*;
 

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -6,6 +6,10 @@
 mod handle;
 pub use crate::handle::*;
 
+
+mod ns;
+pub use crate::ns::*;
+
 mod errors;
 pub use crate::errors::*;
 

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -1,0 +1,77 @@
+use nix::fcntl::OFlag;
+use nix::sched::*;
+use nix::sys::stat::Mode;
+use std::option::Option;
+use std::path::Path;
+
+pub const NETNS_PATH: &str = "/var/run/netns/";
+pub const SELF_NS_PATH: &str = "/proc/self/ns/net";
+pub const NONE_FS: &str = "none";
+
+
+pub struct NetworkNamespace();
+
+
+impl NetworkNamespace {
+    pub async fn add(ns_name: &String) -> nix::Result<()> {
+        let mut netns_path = String::new();
+
+        let dir_path = Path::new(NETNS_PATH);
+        let mut mkdir_mode = Mode::empty();
+        let mut open_flags = OFlag::empty();
+
+        // flags in mkdir
+        mkdir_mode.insert(Mode::S_IRWXU);
+        mkdir_mode.insert(Mode::S_IRGRP);
+        mkdir_mode.insert(Mode::S_IXGRP);
+        mkdir_mode.insert(Mode::S_IROTH);
+        mkdir_mode.insert(Mode::S_IXOTH);
+
+        open_flags.insert(OFlag::O_RDONLY);
+        open_flags.insert(OFlag::O_CREAT);
+        open_flags.insert(OFlag::O_EXCL);
+
+        netns_path.push_str(NETNS_PATH);
+        netns_path.push_str(ns_name);
+
+        // creating namespaces folder if not exists
+        nix::unistd::mkdir(dir_path, mkdir_mode)?;
+
+        let ns_path = Path::new(&netns_path);
+
+        // creating the netns file
+        let fd = nix::fcntl::open(ns_path, open_flags, Mode::empty())?;
+
+        nix::unistd::close(fd)?;
+
+        // unshare to the new network namespace
+        let ret = nix::sched::unshare(CloneFlags::CLONE_NEWNET);
+
+        let self_path = Path::new(&SELF_NS_PATH);
+        let none_fs = Path::new(&NONE_FS);
+        let none_p4: Option<&Path> = None;
+        // bind to the netns
+        nix::mount::mount(
+            Some(self_path),
+            ns_path,
+            Some(none_fs),
+            nix::mount::MsFlags::MS_BIND,
+            none_p4,
+        )?;
+
+        ret
+    }
+
+
+    pub async fn del(ns_name: &String) -> nix::Result<()> {
+        let mut netns_path = String::new();
+        netns_path.push_str(NETNS_PATH);
+        netns_path.push_str(ns_name);
+        let ns_path = Path::new(&netns_path);
+
+        nix::mount::umount2(ns_path, nix::mount::MntFlags::MNT_DETACH)?;
+
+        nix::unistd::unlink(ns_path)
+    }
+
+}

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -194,7 +194,7 @@ impl NetworkNamespace {
     /// Remove a network namespace
     /// This is equivalent to `ip netns del NS_NAME`.
     pub async fn del(ns_name: String) -> Result<(), Error> {
-        let jh = task::spawn_blocking(move || {
+        let res = task::spawn_blocking(move || {
             let mut netns_path = String::new();
             netns_path.push_str(NETNS_PATH);
             netns_path.push_str(&ns_name);
@@ -212,7 +212,7 @@ impl NetworkNamespace {
             }
             Ok(())
         });
-        match jh.await {
+        match res.await {
             Ok(r) => r,
             Err(e) => {
                 let err_msg = format!("Namespace removal failed: {}", e);

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -1,8 +1,17 @@
-use nix::fcntl::OFlag;
-use nix::sched::*;
-use nix::sys::stat::Mode;
-use std::option::Option;
-use std::path::Path;
+//#[cfg(feature = "tokio")]
+use tokio::task;
+
+use crate::Error;
+use nix::{
+    fcntl::OFlag,
+    sched::*,
+    sys::{
+        stat::Mode,
+        wait::{waitpid, WaitStatus},
+    },
+    unistd::{fork, ForkResult},
+};
+use std::{option::Option, path::Path, process::exit};
 
 pub const NETNS_PATH: &str = "/var/run/netns/";
 pub const SELF_NS_PATH: &str = "/proc/self/ns/net";
@@ -11,67 +20,151 @@ pub const NONE_FS: &str = "none";
 
 pub struct NetworkNamespace();
 
-
 impl NetworkNamespace {
-    pub async fn add(ns_name: &String) -> nix::Result<()> {
-        let mut netns_path = String::new();
+    /// Add a new network namespace.
+    /// This is equivalent to `ip netns add NS_NAME`.
+    pub async fn add(ns_name: String) -> Result<(), Error> {
+        // Forking process to avoid moving called into new namespace
+        log::trace!("Forking...");
+        match unsafe { fork() } {
+            Ok(ForkResult::Parent { child, .. }) => {
+                log::trace!("Parent waiting child: {}", child);
+                match waitpid(child, None) {
+                    Ok(wait_status) => match wait_status {
+                        WaitStatus::Exited(_, res) => {
+                            log::trace!("Child exist status: {}", res);
+                            if res == 0 {
+                                return Ok(());
+                            }
+                            let err_msg = format!("Child result: {}", res);
+                            return Err(Error::NamespaceError(err_msg));
+                        }
+                        WaitStatus::Signaled(_, signal, has_dump) => {
+                            let err_msg = format!(
+                                "Child process was killed by signal: {} with core dump {}",
+                                signal, has_dump
+                            );
+                            Err(Error::NamespaceError(err_msg))
+                        }
+                        _ => {
+                            let err_msg = String::from("Unknown child process status");
+                            Err(Error::NamespaceError(err_msg))
+                        }
+                    },
+                    Err(e) => {
+                        let err_msg = format!("Waut failed: {}", e);
+                        Err(Error::NamespaceError(err_msg))
+                    }
+                }
+            }
+            Ok(ForkResult::Child) => {
+                log::trace!("Child spawning blocking task");
+                // As mount can block spawning a blocking task to create the
+                // namespace
+                let _ = task::spawn_blocking(move || {
+                    let mut netns_path = String::new();
 
-        let dir_path = Path::new(NETNS_PATH);
-        let mut mkdir_mode = Mode::empty();
-        let mut open_flags = OFlag::empty();
+                    let dir_path = Path::new(NETNS_PATH);
+                    let mut mkdir_mode = Mode::empty();
+                    let mut open_flags = OFlag::empty();
 
-        // flags in mkdir
-        mkdir_mode.insert(Mode::S_IRWXU);
-        mkdir_mode.insert(Mode::S_IRGRP);
-        mkdir_mode.insert(Mode::S_IXGRP);
-        mkdir_mode.insert(Mode::S_IROTH);
-        mkdir_mode.insert(Mode::S_IXOTH);
+                    // flags in mkdir
+                    mkdir_mode.insert(Mode::S_IRWXU);
+                    mkdir_mode.insert(Mode::S_IRGRP);
+                    mkdir_mode.insert(Mode::S_IXGRP);
+                    mkdir_mode.insert(Mode::S_IROTH);
+                    mkdir_mode.insert(Mode::S_IXOTH);
 
-        open_flags.insert(OFlag::O_RDONLY);
-        open_flags.insert(OFlag::O_CREAT);
-        open_flags.insert(OFlag::O_EXCL);
+                    open_flags.insert(OFlag::O_RDONLY);
+                    open_flags.insert(OFlag::O_CREAT);
+                    open_flags.insert(OFlag::O_EXCL);
 
-        netns_path.push_str(NETNS_PATH);
-        netns_path.push_str(ns_name);
+                    netns_path.push_str(NETNS_PATH);
+                    netns_path.push_str(&ns_name);
 
-        // creating namespaces folder if not exists
-        nix::unistd::mkdir(dir_path, mkdir_mode)?;
+                    // creating namespaces folder if not exists
+                    #[allow(clippy::collapsible_if)]
+                    if nix::sys::stat::stat(dir_path).is_err() {
+                        if nix::unistd::mkdir(dir_path, mkdir_mode).is_err() {
+                            exit(-1);
+                        }
+                    }
 
-        let ns_path = Path::new(&netns_path);
+                    let ns_path = Path::new(&netns_path);
 
-        // creating the netns file
-        let fd = nix::fcntl::open(ns_path, open_flags, Mode::empty())?;
+                    // creating the netns file
+                    let fd = match nix::fcntl::open(ns_path, open_flags, Mode::empty()) {
+                        Ok(raw_fd) => raw_fd,
+                        Err(_) => exit(-1),
+                    };
 
-        nix::unistd::close(fd)?;
+                    if nix::unistd::close(fd).is_err() {
+                        let _ = nix::unistd::unlink(ns_path);
+                        exit(-1)
+                    }
 
-        // unshare to the new network namespace
-        let ret = nix::sched::unshare(CloneFlags::CLONE_NEWNET);
+                    // unshare to the new network namespace
+                    if nix::sched::unshare(CloneFlags::CLONE_NEWNET).is_err() {
+                        let _ = nix::unistd::unlink(ns_path);
+                        exit(-1);
+                    }
 
-        let self_path = Path::new(&SELF_NS_PATH);
-        let none_fs = Path::new(&NONE_FS);
-        let none_p4: Option<&Path> = None;
-        // bind to the netns
-        nix::mount::mount(
-            Some(self_path),
-            ns_path,
-            Some(none_fs),
-            nix::mount::MsFlags::MS_BIND,
-            none_p4,
-        )?;
+                    let self_path = Path::new(&SELF_NS_PATH);
+                    let none_fs = Path::new(&NONE_FS);
+                    let none_p4: Option<&Path> = None;
+                    // bind to the netns
+                    if nix::mount::mount(
+                        Some(self_path),
+                        ns_path,
+                        Some(none_fs),
+                        nix::mount::MsFlags::MS_BIND,
+                        none_p4,
+                    )
+                    .is_err()
+                    {
+                        let _ = nix::unistd::unlink(ns_path);
+                        exit(-1);
+                    }
 
-        ret
+                    exit(0);
+                })
+                .await;
+                Ok(())
+            }
+            Err(e) => {
+                let err_msg = format!("Fork failed: {}", e);
+                Err(Error::NamespaceError(err_msg))
+            }
+        }
     }
 
+    /// Remove a network namespace
+    /// This is equivalent to `ip netns del NS_NAME`.
+    pub async fn del(ns_name: String) -> Result<(), Error> {
+        let jh = task::spawn_blocking(move || {
+            let mut netns_path = String::new();
+            netns_path.push_str(NETNS_PATH);
+            netns_path.push_str(&ns_name);
+            let ns_path = Path::new(&netns_path);
 
-    pub async fn del(ns_name: &String) -> nix::Result<()> {
-        let mut netns_path = String::new();
-        netns_path.push_str(NETNS_PATH);
-        netns_path.push_str(ns_name);
-        let ns_path = Path::new(&netns_path);
+            if nix::mount::umount2(ns_path, nix::mount::MntFlags::MNT_DETACH).is_err() {
+                let err_msg = String::from("Namespace unmound failed (are you running as root?)");
+                return Err(Error::NamespaceError(err_msg));
+            }
 
-        nix::mount::umount2(ns_path, nix::mount::MntFlags::MNT_DETACH)?;
-
-        nix::unistd::unlink(ns_path)
+            if nix::unistd::unlink(ns_path).is_err() {
+                let err_msg =
+                    String::from("Namespace file remove failed (are you running as root?)");
+                return Err(Error::NamespaceError(err_msg));
+            }
+            Ok(())
+        });
+        match jh.await {
+            Ok(r) => r,
+            Err(e) => {
+                let err_msg = format!("Namespace removal failed: {}", e);
+                Err(Error::NamespaceError(err_msg))
+            }
+        }
     }
-
 }

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -17,7 +17,6 @@ pub const NETNS_PATH: &str = "/var/run/netns/";
 pub const SELF_NS_PATH: &str = "/proc/self/ns/net";
 pub const NONE_FS: &str = "none";
 
-
 pub struct NetworkNamespace();
 
 impl NetworkNamespace {

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -1,10 +1,9 @@
-//#[cfg(feature = "tokio")]
 use tokio::task;
 
 use crate::Error;
 use nix::{
     fcntl::OFlag,
-    sched::*,
+    sched::CloneFlags,
     sys::{
         stat::Mode,
         wait::{waitpid, WaitStatus},
@@ -13,7 +12,7 @@ use nix::{
 };
 use std::{option::Option, path::Path, process::exit};
 
-pub const NETNS_PATH: &str = "/var/run/netns/";
+pub const NETNS_PATH: &str = "/run/netns/";
 pub const SELF_NS_PATH: &str = "/proc/self/ns/net";
 pub const NONE_FS: &str = "none";
 
@@ -23,112 +22,167 @@ impl NetworkNamespace {
     /// Add a new network namespace.
     /// This is equivalent to `ip netns add NS_NAME`.
     pub async fn add(ns_name: String) -> Result<(), Error> {
-        // Forking process to avoid moving called into new namespace
+        // Forking process to avoid moving caller into new namespace
         log::trace!("Forking...");
         match unsafe { fork() } {
             Ok(ForkResult::Parent { child, .. }) => {
-                log::trace!("Parent waiting child: {}", child);
-                match waitpid(child, None) {
-                    Ok(wait_status) => match wait_status {
-                        WaitStatus::Exited(_, res) => {
-                            log::trace!("Child exist status: {}", res);
-                            if res == 0 {
-                                return Ok(());
+                // as the wait is blocking spawning it in a blocking task
+                let res = task::spawn_blocking(move || {
+                    log::trace!("Parent waiting child: {}", child);
+                    match waitpid(child, None) {
+                        Ok(wait_status) => match wait_status {
+                            WaitStatus::Exited(_, res) => {
+                                log::trace!("Child exist status: {}", res);
+                                if res == 0 {
+                                    return Ok(());
+                                }
+                                let err_msg = format!("Child result: {}", res);
+                                Err(Error::NamespaceError(err_msg))
                             }
-                            let err_msg = format!("Child result: {}", res);
-                            return Err(Error::NamespaceError(err_msg));
-                        }
-                        WaitStatus::Signaled(_, signal, has_dump) => {
-                            let err_msg = format!(
-                                "Child process was killed by signal: {} with core dump {}",
-                                signal, has_dump
-                            );
+                            WaitStatus::Signaled(_, signal, has_dump) => {
+                                let err_msg = format!(
+                                    "Child process was killed by signal: {} with core dump {}",
+                                    signal, has_dump
+                                );
+                                Err(Error::NamespaceError(err_msg))
+                            }
+                            _ => {
+                                let err_msg = String::from("Unknown child process status");
+                                Err(Error::NamespaceError(err_msg))
+                            }
+                        },
+                        Err(e) => {
+                            let err_msg = format!("wait failed: {}", e);
                             Err(Error::NamespaceError(err_msg))
                         }
-                        _ => {
-                            let err_msg = String::from("Unknown child process status");
-                            Err(Error::NamespaceError(err_msg))
-                        }
-                    },
+                    }
+                })
+                .await;
+                match res {
+                    Ok(r) => r,
                     Err(e) => {
-                        let err_msg = format!("Waut failed: {}", e);
+                        let err_msg = format!("wait failed: {}", e);
+                        log::error!("{}", err_msg);
                         Err(Error::NamespaceError(err_msg))
                     }
                 }
             }
             Ok(ForkResult::Child) => {
-                log::trace!("Child spawning blocking task");
-                // As mount can block spawning a blocking task to create the
-                // namespace
-                let _ = task::spawn_blocking(move || {
-                    let mut netns_path = String::new();
+                log::trace!("Child creating namespace");
 
-                    let dir_path = Path::new(NETNS_PATH);
-                    let mut mkdir_mode = Mode::empty();
-                    let mut open_flags = OFlag::empty();
+                let mut netns_path = String::new();
 
-                    // flags in mkdir
-                    mkdir_mode.insert(Mode::S_IRWXU);
-                    mkdir_mode.insert(Mode::S_IRGRP);
-                    mkdir_mode.insert(Mode::S_IXGRP);
-                    mkdir_mode.insert(Mode::S_IROTH);
-                    mkdir_mode.insert(Mode::S_IXOTH);
+                let dir_path = Path::new(NETNS_PATH);
+                let mut mkdir_mode = Mode::empty();
+                let mut open_flags = OFlag::empty();
+                let mut mount_flags = nix::mount::MsFlags::empty();
+                let mut setns_flags = CloneFlags::empty();
+                let none_fs = Path::new(&NONE_FS);
+                let none_p4: Option<&Path> = None;
 
-                    open_flags.insert(OFlag::O_RDONLY);
-                    open_flags.insert(OFlag::O_CREAT);
-                    open_flags.insert(OFlag::O_EXCL);
+                // flags in mkdir
+                mkdir_mode.insert(Mode::S_IRWXU);
+                mkdir_mode.insert(Mode::S_IRGRP);
+                mkdir_mode.insert(Mode::S_IXGRP);
+                mkdir_mode.insert(Mode::S_IROTH);
+                mkdir_mode.insert(Mode::S_IXOTH);
 
-                    netns_path.push_str(NETNS_PATH);
-                    netns_path.push_str(&ns_name);
+                open_flags.insert(OFlag::O_RDONLY);
+                open_flags.insert(OFlag::O_CREAT);
+                open_flags.insert(OFlag::O_EXCL);
 
-                    // creating namespaces folder if not exists
-                    #[allow(clippy::collapsible_if)]
-                    if nix::sys::stat::stat(dir_path).is_err() {
-                        if nix::unistd::mkdir(dir_path, mkdir_mode).is_err() {
-                            exit(-1);
-                        }
-                    }
+                netns_path.push_str(NETNS_PATH);
+                netns_path.push_str(&ns_name);
 
-                    let ns_path = Path::new(&netns_path);
-
-                    // creating the netns file
-                    let fd = match nix::fcntl::open(ns_path, open_flags, Mode::empty()) {
-                        Ok(raw_fd) => raw_fd,
-                        Err(_) => exit(-1),
-                    };
-
-                    if nix::unistd::close(fd).is_err() {
-                        let _ = nix::unistd::unlink(ns_path);
-                        exit(-1)
-                    }
-
-                    // unshare to the new network namespace
-                    if nix::sched::unshare(CloneFlags::CLONE_NEWNET).is_err() {
-                        let _ = nix::unistd::unlink(ns_path);
+                // creating namespaces folder if not exists
+                #[allow(clippy::collapsible_if)]
+                if nix::sys::stat::stat(dir_path).is_err() {
+                    if nix::unistd::mkdir(dir_path, mkdir_mode).is_err() {
                         exit(-1);
                     }
+                }
 
-                    let self_path = Path::new(&SELF_NS_PATH);
-                    let none_fs = Path::new(&NONE_FS);
-                    let none_p4: Option<&Path> = None;
-                    // bind to the netns
-                    if nix::mount::mount(
-                        Some(self_path),
-                        ns_path,
-                        Some(none_fs),
-                        nix::mount::MsFlags::MS_BIND,
-                        none_p4,
-                    )
-                    .is_err()
-                    {
-                        let _ = nix::unistd::unlink(ns_path);
-                        exit(-1);
-                    }
+                mount_flags.insert(nix::mount::MsFlags::MS_BIND);
+                mount_flags.insert(nix::mount::MsFlags::MS_REC);
 
-                    exit(0);
-                })
-                .await;
-                Ok(())
+                if nix::mount::mount(
+                    Some(Path::new(dir_path)),
+                    dir_path,
+                    Some(none_fs),
+                    mount_flags,
+                    none_p4,
+                )
+                .is_err()
+                {
+                    exit(-1);
+                }
+
+                mount_flags = nix::mount::MsFlags::empty();
+                mount_flags.insert(nix::mount::MsFlags::MS_SHARED);
+                mount_flags.insert(nix::mount::MsFlags::MS_REC);
+                if nix::mount::mount(
+                    Some(Path::new("")),
+                    dir_path,
+                    Some(none_fs),
+                    mount_flags,
+                    none_p4,
+                )
+                .is_err()
+                {
+                    exit(-1);
+                }
+
+                let ns_path = Path::new(&netns_path);
+
+                // creating the netns file
+                let fd = match nix::fcntl::open(ns_path, open_flags, Mode::empty()) {
+                    Ok(raw_fd) => raw_fd,
+                    Err(_) => exit(-1),
+                };
+
+                if nix::unistd::close(fd).is_err() {
+                    let _ = nix::unistd::unlink(ns_path);
+                    exit(-1)
+                }
+
+                // unshare to the new network namespace
+                if nix::sched::unshare(CloneFlags::CLONE_NEWNET).is_err() {
+                    let _ = nix::unistd::unlink(ns_path);
+                    exit(-1);
+                }
+                open_flags = OFlag::empty();
+                open_flags.insert(OFlag::O_RDONLY);
+                open_flags.insert(OFlag::O_CLOEXEC);
+
+                let fd = match nix::fcntl::open(Path::new(&SELF_NS_PATH), open_flags, Mode::empty())
+                {
+                    Ok(raw_fd) => raw_fd,
+                    Err(_) => exit(-1),
+                };
+
+                let self_path = Path::new(&SELF_NS_PATH);
+
+                // bind to the netns
+                if nix::mount::mount(
+                    Some(self_path),
+                    ns_path,
+                    Some(none_fs),
+                    nix::mount::MsFlags::MS_BIND,
+                    none_p4,
+                )
+                .is_err()
+                {
+                    let _ = nix::unistd::unlink(ns_path);
+                    exit(-1);
+                }
+
+                setns_flags.insert(CloneFlags::CLONE_NEWNET);
+                if nix::sched::setns(fd, setns_flags).is_err() {
+                    let _ = nix::unistd::unlink(ns_path);
+                    exit(-1);
+                }
+
+                exit(0)
             }
             Err(e) => {
                 let err_msg = format!("Fork failed: {}", e);

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -23,165 +23,13 @@ impl NetworkNamespace {
     /// This is equivalent to `ip netns add NS_NAME`.
     pub async fn add(ns_name: String) -> Result<(), Error> {
         // Forking process to avoid moving caller into new namespace
+        NetworkNamespace::prep_for_fork()?;
         log::trace!("Forking...");
         match unsafe { fork() } {
-            Ok(ForkResult::Parent { child, .. }) => {
-                // as the wait is blocking spawning it in a blocking task
-                let res = task::spawn_blocking(move || {
-                    log::trace!("Parent waiting child: {}", child);
-                    match waitpid(child, None) {
-                        Ok(wait_status) => match wait_status {
-                            WaitStatus::Exited(_, res) => {
-                                log::trace!("Child exist status: {}", res);
-                                if res == 0 {
-                                    return Ok(());
-                                }
-                                let err_msg = format!("Child result: {}", res);
-                                Err(Error::NamespaceError(err_msg))
-                            }
-                            WaitStatus::Signaled(_, signal, has_dump) => {
-                                let err_msg = format!(
-                                    "Child process was killed by signal: {} with core dump {}",
-                                    signal, has_dump
-                                );
-                                Err(Error::NamespaceError(err_msg))
-                            }
-                            _ => {
-                                let err_msg = String::from("Unknown child process status");
-                                Err(Error::NamespaceError(err_msg))
-                            }
-                        },
-                        Err(e) => {
-                            let err_msg = format!("wait failed: {}", e);
-                            Err(Error::NamespaceError(err_msg))
-                        }
-                    }
-                })
-                .await;
-                match res {
-                    Ok(r) => r,
-                    Err(e) => {
-                        let err_msg = format!("wait failed: {}", e);
-                        log::error!("{}", err_msg);
-                        Err(Error::NamespaceError(err_msg))
-                    }
-                }
-            }
+            Ok(ForkResult::Parent { child, .. }) => NetworkNamespace::parent_process(child),
             Ok(ForkResult::Child) => {
-                log::trace!("Child creating namespace");
-
-                let mut netns_path = String::new();
-
-                let dir_path = Path::new(NETNS_PATH);
-                let mut mkdir_mode = Mode::empty();
-                let mut open_flags = OFlag::empty();
-                let mut mount_flags = nix::mount::MsFlags::empty();
-                let mut setns_flags = CloneFlags::empty();
-                let none_fs = Path::new(&NONE_FS);
-                let none_p4: Option<&Path> = None;
-
-                // flags in mkdir
-                mkdir_mode.insert(Mode::S_IRWXU);
-                mkdir_mode.insert(Mode::S_IRGRP);
-                mkdir_mode.insert(Mode::S_IXGRP);
-                mkdir_mode.insert(Mode::S_IROTH);
-                mkdir_mode.insert(Mode::S_IXOTH);
-
-                open_flags.insert(OFlag::O_RDONLY);
-                open_flags.insert(OFlag::O_CREAT);
-                open_flags.insert(OFlag::O_EXCL);
-
-                netns_path.push_str(NETNS_PATH);
-                netns_path.push_str(&ns_name);
-
-                // creating namespaces folder if not exists
-                #[allow(clippy::collapsible_if)]
-                if nix::sys::stat::stat(dir_path).is_err() {
-                    if nix::unistd::mkdir(dir_path, mkdir_mode).is_err() {
-                        exit(-1);
-                    }
-                }
-
-                mount_flags.insert(nix::mount::MsFlags::MS_BIND);
-                mount_flags.insert(nix::mount::MsFlags::MS_REC);
-
-                if nix::mount::mount(
-                    Some(Path::new(dir_path)),
-                    dir_path,
-                    Some(none_fs),
-                    mount_flags,
-                    none_p4,
-                )
-                .is_err()
-                {
-                    exit(-1);
-                }
-
-                mount_flags = nix::mount::MsFlags::empty();
-                mount_flags.insert(nix::mount::MsFlags::MS_SHARED);
-                mount_flags.insert(nix::mount::MsFlags::MS_REC);
-                if nix::mount::mount(
-                    Some(Path::new("")),
-                    dir_path,
-                    Some(none_fs),
-                    mount_flags,
-                    none_p4,
-                )
-                .is_err()
-                {
-                    exit(-1);
-                }
-
-                let ns_path = Path::new(&netns_path);
-
-                // creating the netns file
-                let fd = match nix::fcntl::open(ns_path, open_flags, Mode::empty()) {
-                    Ok(raw_fd) => raw_fd,
-                    Err(_) => exit(-1),
-                };
-
-                if nix::unistd::close(fd).is_err() {
-                    let _ = nix::unistd::unlink(ns_path);
-                    exit(-1)
-                }
-
-                // unshare to the new network namespace
-                if nix::sched::unshare(CloneFlags::CLONE_NEWNET).is_err() {
-                    let _ = nix::unistd::unlink(ns_path);
-                    exit(-1);
-                }
-                open_flags = OFlag::empty();
-                open_flags.insert(OFlag::O_RDONLY);
-                open_flags.insert(OFlag::O_CLOEXEC);
-
-                let fd = match nix::fcntl::open(Path::new(&SELF_NS_PATH), open_flags, Mode::empty())
-                {
-                    Ok(raw_fd) => raw_fd,
-                    Err(_) => exit(-1),
-                };
-
-                let self_path = Path::new(&SELF_NS_PATH);
-
-                // bind to the netns
-                if nix::mount::mount(
-                    Some(self_path),
-                    ns_path,
-                    Some(none_fs),
-                    nix::mount::MsFlags::MS_BIND,
-                    none_p4,
-                )
-                .is_err()
-                {
-                    let _ = nix::unistd::unlink(ns_path);
-                    exit(-1);
-                }
-
-                setns_flags.insert(CloneFlags::CLONE_NEWNET);
-                if nix::sched::setns(fd, setns_flags).is_err() {
-                    let _ = nix::unistd::unlink(ns_path);
-                    exit(-1);
-                }
-
+                let netns_path = NetworkNamespace::child_process(ns_name)?;
+                NetworkNamespace::unshare_processing(netns_path)?;
                 exit(0)
             }
             Err(e) => {
@@ -201,7 +49,7 @@ impl NetworkNamespace {
             let ns_path = Path::new(&netns_path);
 
             if nix::mount::umount2(ns_path, nix::mount::MntFlags::MNT_DETACH).is_err() {
-                let err_msg = String::from("Namespace unmound failed (are you running as root?)");
+                let err_msg = String::from("Namespace unmount failed (are you running as root?)");
                 return Err(Error::NamespaceError(err_msg));
             }
 
@@ -219,5 +67,235 @@ impl NetworkNamespace {
                 Err(Error::NamespaceError(err_msg))
             }
         }
+    }
+
+    pub fn prep_for_fork() -> Result<(), Error> {
+        // Placeholder function, nothing to do here.
+        Ok(())
+    }
+
+    /// This is the parent process form the fork, it waits for the
+    /// child to exit properly
+    pub fn parent_process(child: nix::unistd::Pid) -> Result<(), Error> {
+        log::trace!("parent_process child PID: {}", child);
+        log::trace!("Waiting for child to finish...");
+        match waitpid(child, None) {
+            Ok(wait_status) => match wait_status {
+                WaitStatus::Exited(_, res) => {
+                    log::trace!("Child exited with: {}", res);
+                    if res == 0 {
+                        return Ok(());
+                    }
+                    log::error!("Error child result: {}", res);
+                    let err_msg = format!("Error child result: {}", res);
+                    Err(Error::NamespaceError(err_msg))
+                }
+                WaitStatus::Signaled(_, signal, has_dump) => {
+                    log::error!("Error child killed by signal: {}", signal);
+                    let err_msg = format!(
+                        "Error child process was killed by signal: {} with core dump {}",
+                        signal, has_dump
+                    );
+                    Err(Error::NamespaceError(err_msg))
+                }
+                _ => {
+                    log::error!("Unknown child process status");
+                    let err_msg = String::from("Unknown child process status");
+                    Err(Error::NamespaceError(err_msg))
+                }
+            },
+            Err(e) => {
+                log::error!("wait error: {}", e);
+                let err_msg = format!("wait error: {}", e);
+                Err(Error::NamespaceError(err_msg))
+            }
+        }
+    }
+
+    /// This is the child process, it will actually create the namespace
+    /// resources. It creates the folder and namespace file.
+    /// Returns the namespace file path
+    pub fn child_process(ns_name: String) -> Result<String, Error> {
+        log::trace!("child_process will create the namespace");
+
+        let mut netns_path = String::new();
+
+        let dir_path = Path::new(NETNS_PATH);
+        let mut mkdir_mode = Mode::empty();
+        let mut open_flags = OFlag::empty();
+        let mut mount_flags = nix::mount::MsFlags::empty();
+        let none_fs = Path::new(&NONE_FS);
+        let none_p4: Option<&Path> = None;
+
+        // flags in mkdir
+        mkdir_mode.insert(Mode::S_IRWXU);
+        mkdir_mode.insert(Mode::S_IRGRP);
+        mkdir_mode.insert(Mode::S_IXGRP);
+        mkdir_mode.insert(Mode::S_IROTH);
+        mkdir_mode.insert(Mode::S_IXOTH);
+
+        open_flags.insert(OFlag::O_RDONLY);
+        open_flags.insert(OFlag::O_CREAT);
+        open_flags.insert(OFlag::O_EXCL);
+
+        netns_path.push_str(NETNS_PATH);
+        netns_path.push_str(&ns_name);
+
+        // creating namespaces folder if not exists
+        #[allow(clippy::collapsible_if)]
+        if nix::sys::stat::stat(dir_path).is_err() {
+            match nix::unistd::mkdir(dir_path, mkdir_mode) {
+                Err(e) => {
+                    log::error!("mkdir error: {}", e);
+                    let err_msg = format!("mkdir error: {}", e);
+                    return Err(Error::NamespaceError(err_msg));
+                }
+                Ok(_) => (),
+            }
+        }
+
+        // Check try to mount /run/netns, with MS_REC | MS_SHARED
+        // if fails creates the mount with MS_BIND | MS_REC
+        // this is the same strategy used by `ip netns add NS`
+        mount_flags.insert(nix::mount::MsFlags::MS_REC);
+        mount_flags.insert(nix::mount::MsFlags::MS_SHARED);
+        if nix::mount::mount(
+            Some(Path::new("")),
+            dir_path,
+            Some(none_fs),
+            mount_flags,
+            none_p4,
+        )
+        .is_err()
+        {
+            mount_flags = nix::mount::MsFlags::empty();
+            mount_flags.insert(nix::mount::MsFlags::MS_BIND);
+            mount_flags.insert(nix::mount::MsFlags::MS_REC);
+
+            match nix::mount::mount(
+                Some(Path::new(dir_path)),
+                dir_path,
+                Some(none_fs),
+                mount_flags,
+                none_p4,
+            ) {
+                Err(e) => {
+                    log::error!("mount error: {}", e);
+                    let err_msg = format!("mount error: {}", e);
+                    return Err(Error::NamespaceError(err_msg));
+                }
+                Ok(_) => (),
+            }
+        }
+
+        mount_flags = nix::mount::MsFlags::empty();
+        mount_flags.insert(nix::mount::MsFlags::MS_REC);
+        mount_flags.insert(nix::mount::MsFlags::MS_SHARED);
+        match nix::mount::mount(
+            Some(Path::new("")),
+            dir_path,
+            Some(none_fs),
+            mount_flags,
+            none_p4,
+        ) {
+            Err(e) => {
+                log::error!("mount error: {}", e);
+                let err_msg = format!("mount error: {}", e);
+                return Err(Error::NamespaceError(err_msg));
+            }
+            Ok(_) => (),
+        }
+
+        let ns_path = Path::new(&netns_path);
+
+        // creating the netns file
+        let fd = match nix::fcntl::open(ns_path, open_flags, Mode::empty()) {
+            Ok(raw_fd) => raw_fd,
+            Err(e) => {
+                log::error!("open error: {}", e);
+                let err_msg = format!("open error: {}", e);
+                return Err(Error::NamespaceError(err_msg));
+            }
+        };
+
+        match nix::unistd::close(fd) {
+            Err(e) => {
+                log::error!("close error: {}", e);
+                let err_msg = format!("close error: {}", e);
+                let _ = nix::unistd::unlink(ns_path);
+                return Err(Error::NamespaceError(err_msg));
+            }
+            Ok(_) => (),
+        }
+
+        Ok(netns_path)
+    }
+
+    /// This function unshare the calling process and move into
+    /// the given network namespace
+    #[allow(unused)]
+    pub fn unshare_processing(netns_path: String) -> Result<(), Error> {
+        let mut setns_flags = CloneFlags::empty();
+        let mut open_flags = OFlag::empty();
+        let ns_path = Path::new(&netns_path);
+
+        let none_fs = Path::new(&NONE_FS);
+        let none_p4: Option<&Path> = None;
+
+        // unshare to the new network namespace
+        match nix::sched::unshare(CloneFlags::CLONE_NEWNET) {
+            Err(e) => {
+                log::error!("unshare error: {}", e);
+                let err_msg = format!("unshare error: {}", e);
+                let _ = nix::unistd::unlink(ns_path);
+                return Err(Error::NamespaceError(err_msg));
+            }
+            Ok(_) => (),
+        }
+
+        open_flags = OFlag::empty();
+        open_flags.insert(OFlag::O_RDONLY);
+        open_flags.insert(OFlag::O_CLOEXEC);
+
+        let fd = match nix::fcntl::open(Path::new(&SELF_NS_PATH), open_flags, Mode::empty()) {
+            Ok(raw_fd) => raw_fd,
+            Err(e) => {
+                log::error!("open error: {}", e);
+                let err_msg = format!("open error: {}", e);
+                return Err(Error::NamespaceError(err_msg));
+            }
+        };
+
+        let self_path = Path::new(&SELF_NS_PATH);
+
+        // bind to the netns
+        match nix::mount::mount(
+            Some(self_path),
+            ns_path,
+            Some(none_fs),
+            nix::mount::MsFlags::MS_BIND,
+            none_p4,
+        ) {
+            Err(e) => {
+                log::error!("mount error: {}", e);
+                let err_msg = format!("mount error: {}", e);
+                let _ = nix::unistd::unlink(ns_path);
+                return Err(Error::NamespaceError(err_msg));
+            }
+            Ok(_) => (),
+        }
+
+        setns_flags.insert(CloneFlags::CLONE_NEWNET);
+        match nix::sched::setns(fd, setns_flags) {
+            Err(e) => {
+                log::error!("setns error: {}", e);
+                let err_msg = format!("setns error: {}", e);
+                let _ = nix::unistd::unlink(ns_path);
+                return Err(Error::NamespaceError(err_msg));
+            }
+            Ok(_) => (),
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
I will use this PR to keep track of the implementation of the creation and deletion of network namespaces in a similar way as done by `ip netns` command (#38).


- [x] Async network namespace creation
- [x] Async network namespace deletion
- [x] example
- [x] docs