### PR TITLE
Make Parseable<T> can parse from ?Sized type

### DIFF
--- a/netlink-packet-utils/src/traits.rs
+++ b/netlink-packet-utils/src/traits.rs
@@ -16,7 +16,7 @@ pub trait Emitable {
     fn emit(&self, buffer: &mut [u8]);
 }
 
-/// A `Parseable` type can be used to deserialize data into the target type `T` for which it is
+/// A `Parseable` type can be used to deserialize data from the type `T` for which it is
 /// implemented.
 pub trait Parseable<T>
 where
@@ -27,7 +27,7 @@ where
     fn parse(buf: &T) -> Result<Self, DecodeError>;
 }
 
-/// A `Parseable` type can be used to deserialize data into the target type `T` for which it is
+/// A `Parseable` type can be used to deserialize data from the type `T` for which it is
 /// implemented.
 pub trait ParseableParametrized<T, P>
 where

--- a/netlink-packet-utils/src/traits.rs
+++ b/netlink-packet-utils/src/traits.rs
@@ -21,6 +21,7 @@ pub trait Emitable {
 pub trait Parseable<T>
 where
     Self: Sized,
+    T: ?Sized,
 {
     /// Deserialize the current type.
     fn parse(buf: &T) -> Result<Self, DecodeError>;
@@ -31,6 +32,7 @@ where
 pub trait ParseableParametrized<T, P>
 where
     Self: Sized,
+    T: ?Sized,
 {
     /// Deserialize the current type.
     fn parse_with_param(buf: &T, params: P) -> Result<Self, DecodeError>;


### PR DESCRIPTION
Recently, I try to implement the generic netlink protocol. But I found that I could not compile the following codes:
```rust
impl ParseableParametrized<[u8], u16> for FooMessage {
    fn parse_with_param(buf: &[u8], message_type: u16) -> Result<Self, DecodeError> {
        // Parse data...
    }
}
```
It's because that the type T isn't marked as `?Sized`. However, the parameter type pass to the function have a reference on it (`&T`). So, this should be fine. 

I also fix the doc comments of the two traits.

Note: I am not sure if this would break the backward compatibility of `netlink-packet-utils`.