### PR TITLE
WIP: rtnetlink/addr: Support adding arbitrary IP address

### DIFF
--- a/rtnetlink/src/addr/add.rs
+++ b/rtnetlink/src/addr/add.rs
@@ -70,6 +70,10 @@ impl AddressAddRequest {
         AddressAddRequest { handle, message }
     }
 
+    pub(crate) fn new_raw(handle: Handle, message: AddressMessage) -> Self {
+        AddressAddRequest { handle, message }
+    }
+
     /// Execute the request.
     pub async fn execute(self) -> Result<(), Error> {
         let AddressAddRequest {

--- a/rtnetlink/src/addr/handle.rs
+++ b/rtnetlink/src/addr/handle.rs
@@ -22,6 +22,10 @@ impl AddressHandle {
         AddressAddRequest::new(self.0.clone(), index, address, prefix_len)
     }
 
+    pub fn add_raw(&self, address: AddressMessage) -> AddressAddRequest {
+        AddressAddRequest::new_raw(self.0.clone(), address)
+    }
+
     /// Delete the given address
     pub fn del(&self, address: AddressMessage) -> AddressDelRequest {
         AddressDelRequest::new(self.0.clone(), address)


### PR DESCRIPTION
Introducing `AddressHandle::add_raw()` allowing user to add IP
address using netlink `AddressMesssage`.

The most useful options user could be benefit from would be:
 * `valid_lft` and `preferred_lft`. Widely used in DHCP/IPv6-RA.
 * metric