### PR TITLE
netlink-packet-route: fix IPoIB umcast flag value

### DIFF
--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -458,7 +458,7 @@ pub const IFLA_IPVLAN_FLAGS: u16 = 2;
 pub const IFLA_IPOIB_UNSPEC: u16 = 0;
 pub const IFLA_IPOIB_PKEY: u16 = 1;
 pub const IFLA_IPOIB_MODE: u16 = 2;
-pub const IFLA_IPOIB_UMCAST: u16 = 4;
+pub const IFLA_IPOIB_UMCAST: u16 = 3;
 pub const VETH_INFO_UNSPEC: u16 = 0;
 pub const VETH_INFO_PEER: u16 = 1;
 


### PR DESCRIPTION
The value should be "3" instead of "4".

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>