### PR TITLE
netlink-packet-route: VXLAN port attribute must be parsed as u16_be

### DIFF
--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -650,7 +650,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoVxlan {
                 let high = parse_u16(&payload[2..]).context(err)?;
                 PortRange((low, high))
             }
-            IFLA_VXLAN_PORT => Port(parse_u16(payload).context("invalid IFLA_VXLAN_PORT value")?),
+            IFLA_VXLAN_PORT => {
+                Port(parse_u16_be(payload).context("invalid IFLA_VXLAN_PORT value")?)
+            }
             IFLA_VXLAN_UDP_CSUM => {
                 UDPCsum(parse_u8(payload).context("invalid IFLA_VXLAN_UDP_CSUM value")?)
             }


### PR DESCRIPTION
Currently it is returning a wrong value. e.g:

For a VXLAN with a dst_port "4789" the value that rust-netlink returns
is "46354".

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>