### PR TITLE
Update netlink-proto to tokio 1.0, tokio-util 0.6, and bytes 1.0

### DIFF
--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/little-dude/netlink"
 description = "async netlink protocol"
 
 [dependencies]
-bytes = "0.5.3"
+bytes = "1.0"
 log = "0.4.8"
 futures = "0.3.11"
-tokio = { version = "1.0.1", default-features = false, features = ["io-util"] }
-tokio-util = { version = "0.2.0", default-features = false, features = ["codec"] }
+tokio = { version = "1.0", default-features = false, features = ["io-util"] }
+tokio-util = { version = "0.6", default-features = false, features = ["codec"] }
 netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }
 netlink-sys = { path = "../netlink-sys", default-features = false, features = ["tokio_socket"], version = "0.6" }
 

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -14,7 +14,7 @@ description = "async netlink protocol"
 [dependencies]
 bytes = "1.0"
 log = "0.4.8"
-futures = "0.3.11"
+futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.6", default-features = false, features = ["codec"] }
 netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }


### PR DESCRIPTION
These version bumps are all interdependent.

A summary of the changes here:

* `tokio_util::codec::Encoder` now takes the item type as a generic parameter rather than an associated type

* `BufMut::bytes_mut` has been renamed `chunk_mut` and now returns `bytes::buf::UninitSlice` rather than a slice of `MaybeUninit<u8>`. A safe API is provided to write to the slice. The semantics of the function are otherwise unchanged.

* Relaxed version constraints on tokio, tokio-util, and bytes. This will make it less likely that multiple versions of tokio are compiled into an application which will cause unpredictable runtime errors.