### PR TITLE
Add infokind and data for wireguard

### DIFF
--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -32,6 +32,7 @@ const VTI: &str = "vti";
 const VRF: &str = "vrf";
 const GTP: &str = "gtp";
 const IPOIB: &str = "ipoib";
+const WIREGUARD: &str = "wireguard";
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Info {
@@ -226,6 +227,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for VecInfo {
                                 }
                                 InfoData::Ipoib(v)
                             }
+                            InfoKind::Wireguard => InfoData::Wireguard(payload.to_vec()),
                             InfoKind::Other(_) => InfoData::Other(payload.to_vec()),
                         };
                         res.push(Info::Data(info_data));
@@ -265,6 +267,7 @@ pub enum InfoData {
     Vrf(Vec<InfoVrf>),
     Gtp(Vec<u8>),
     Ipoib(Vec<InfoIpoib>),
+    Wireguard(Vec<u8>),
     Other(Vec<u8>),
 }
 
@@ -295,6 +298,7 @@ impl Nla for InfoData {
                 | GreTun6(ref bytes)
                 | Vti(ref bytes)
                 | Gtp(ref bytes)
+                | Wireguard(ref bytes)
                 | Other(ref bytes)
                 => bytes.len(),
         }
@@ -326,6 +330,7 @@ impl Nla for InfoData {
                 | GreTun6(ref bytes)
                 | Vti(ref bytes)
                 | Gtp(ref bytes)
+                | Wireguard(ref bytes)
                 | Other(ref bytes)
                 => buffer.copy_from_slice(bytes),
         }
@@ -360,6 +365,7 @@ pub enum InfoKind {
     Vrf,
     Gtp,
     Ipoib,
+    Wireguard,
     Other(String),
 }
 
@@ -389,6 +395,7 @@ impl Nla for InfoKind {
             Vrf => VRF.len(),
             Gtp => GTP.len(),
             Ipoib => IPOIB.len(),
+            Wireguard => WIREGUARD.len(),
             Other(ref s) => s.len(),
         };
         len + 1
@@ -419,6 +426,7 @@ impl Nla for InfoKind {
             Vrf => VRF,
             Gtp => GTP,
             Ipoib => IPOIB,
+            Wireguard => WIREGUARD,
             Other(ref s) => s.as_str(),
         };
         buffer[..s.len()].copy_from_slice(s.as_bytes());
@@ -462,6 +470,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoKind {
             VRF => Vrf,
             GTP => Gtp,
             IPOIB => Ipoib,
+            WIREGUARD => Wireguard,
             _ => Other(s),
         })
     }

--- a/rtnetlink/src/link/mod.rs
+++ b/rtnetlink/src/link/mod.rs
@@ -12,3 +12,6 @@ pub use self::get::*;
 
 mod set;
 pub use self::set::*;
+
+#[cfg(test)]
+mod test;

--- a/rtnetlink/src/link/test.rs
+++ b/rtnetlink/src/link/test.rs
@@ -1,0 +1,55 @@
+use futures::stream::TryStreamExt;
+use tokio::runtime::Runtime;
+
+use crate::{
+    new_connection,
+    packet::rtnl::link::{
+        nlas::{Info, InfoKind, Nla},
+        LinkMessage,
+    },
+    Error,
+    LinkHandle,
+};
+
+
+const IFACE_NAME: &str = "wg142"; // rand?
+
+#[test]
+fn create_get_delete_wg() {
+    let mut rt = Runtime::new().unwrap();
+    let handle = rt.block_on(_create_wg());
+    assert!(handle.is_ok());
+    let mut handle = handle.unwrap();
+    let msg = rt.block_on(_get_wg(&mut handle));
+    assert!(msg.is_ok());
+    let msg = msg.unwrap();
+    assert!(has_nla(&msg, &Nla::Info(vec![Info::Kind(InfoKind::Wireguard)])));
+    assert!(rt.block_on(_del_wg(&mut handle, msg.header.index)).is_ok());
+}
+
+fn has_nla(msg: &LinkMessage, nla: &Nla) -> bool {
+    msg.nlas.iter().any(|x| x == nla)
+}
+
+async fn _create_wg() -> Result<LinkHandle, Error> {
+    let (conn, handle, _) = new_connection().unwrap();
+    tokio::spawn(conn);
+    let link_handle = handle.link();
+    let mut req = link_handle.add();
+    let mutator = req.message_mut();
+    let info = Nla::Info(vec![Info::Kind(InfoKind::Wireguard)]);
+    mutator.nlas.push(info);
+    mutator.nlas.push(Nla::IfName(IFACE_NAME.to_owned()));
+    req.execute().await?;
+    Ok(link_handle)
+}
+
+async fn _get_wg(handle: &mut LinkHandle) -> Result<LinkMessage, Error> {
+    let mut links = handle.get().set_name_filter(IFACE_NAME.to_owned()).execute();
+    let msg = links.try_next().await?;
+    msg.ok_or_else(|| Error::RequestFailed)
+}
+
+async fn _del_wg(handle: &mut LinkHandle, index: u32) -> Result<(), Error> {
+    handle.del(index).execute().await
+}


### PR DESCRIPTION
Add bare minimum support for creating a wireguard interface without
allocating an extra string.