### PR TITLE
rtnetlink: use macros in response handling

### DIFF
--- a/netlink-proto/src/connection.rs
+++ b/netlink-proto/src/connection.rs
@@ -222,7 +222,7 @@ where
                     // hence closing the channel and signaling the
                     // handle that no more messages are expected.
                     Noop | Done | Ack(_) => {
-                        trace!("not forwarding Ack/Done message to the handle");
+                        trace!("not forwarding Noop/Ack/Done message to the handle");
                         continue;
                     }
                     // I'm not sure how we should handle overrun messages

--- a/rtnetlink/src/addr/add.rs
+++ b/rtnetlink/src/addr/add.rs
@@ -5,7 +5,6 @@ use netlink_packet_route::{
     nlas::address::Nla,
     AddressMessage,
     NetlinkMessage,
-    NetlinkPayload,
     RtnlMessage,
     AF_INET,
     AF_INET6,
@@ -15,7 +14,7 @@ use netlink_packet_route::{
     NLM_F_REQUEST,
 };
 
-use crate::{Error, Handle};
+use crate::{try_nl, Error, Handle};
 
 /// A request to create a new address. This is equivalent to the `ip address add` commands.
 pub struct AddressAddRequest {
@@ -81,9 +80,7 @@ impl AddressAddRequest {
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
-            if let NetlinkPayload::Error(err) = message.payload {
-                return Err(Error::NetlinkError(err));
-            }
+            try_nl!(message);
         }
         Ok(())
     }

--- a/rtnetlink/src/addr/del.rs
+++ b/rtnetlink/src/addr/del.rs
@@ -1,14 +1,8 @@
 use futures::stream::StreamExt;
 
 use crate::{
-    packet::{
-        AddressMessage,
-        NetlinkMessage,
-        NetlinkPayload,
-        RtnlMessage,
-        NLM_F_ACK,
-        NLM_F_REQUEST,
-    },
+    packet::{AddressMessage, NetlinkMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST},
+    try_nl,
     Error,
     Handle,
 };
@@ -34,9 +28,7 @@ impl AddressDelRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
         let mut response = handle.request(req)?;
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload {
-                return Err(Error::NetlinkError(e));
-            }
+            try_nl!(msg);
         }
         Ok(())
     }

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -37,3 +37,5 @@ pub mod proto {
     pub use netlink_proto::{Connection, ConnectionHandle, Error, ErrorKind};
 }
 pub use netlink_proto::sys;
+
+mod macros;

--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -5,7 +5,6 @@ use crate::{
         nlas::link::{Info, InfoData, InfoKind, InfoVlan, InfoVxlan, Nla, VethInfo},
         LinkMessage,
         NetlinkMessage,
-        NetlinkPayload,
         RtnlMessage,
         IFF_UP,
         NLM_F_ACK,
@@ -13,6 +12,7 @@ use crate::{
         NLM_F_EXCL,
         NLM_F_REQUEST,
     },
+    try_nl,
     Error,
     Handle,
 };
@@ -265,9 +265,7 @@ impl LinkAddRequest {
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
-            if let NetlinkPayload::Error(err) = message.payload {
-                return Err(Error::NetlinkError(err));
-            }
+            try_nl!(message);
         }
         Ok(())
     }

--- a/rtnetlink/src/link/del.rs
+++ b/rtnetlink/src/link/del.rs
@@ -4,13 +4,13 @@ use crate::{
     packet::{
         LinkMessage,
         NetlinkMessage,
-        NetlinkPayload,
         RtnlMessage,
         NLM_F_ACK,
         NLM_F_CREATE,
         NLM_F_EXCL,
         NLM_F_REQUEST,
     },
+    try_nl,
     Error,
     Handle,
 };
@@ -38,9 +38,7 @@ impl LinkDelRequest {
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
-            if let NetlinkPayload::Error(err) = message.payload {
-                return Err(Error::NetlinkError(err));
-            }
+            try_nl!(message)
         }
         Ok(())
     }

--- a/rtnetlink/src/link/set.rs
+++ b/rtnetlink/src/link/set.rs
@@ -3,7 +3,6 @@ use crate::{
         nlas::link::Nla,
         LinkMessage,
         NetlinkMessage,
-        NetlinkPayload,
         RtnlMessage,
         IFF_NOARP,
         IFF_PROMISC,
@@ -13,6 +12,7 @@ use crate::{
         NLM_F_EXCL,
         NLM_F_REQUEST,
     },
+    try_nl,
     Error,
     Handle,
 };
@@ -42,9 +42,7 @@ impl LinkSetRequest {
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
-            if let NetlinkPayload::Error(err) = message.payload {
-                return Err(Error::NetlinkError(err));
-            }
+            try_nl!(message);
         }
         Ok(())
     }

--- a/rtnetlink/src/macros.rs
+++ b/rtnetlink/src/macros.rs
@@ -1,0 +1,29 @@
+#[macro_export]
+macro_rules! try_rtnl {
+    ($msg: expr, $message_type:path) => {{
+        use netlink_packet_route::{NetlinkMessage, NetlinkPayload, RtnlMessage};
+        use $crate::Error;
+
+        let (header, payload) = $msg.into_parts();
+        match payload {
+            NetlinkPayload::InnerMessage($message_type(msg)) => msg,
+            NetlinkPayload::Error(err) => return Err(Error::NetlinkError(err)),
+            _ => {
+                return Err(Error::UnexpectedMessage(NetlinkMessage::new(
+                    header, payload,
+                )))
+            }
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! try_nl {
+    ($msg: expr) => {{
+        use netlink_packet_route::NetlinkPayload;
+        use $crate::Error;
+        if let NetlinkPayload::Error(err) = $msg.payload {
+            return Err(Error::NetlinkError(err));
+        }
+    }};
+}

--- a/rtnetlink/src/route/add.rs
+++ b/rtnetlink/src/route/add.rs
@@ -5,12 +5,11 @@ use netlink_packet_route::{
     constants::*,
     nlas::route::Nla,
     NetlinkMessage,
-    NetlinkPayload,
     RouteMessage,
     RtnlMessage,
 };
 
-use crate::{Error, Handle};
+use crate::{try_nl, Error, Handle};
 
 /// A request to create a new route. This is equivalent to the `ip route add` commands.
 struct RouteAddRequest {
@@ -85,9 +84,7 @@ impl RouteAddRequest {
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
-            if let NetlinkPayload::Error(err) = message.payload {
-                return Err(Error::NetlinkError(err));
-            }
+            try_nl!(message);
         }
         Ok(())
     }

--- a/rtnetlink/src/rule/add.rs
+++ b/rtnetlink/src/rule/add.rs
@@ -5,12 +5,11 @@ use netlink_packet_route::{
     constants::*,
     nlas::rule::Nla,
     NetlinkMessage,
-    NetlinkPayload,
     RtnlMessage,
     RuleMessage,
 };
 
-use crate::{Error, Handle};
+use crate::{try_nl, Error, Handle};
 
 /// A request to create a new rule. This is equivalent to the `ip rule add` command.
 struct RuleAddRequest {
@@ -71,9 +70,7 @@ impl RuleAddRequest {
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
-            if let NetlinkPayload::Error(err) = message.payload {
-                return Err(Error::NetlinkError(err));
-            }
+            try_nl!(message);
         }
         Ok(())
     }

--- a/rtnetlink/src/rule/del.rs
+++ b/rtnetlink/src/rule/del.rs
@@ -1,7 +1,8 @@
 use futures::stream::StreamExt;
 
 use crate::{
-    packet::{NetlinkMessage, NetlinkPayload, RtnlMessage, RuleMessage, NLM_F_ACK, NLM_F_REQUEST},
+    packet::{NetlinkMessage, RtnlMessage, RuleMessage, NLM_F_ACK, NLM_F_REQUEST},
+    try_nl,
     Error,
     Handle,
 };
@@ -27,9 +28,7 @@ impl RuleDelRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
         let mut response = handle.request(req)?;
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload {
-                return Err(Error::NetlinkError(e));
-            }
+            try_nl!(msg);
         }
         Ok(())
     }

--- a/rtnetlink/src/rule/get.rs
+++ b/rtnetlink/src/rule/get.rs
@@ -5,15 +5,9 @@ use futures::{
     FutureExt,
 };
 
-use netlink_packet_route::{
-    constants::*,
-    NetlinkMessage,
-    NetlinkPayload,
-    RtnlMessage,
-    RuleMessage,
-};
+use netlink_packet_route::{constants::*, NetlinkMessage, RtnlMessage, RuleMessage};
 
-use crate::{Error, Handle};
+use crate::{try_rtnl, Error, Handle};
 
 pub struct RuleGetRequest {
     handle: Handle,
@@ -51,16 +45,9 @@ impl RuleGetRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
 
         match handle.request(req) {
-            Ok(response) => Either::Left(response.map(move |msg| {
-                let (header, payload) = msg.into_parts();
-                match payload {
-                    NetlinkPayload::InnerMessage(RtnlMessage::NewRule(msg)) => Ok(msg),
-                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
-                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
-                        header, payload,
-                    ))),
-                }
-            })),
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_rtnl!(msg, RtnlMessage::NewRule))))
+            }
             Err(e) => Either::Right(future::err::<RuleMessage, Error>(e).into_stream()),
         }
     }

--- a/rtnetlink/src/traffic_control/get.rs
+++ b/rtnetlink/src/traffic_control/get.rs
@@ -5,7 +5,8 @@ use futures::{
 };
 
 use crate::{
-    packet::{NetlinkMessage, NetlinkPayload, RtnlMessage, TcMessage, NLM_F_DUMP, NLM_F_REQUEST},
+    packet::{NetlinkMessage, RtnlMessage, TcMessage, NLM_F_DUMP, NLM_F_REQUEST},
+    try_rtnl,
     Error,
     Handle,
 };
@@ -34,17 +35,9 @@ impl QDiscGetRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
 
         match handle.request(req) {
-            Ok(response) => Either::Left(response.map(move |msg| {
-                let (header, payload) = msg.into_parts();
-                match payload {
-                    // The kernel use RTM_NEWQDISC for returned message
-                    NetlinkPayload::InnerMessage(RtnlMessage::NewQueueDiscipline(msg)) => Ok(msg),
-                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
-                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
-                        header, payload,
-                    ))),
-                }
-            })),
+            Ok(response) => Either::Left(
+                response.map(move |msg| Ok(try_rtnl!(msg, RtnlMessage::NewQueueDiscipline))),
+            ),
             Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
         }
     }
@@ -73,17 +66,9 @@ impl TrafficClassGetRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
 
         match handle.request(req) {
-            Ok(response) => Either::Left(response.map(move |msg| {
-                let (header, payload) = msg.into_parts();
-                match payload {
-                    // The kernel use RTM_NEWTCLASS for returned message
-                    NetlinkPayload::InnerMessage(RtnlMessage::NewTrafficClass(msg)) => Ok(msg),
-                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
-                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
-                        header, payload,
-                    ))),
-                }
-            })),
+            Ok(response) => Either::Left(
+                response.map(move |msg| Ok(try_rtnl!(msg, RtnlMessage::NewTrafficClass))),
+            ),
             Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
         }
     }
@@ -112,17 +97,9 @@ impl TrafficFilterGetRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
 
         match handle.request(req) {
-            Ok(response) => Either::Left(response.map(move |msg| {
-                let (header, payload) = msg.into_parts();
-                match payload {
-                    // The kernel use RTM_NEWTFILTER for returned message
-                    NetlinkPayload::InnerMessage(RtnlMessage::NewTrafficFilter(msg)) => Ok(msg),
-                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
-                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
-                        header, payload,
-                    ))),
-                }
-            })),
+            Ok(response) => Either::Left(
+                response.map(move |msg| Ok(try_rtnl!(msg, RtnlMessage::NewTrafficFilter))),
+            ),
             Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
         }
     }
@@ -151,17 +128,9 @@ impl TrafficChainGetRequest {
         req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
 
         match handle.request(req) {
-            Ok(response) => Either::Left(response.map(move |msg| {
-                let (header, payload) = msg.into_parts();
-                match payload {
-                    // The kernel use RTM_NEWCHAIN for returned message
-                    NetlinkPayload::InnerMessage(RtnlMessage::NewTrafficChain(msg)) => Ok(msg),
-                    NetlinkPayload::Error(err) => Err(Error::NetlinkError(err)),
-                    _ => Err(Error::UnexpectedMessage(NetlinkMessage::new(
-                        header, payload,
-                    ))),
-                }
-            })),
+            Ok(response) => Either::Left(
+                response.map(move |msg| Ok(try_rtnl!(msg, RtnlMessage::NewTrafficChain))),
+            ),
             Err(e) => Either::Right(future::err::<TcMessage, Error>(e).into_stream()),
         }
     }


### PR DESCRIPTION
This is an attempt at de-duplicating some of the code. Not sure this
makes things more readable though. Wdyt?

This adds two macros: `try_rtnl!` that returns an error if the given message is not a specific `RtnlMessage::Xxx` variant, and `try_nl!` that returns an error if the given message is a `NetlinkPayload::Error`.