### PR TITLE
Ip link property altifname

### DIFF
--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -56,6 +56,8 @@ pub const RTM_NEWCACHEREPORT: u16 = 96;
 pub const RTM_NEWCHAIN: u16 = 100;
 pub const RTM_DELCHAIN: u16 = 101;
 pub const RTM_GETCHAIN: u16 = 102;
+pub const RTM_NEWLINKPROP: u16 = 108;
+pub const RTM_DELLINKPROP: u16 = 109;
 
 /// Unknown route
 pub const RTN_UNSPEC: u8 = 0;

--- a/netlink-packet-route/src/rtnl/link/nlas/prop_list.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/prop_list.rs
@@ -1,0 +1,60 @@
+use crate::{
+    constants::*,
+    nlas::{DefaultNla, Nla, NlaBuffer},
+    parsers::parse_string,
+    traits::Parseable,
+    DecodeError,
+};
+
+use anyhow::Context;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Prop {
+    AltIfName(String),
+    Other(DefaultNla),
+}
+
+impl Nla for Prop {
+    #[rustfmt::skip]
+    fn value_len(&self) -> usize {
+        use self::Prop::*;
+        match self {
+            AltIfName(ref string) => string.as_bytes().len() + 1,
+            Other(nla) => nla.value_len()
+        }
+    }
+
+    #[rustfmt::skip]
+    fn emit_value(&self, buffer: &mut [u8]) {
+        use self::Prop::*;
+        match self {
+            AltIfName(ref string) => {
+                buffer[..string.len()].copy_from_slice(string.as_bytes());
+                buffer[string.len()] = 0;
+            },
+            Other(nla) => nla.emit_value(buffer)
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        use self::Prop::*;
+        match self {
+            AltIfName(_) => IFLA_ALT_IFNAME,
+            Other(nla) => nla.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Prop {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            IFLA_ALT_IFNAME => {
+                Prop::AltIfName(parse_string(payload).context("invalid IFLA_ALT_IFNAME value")?)
+            }
+            kind => {
+                Prop::Other(DefaultNla::parse(buf).context(format!("Unknown NLA type {}", kind))?)
+            }
+        })
+    }
+}

--- a/netlink-packet-route/src/rtnl/message.rs
+++ b/netlink-packet-route/src/rtnl/message.rs
@@ -23,6 +23,8 @@ pub enum RtnlMessage {
     DelLink(LinkMessage),
     GetLink(LinkMessage),
     SetLink(LinkMessage),
+    NewLinkProp(LinkMessage),
+    DelLinkProp(LinkMessage),
     NewAddress(AddressMessage),
     DelAddress(AddressMessage),
     GetAddress(AddressMessage),
@@ -200,6 +202,8 @@ impl RtnlMessage {
             DelLink(_) => RTM_DELLINK,
             GetLink(_) => RTM_GETLINK,
             SetLink(_) => RTM_SETLINK,
+            NewLinkProp(_) => RTM_NEWLINKPROP,
+            DelLinkProp(_) => RTM_DELLINKPROP,
             NewAddress(_) => RTM_NEWADDR,
             DelAddress(_) => RTM_DELADDR,
             GetAddress(_) => RTM_GETADDR,
@@ -243,6 +247,8 @@ impl Emitable for RtnlMessage {
             | DelLink(ref msg)
             | GetLink(ref msg)
             | SetLink(ref msg)
+            | NewLinkProp(ref msg)
+            | DelLinkProp(ref msg)
             =>  msg.buffer_len(),
 
             | NewAddress(ref msg)
@@ -299,6 +305,8 @@ impl Emitable for RtnlMessage {
             | DelLink(ref msg)
             | GetLink(ref msg)
             | SetLink(ref msg)
+            | NewLinkProp(ref msg)
+            | DelLinkProp(ref msg)
             => msg.emit(buffer),
 
             | NewAddress(ref msg)

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -21,7 +21,7 @@ smol_socket = ["netlink-proto/smol_socket", "async-std"]
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
-netlink-packet-route = "0.7"
+netlink-packet-route = "0.8"
 netlink-proto = { default-features = false, version = "0.7" }
 byteordered = "0.5.0"
 nix = "0.22.0"

--- a/rtnetlink/examples/property_altname.rs
+++ b/rtnetlink/examples/property_altname.rs
@@ -1,0 +1,138 @@
+use futures::stream::TryStreamExt;
+use rtnetlink::{
+    new_connection,
+    packet::{
+        rtnl::link::nlas::{Nla, Prop},
+        LinkMessage,
+    },
+    Error,
+    Handle,
+};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        usage();
+        return Ok(());
+    }
+
+    let link_name = &args[1];
+    let action = &args[2];
+    let alt_ifnames = &args[3..].iter().map(String::as_str).collect();
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    match action.as_str() {
+        "add" => {
+            if let Err(e) =
+                add_property_alt_ifnames(link_name, &alt_ifnames, handle.clone()).await
+            {
+                eprintln!("{}", e);
+            }
+        }
+
+        "del" => {
+            if let Err(e) = del_property_alt_ifnames(link_name, &alt_ifnames, handle.clone()).await
+            {
+                eprintln!("{}", e);
+            }
+        }
+
+        "show" => {
+            if let Err(e) = show_property_alt_ifnames(link_name, handle.clone()).await {
+                eprintln!("{}", e);
+            }
+        }
+
+        _ => panic!("Unknown action {:?}", action),
+    }
+
+    Ok(())
+}
+
+async fn show_property_alt_ifnames(link_name: &str, handle: Handle) -> Result<(), Error> {
+    for nla in get_link(link_name, handle).await?.nlas.into_iter() {
+        if let Nla::PropList(ref prop_list) = nla {
+            for prop in prop_list {
+                if let Prop::AltIfName(altname) = prop {
+                    println!("altname: {}", altname);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_property_alt_ifnames(
+    link_name: &str,
+    alt_ifnames: &Vec<&str>,
+    handle: Handle,
+) -> Result<(), Error> {
+    let link_index = get_link_index(link_name, handle.clone()).await?;
+
+    handle
+        .link()
+        .property_add(link_index)
+        .alt_ifname(alt_ifnames)
+        .execute()
+        .await?;
+
+    Ok(())
+}
+
+async fn del_property_alt_ifnames(
+    link_name: &str,
+    alt_ifnames: &Vec<&str>,
+    handle: Handle,
+) -> Result<(), Error> {
+    let link_index = get_link_index(link_name, handle.clone()).await?;
+
+    handle
+        .link()
+        .property_del(link_index)
+        .alt_ifname(alt_ifnames)
+        .execute()
+        .await?;
+
+    Ok(())
+}
+
+async fn get_link(link_name: &str, handle: Handle) -> Result<LinkMessage, Error> {
+    let mut links = handle
+        .link()
+        .get()
+        .set_name_filter(link_name.to_string())
+        .execute();
+
+    match links.try_next().await? {
+        Some(msg) => Ok(msg),
+        _ => {
+            eprintln!("Interface {} not found", link_name.to_string());
+            Err(Error::RequestFailed)
+        }
+    }
+}
+
+async fn get_link_index(link_name: &str, handle: Handle) -> Result<u32, Error> {
+    Ok(get_link(link_name, handle.clone()).await?.header.index)
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example property_altname -- <link_name> [add | del | show] ALTNAME [ALTNAME ...]
+
+Note that you need to run this program as root for add and del. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example property_altname
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./property_altname <link_name> <ip_address>"
+    );
+}

--- a/rtnetlink/src/link/handle.rs
+++ b/rtnetlink/src/link/handle.rs
@@ -1,4 +1,11 @@
-use super::{LinkAddRequest, LinkDelRequest, LinkGetRequest, LinkSetRequest};
+use super::{
+    LinkAddRequest,
+    LinkDelPropRequest,
+    LinkDelRequest,
+    LinkGetRequest,
+    LinkNewPropRequest,
+    LinkSetRequest,
+};
 use crate::Handle;
 
 pub struct LinkHandle(Handle);
@@ -14,6 +21,14 @@ impl LinkHandle {
 
     pub fn add(&self) -> LinkAddRequest {
         LinkAddRequest::new(self.0.clone())
+    }
+
+    pub fn property_add(&self, index: u32) -> LinkNewPropRequest {
+        LinkNewPropRequest::new(self.0.clone(), index)
+    }
+
+    pub fn property_del(&self, index: u32) -> LinkDelPropRequest {
+        LinkDelPropRequest::new(self.0.clone(), index)
     }
 
     pub fn del(&mut self, index: u32) -> LinkDelRequest {

--- a/rtnetlink/src/link/mod.rs
+++ b/rtnetlink/src/link/mod.rs
@@ -13,5 +13,11 @@ pub use self::get::*;
 mod set;
 pub use self::set::*;
 
+mod property_add;
+pub use self::property_add::*;
+
+mod property_del;
+pub use self::property_del::*;
+
 #[cfg(test)]
 mod test;

--- a/rtnetlink/src/link/property_add.rs
+++ b/rtnetlink/src/link/property_add.rs
@@ -1,0 +1,65 @@
+use crate::{
+    packet::{
+        nlas::link::{Nla, Prop},
+        LinkMessage,
+        NetlinkMessage,
+        NetlinkPayload,
+        RtnlMessage,
+        NLM_F_ACK,
+        NLM_F_APPEND,
+        NLM_F_CREATE,
+        NLM_F_EXCL,
+        NLM_F_REQUEST,
+    },
+    Error,
+    Handle,
+};
+use futures::stream::StreamExt;
+
+pub struct LinkNewPropRequest {
+    handle: Handle,
+    message: LinkMessage,
+}
+
+impl LinkNewPropRequest {
+    pub(crate) fn new(handle: Handle, index: u32) -> Self {
+        let mut message = LinkMessage::default();
+        message.header.index = index;
+        LinkNewPropRequest { handle, message }
+    }
+
+    /// Execute the request
+    pub async fn execute(self) -> Result<(), Error> {
+        let LinkNewPropRequest {
+            mut handle,
+            message,
+        } = self;
+        let mut req = NetlinkMessage::from(RtnlMessage::NewLinkProp(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE | NLM_F_APPEND;
+
+        let mut response = handle.request(req)?;
+        while let Some(message) = response.next().await {
+            if let NetlinkPayload::Error(err) = message.payload {
+                return Err(Error::NetlinkError(err));
+            }
+        }
+        Ok(())
+    }
+
+    /// Return a mutable reference to the request
+    pub fn message_mut(&mut self) -> &mut LinkMessage {
+        &mut self.message
+    }
+
+    /// Add alternative name to the link. This is equivalent to `ip link property add altname
+    /// ALT_IFNAME dev LINK`.
+    pub fn alt_ifname(mut self, alt_ifnames: &[&str]) -> Self {
+        let mut props = Vec::new();
+        for alt_ifname in alt_ifnames {
+            props.push(Prop::AltIfName(alt_ifname.to_string()));
+        }
+
+        self.message.nlas.push(Nla::PropList(props));
+        self
+    }
+}

--- a/rtnetlink/src/link/property_del.rs
+++ b/rtnetlink/src/link/property_del.rs
@@ -1,0 +1,63 @@
+use crate::{
+    packet::{
+        nlas::link::{Nla, Prop},
+        LinkMessage,
+        NetlinkMessage,
+        NetlinkPayload,
+        RtnlMessage,
+        NLM_F_ACK,
+        NLM_F_EXCL,
+        NLM_F_REQUEST,
+    },
+    Error,
+    Handle,
+};
+use futures::stream::StreamExt;
+
+pub struct LinkDelPropRequest {
+    handle: Handle,
+    message: LinkMessage,
+}
+
+impl LinkDelPropRequest {
+    pub(crate) fn new(handle: Handle, index: u32) -> Self {
+        let mut message = LinkMessage::default();
+        message.header.index = index;
+        LinkDelPropRequest { handle, message }
+    }
+
+    /// Execute the request
+    pub async fn execute(self) -> Result<(), Error> {
+        let LinkDelPropRequest {
+            mut handle,
+            message,
+        } = self;
+        let mut req = NetlinkMessage::from(RtnlMessage::DelLinkProp(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL;
+
+        let mut response = handle.request(req)?;
+        while let Some(message) = response.next().await {
+            if let NetlinkPayload::Error(err) = message.payload {
+                return Err(Error::NetlinkError(err));
+            }
+        }
+        Ok(())
+    }
+
+    /// Return a mutable reference to the request
+    pub fn message_mut(&mut self) -> &mut LinkMessage {
+        &mut self.message
+    }
+
+    /// Remove alternative name to the link. This is equivalent to `ip link property del altname
+    /// ALT_IFNAME dev LINK`.
+    pub fn alt_ifname(mut self, alt_ifnames: &[&str]) -> Self {
+        let mut props = Vec::new();
+        for alt_ifname in alt_ifnames {
+            props.push(Prop::AltIfName(alt_ifname.to_string()));
+        }
+
+        self.message.nlas.push(Nla::PropList(props));
+        self
+    }
+}


### PR DESCRIPTION
Hello, I add the netlink implementation of ip link property (RTM_NEWLINKPROP, IFLA_PROP_LIST...) and the attribute IFLA_ALT_IFNAME of PropList.

This branch permit to do the same thing as:
ip link property add/del altname XXXX dev LINK_NAME

And showing all altname like ip link show dev LINK_NAME
