### PR TITLE
Rework rule/route builders

### DIFF
--- a/rtnetlink/examples/add_route.rs
+++ b/rtnetlink/examples/add_route.rs
@@ -32,7 +32,8 @@ async fn main() -> Result<(), ()> {
 async fn add_route(dest: &Ipv4Network, gateway: &Ipv4Network, handle: Handle) -> Result<(), Error> {
     let route = handle.route();
     route
-        .add_v4()
+        .add()
+        .v4()
         .destination_prefix(dest.ip(), dest.prefix())
         .gateway(gateway.ip())
         .execute()

--- a/rtnetlink/examples/add_rule.rs
+++ b/rtnetlink/examples/add_rule.rs
@@ -27,10 +27,12 @@ async fn main() -> Result<(), ()> {
 
 async fn add_rule(dest: &Ipv4Network, handle: Handle) -> Result<(), Error> {
     let rule = handle.rule();
-    rule.add_v4()
+    rule.add()
+        .v4()
         .destination_prefix(dest.ip(), dest.prefix())
         .execute()
         .await?;
+
     Ok(())
 }
 

--- a/rtnetlink/src/route/handle.rs
+++ b/rtnetlink/src/route/handle.rs
@@ -1,7 +1,4 @@
-//use std::net::IpAddr;
-
-use super::{RouteAddIpv4Request, RouteAddIpv6Request};
-use crate::{Handle, IpVersion, RouteDelRequest, RouteGetRequest};
+use crate::{Handle, IpVersion, RouteAddRequest, RouteDelRequest, RouteGetRequest};
 use netlink_packet_route::RouteMessage;
 
 pub struct RouteHandle(Handle);
@@ -17,13 +14,8 @@ impl RouteHandle {
     }
 
     /// Add an routing table entry (equivalent to `ip route add`)
-    pub fn add_v4(&self) -> RouteAddIpv4Request {
-        RouteAddIpv4Request::new(self.0.clone())
-    }
-
-    /// Add an routing table entry (equivalent to `ip route add`)
-    pub fn add_v6(&self) -> RouteAddIpv6Request {
-        RouteAddIpv6Request::new(self.0.clone())
+    pub fn add(&self) -> RouteAddRequest {
+        RouteAddRequest::new(self.0.clone())
     }
 
     /// Delete the given routing table entry (equivalent to `ip route del`)

--- a/rtnetlink/src/rule/add.rs
+++ b/rtnetlink/src/rule/add.rs
@@ -1,5 +1,8 @@
 use futures::stream::StreamExt;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    marker::PhantomData,
+    net::{Ipv4Addr, Ipv6Addr},
+};
 
 use netlink_packet_route::{
     constants::*,
@@ -13,29 +16,34 @@ use netlink_packet_route::{
 use crate::{Error, Handle};
 
 /// A request to create a new rule. This is equivalent to the `ip rule add` command.
-struct RuleAddRequest {
+pub struct RuleAddRequest<T = ()> {
     handle: Handle,
     message: RuleMessage,
+    _phantom: PhantomData<T>,
 }
 
-impl RuleAddRequest {
-    fn new(handle: Handle) -> Self {
+impl<T> RuleAddRequest<T> {
+    pub(crate) fn new(handle: Handle) -> Self {
         let mut message = RuleMessage::default();
 
         message.header.table = RT_TABLE_MAIN;
         message.header.action = FR_ACT_UNSPEC;
 
-        RuleAddRequest { handle, message }
+        RuleAddRequest {
+            handle,
+            message,
+            _phantom: Default::default(),
+        }
     }
 
     /// Sets the input interface name.
-    fn input_interface(mut self, ifname: String) -> Self {
+    pub fn input_interface(mut self, ifname: String) -> Self {
         self.message.nlas.push(Nla::Iifname(ifname));
         self
     }
 
     /// Sets the output interface name.
-    fn output_interface(mut self, ifname: String) -> Self {
+    pub fn output_interface(mut self, ifname: String) -> Self {
         self.message.nlas.push(Nla::OifName(ifname));
         self
     }
@@ -43,21 +51,41 @@ impl RuleAddRequest {
     /// Sets the rule table.
     ///
     /// Default is main rule table.
-    fn table(mut self, table: u8) -> Self {
+    pub fn table(mut self, table: u8) -> Self {
         self.message.header.table = table;
         self
     }
 
     /// Set the tos.
-    fn tos(mut self, tos: u8) -> Self {
+    pub fn tos(mut self, tos: u8) -> Self {
         self.message.header.tos = tos;
         self
     }
 
     /// Set action.
-    fn action(mut self, action: u8) -> Self {
+    pub fn action(mut self, action: u8) -> Self {
         self.message.header.action = action;
         self
+    }
+
+    /// Build an IP v4 rule
+    pub fn v4(mut self) -> RuleAddRequest<Ipv4Addr> {
+        self.message.header.family = AF_INET as u8;
+        RuleAddRequest {
+            handle: self.handle,
+            message: self.message,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Build an IP v6 rule
+    pub fn v6(mut self) -> RuleAddRequest<Ipv6Addr> {
+        self.message.header.family = AF_INET6 as u8;
+        RuleAddRequest {
+            handle: self.handle,
+            message: self.message,
+            _phantom: Default::default(),
+        }
     }
 
     /// Execute the request.
@@ -65,6 +93,7 @@ impl RuleAddRequest {
         let RuleAddRequest {
             mut handle,
             message,
+            ..
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::NewRule(message));
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
@@ -75,142 +104,47 @@ impl RuleAddRequest {
                 return Err(Error::NetlinkError(err));
             }
         }
+
         Ok(())
     }
 
-    fn message_mut(&mut self) -> &mut RuleMessage {
+    pub fn message_mut(&mut self) -> &mut RuleMessage {
         &mut self.message
     }
 }
 
-pub struct RuleAddIpv4Request(RuleAddRequest);
-
-impl RuleAddIpv4Request {
-    pub fn new(handle: Handle) -> Self {
-        let mut req = RuleAddRequest::new(handle);
-        req.message_mut().header.family = AF_INET as u8;
-        Self(req)
-    }
-
-    /// Sets the input interface name.
-    pub fn input_interface(self, ifname: String) -> Self {
-        Self(self.0.input_interface(ifname))
-    }
-
-    /// Sets the output interface name.
-    pub fn output_interface(self, ifname: String) -> Self {
-        Self(self.0.output_interface(ifname))
-    }
-
+impl RuleAddRequest<Ipv4Addr> {
     /// Sets the source address prefix.
     pub fn source_prefix(mut self, addr: Ipv4Addr, prefix_length: u8) -> Self {
-        self.0.message.header.src_len = prefix_length;
-        self.0
-            .message
-            .nlas
-            .push(Nla::Source(addr.octets().to_vec()));
+        self.message.header.src_len = prefix_length;
+        let src = addr.octets().to_vec();
+        self.message.nlas.push(Nla::Source(src));
         self
     }
 
     /// Sets the destination address prefix.
     pub fn destination_prefix(mut self, addr: Ipv4Addr, prefix_length: u8) -> Self {
-        self.0.message.header.dst_len = prefix_length;
-        self.0
-            .message
-            .nlas
-            .push(Nla::Destination(addr.octets().to_vec()));
+        self.message.header.dst_len = prefix_length;
+        let dst = addr.octets().to_vec();
+        self.message.nlas.push(Nla::Destination(dst));
         self
-    }
-
-    /// Sets the rule table.
-    ///
-    /// Default is main rule table.
-    pub fn table(self, table: u8) -> Self {
-        Self(self.0.table(table))
-    }
-
-    /// Set the tos.
-    pub fn tos(self, tos: u8) -> Self {
-        Self(self.0.tos(tos))
-    }
-
-    /// Set action.
-    pub fn action(self, action: u8) -> Self {
-        Self(self.0.action(action))
-    }
-
-    /// Execute the request.
-    pub async fn execute(self) -> Result<(), Error> {
-        self.0.execute().await
-    }
-
-    pub fn message_mut(&mut self) -> &mut RuleMessage {
-        self.0.message_mut()
     }
 }
 
-pub struct RuleAddIpv6Request(RuleAddRequest);
-
-impl RuleAddIpv6Request {
-    pub fn new(handle: Handle) -> Self {
-        let mut req = RuleAddRequest::new(handle);
-        req.message_mut().header.family = AF_INET6 as u8;
-        Self(req)
-    }
-
-    /// Sets the input interface name.
-    pub fn input_interface(self, ifname: String) -> Self {
-        Self(self.0.input_interface(ifname))
-    }
-
-    /// Sets the output interface name.
-    pub fn output_interface(self, ifname: String) -> Self {
-        Self(self.0.output_interface(ifname))
-    }
-
+impl RuleAddRequest<Ipv6Addr> {
     /// Sets the source address prefix.
     pub fn source_prefix(mut self, addr: Ipv6Addr, prefix_length: u8) -> Self {
-        self.0.message.header.src_len = prefix_length;
-        self.0
-            .message
-            .nlas
-            .push(Nla::Source(addr.octets().to_vec()));
+        self.message.header.src_len = prefix_length;
+        let src = addr.octets().to_vec();
+        self.message.nlas.push(Nla::Source(src));
         self
     }
 
     /// Sets the destination address prefix.
     pub fn destination_prefix(mut self, addr: Ipv6Addr, prefix_length: u8) -> Self {
-        self.0.message.header.dst_len = prefix_length;
-        self.0
-            .message
-            .nlas
-            .push(Nla::Destination(addr.octets().to_vec()));
+        self.message.header.dst_len = prefix_length;
+        let dst = addr.octets().to_vec();
+        self.message.nlas.push(Nla::Destination(dst));
         self
-    }
-
-    /// Sets the rule table.
-    ///
-    /// Default is main rule table.
-    pub fn table(self, table: u8) -> Self {
-        Self(self.0.table(table))
-    }
-
-    /// Set the tos.
-    pub fn tos(self, tos: u8) -> Self {
-        Self(self.0.tos(tos))
-    }
-
-    /// Set action.
-    pub fn action(self, action: u8) -> Self {
-        Self(self.0.action(action))
-    }
-
-    /// Execute the request.
-    pub async fn execute(self) -> Result<(), Error> {
-        self.0.execute().await
-    }
-
-    pub fn message_mut(&mut self) -> &mut RuleMessage {
-        self.0.message_mut()
     }
 }

--- a/rtnetlink/src/rule/handle.rs
+++ b/rtnetlink/src/rule/handle.rs
@@ -1,5 +1,4 @@
-use super::{RuleAddIpv4Request, RuleAddIpv6Request};
-use crate::{Handle, IpVersion, RuleDelRequest, RuleGetRequest};
+use crate::{Handle, IpVersion, RuleAddRequest, RuleDelRequest, RuleGetRequest};
 use netlink_packet_route::RuleMessage;
 
 pub struct RuleHandle(Handle);
@@ -15,13 +14,8 @@ impl RuleHandle {
     }
 
     /// Add a route rule entry (equivalent to `ip rule add`)
-    pub fn add_v4(&self) -> RuleAddIpv4Request {
-        RuleAddIpv4Request::new(self.0.clone())
-    }
-
-    /// Add a route rule entry (equivalent to `ip rule add`)
-    pub fn add_v6(&self) -> RuleAddIpv6Request {
-        RuleAddIpv6Request::new(self.0.clone())
+    pub fn add(&self) -> RuleAddRequest {
+        RuleAddRequest::new(self.0.clone())
     }
 
     /// Delete the given route rule entry (equivalent to `ip rule del`)


### PR DESCRIPTION
Currently netlink offers two separate rule builders (for v4 and v6), so I ended up with the code like this:
```rust
    for route in list {
            const MAIN_TABLE: u8 = packet::constants::RT_TABLE_MAIN;
            const UNICAST: u8 = packet::constants::RTN_UNICAST;
            const BOOT_PROT: u8 = packet::constants::RTPROT_BOOT;

            if is_v6 {
                // Build IP v6 request
                let mut request = self
                    .handle
                    .route()
                    .add_v6()
                    .table(MAIN_TABLE)
                    .kind(UNICAST)
                    .protocol(BOOT_PROT)
                    ...
            } else {
                // Build IP v4 request
                let mut request = self
                    .handle
                    .route()
                    .add_v4()
                    .table(MAIN_TABLE)
                    .kind(UNICAST)
                    .protocol(BOOT_PROT)
                     ...
            }
        }
```

Which is not super convenient because the majority of fields are same (except source/dest address).


This PR slightly refactors rule builder and adds a bit of rust magic, so we can have just one builder, that supports branching.
So we can do things like this:

```rust
    rule.add()
        .v4()
        .destination_prefix(dest.ip(), dest.prefix())
        .execute()
        .await?;
```

or for example above:

```rust
   let mut builder = rule.add().table(MAIN_TABLE)
                    .kind(UNICAST)
                    .protocol(BOOT_PROT)

   builder = if ip_v6 {
      builder.v6().destination_prefix(IpV6Addr).source_prefix() // v6 variation
   } else {
     builder.v4().destination_prefix(IpV4Addr).source_prefix() // v4 variation
  }

  builder.execute();

```

@little-dude would be interested in your opinion on this. 

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>