### PR TITLE
Allow to parse other audit events

### DIFF
--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 

--- a/netlink-packet-audit/Cargo.toml
+++ b/netlink-packet-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-audit"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-audit/src/buffer.rs
+++ b/netlink-packet-audit/src/buffer.rs
@@ -75,7 +75,11 @@ impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<AuditBuffer<&'a T>, u16>
                     .context("failed to parse audit event data as a valid string")?;
                 Event((i, data))
             }
-            _ => return Err(format!("unknown message type {}", message_type).into()),
+            i => {
+                let data = String::from_utf8(buf.inner().to_vec())
+                    .context("failed to parse audit event data as a valid string")?;
+                Other((i, data))
+            }
         };
         Ok(message)
     }

--- a/netlink-packet-audit/src/message.rs
+++ b/netlink-packet-audit/src/message.rs
@@ -30,6 +30,8 @@ pub enum AuditMessage {
     ///
     /// The first element of the tuple is the message type, and the second is the event data.
     Event((u16, String)),
+    /// All the other events are parsed as such as they can be parsed also.
+    Other((u16, String)),
 }
 
 impl AuditMessage {
@@ -67,6 +69,7 @@ impl AuditMessage {
             AddRule(_) => AUDIT_ADD_RULE,
             DelRule(_) => AUDIT_DEL_RULE,
             Event((message_type, _)) => *message_type,
+            Other((message_type, _)) => *message_type,
         }
     }
 }
@@ -83,6 +86,7 @@ impl Emitable for AuditMessage {
             ListRules(Some(ref msg)) => msg.buffer_len(),
             GetStatus(None) | ListRules(None) => 0,
             Event((_, ref data)) => data.len(),
+            Other((_, ref data)) => data.len(),
         }
     }
 
@@ -97,6 +101,7 @@ impl Emitable for AuditMessage {
             ListRules(Some(ref msg)) => msg.emit(buffer),
             ListRules(None) | GetStatus(None) => {}
             Event((_, ref data)) => buffer.copy_from_slice(data.as_bytes()),
+            Other((_, ref data)) => buffer.copy_from_slice(data.as_bytes()),
         }
     }
 }


### PR DESCRIPTION
For any other event which are not audit one (but still needs to be logged AuditMessage throw a decode error which is not totally true, since a lot of events are still valid (you only take into account Audit Event but a lot of people are installed in all the events: https://github.com/linux-audit/audit-documentation/blob/main/specs/messages/message-dictionary.csv )
This PR create an Other enum field which holds all valid Audit message which are not Audit events, delete, list ...
If you don't like this kind of handling, we could make a RawAuditMessage which allow such handling