### PR TITLE
WIP: Introduce ethtool PAUSE query support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "netlink-proto",
     "rtnetlink",
     "audit",
+    "netlink-generic",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "rtnetlink",
     "audit",
     "netlink-generic",
+    "netlink-ethtool",
 ]

--- a/netlink-ethtool/Cargo.toml
+++ b/netlink-ethtool/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "netlink-ethtool"
+version = "1.0.1"
+authors = ["Gris Ge <cnfourt@gmail.com>"]
+license = "MIT"
+edition = "2018"
+description = "Linux Ethtool Communication Library"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+
+[lib]
+name = "netlink_ethtool"
+path = "lib.rs"
+crate-type = ["lib"]
+
+[dependencies]
+netlink-sys = {path="../netlink-sys"}
+netlink-packet-utils = {path="../netlink-packet-utils"}
+netlink-packet-core = {path="../netlink-packet-core"}
+netlink-proto = {path="../netlink-proto"}
+netlink-generic = {path="../netlink-generic"}
+#tokio = { version = "1.0.1", features = ["rt"], optional = true}
+futures = "0.3.11"
+anyhow = "1.0.31"
+thiserror = "1"
+byteorder = "1.3.2"
+
+[dev-dependencies]
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }
+#async-std = { version = "1.9.0", features = ["attributes"]}

--- a/netlink-ethtool/connection.rs
+++ b/netlink-ethtool/connection.rs
@@ -1,0 +1,20 @@
+use std::io;
+
+use futures::channel::mpsc::UnboundedReceiver;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::{self, Connection};
+use netlink_sys::{constants::NETLINK_GENERIC, SocketAddr};
+
+use crate::{EthtoolHandle, EthtoolMessage};
+
+#[allow(clippy::type_complexity)]
+pub fn new_connection(
+    family_id: u16,
+) -> io::Result<(
+    Connection<EthtoolMessage>,
+    EthtoolHandle,
+    UnboundedReceiver<(NetlinkMessage<EthtoolMessage>, SocketAddr)>,
+)> {
+    let (conn, handle, messages) = netlink_proto::new_connection(NETLINK_GENERIC)?;
+    Ok((conn, EthtoolHandle::new(handle, family_id), messages))
+}

--- a/netlink-ethtool/error.rs
+++ b/netlink-ethtool/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+use netlink_packet_core::{ErrorMessage, NetlinkMessage};
+
+use crate::EthtoolMessage;
+
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum EthtoolError {
+    #[error("Received an unexpected message {0:?}")]
+    UnexpectedMessage(NetlinkMessage<EthtoolMessage>),
+
+    #[error("Received a netlink error message {0}")]
+    NetlinkError(ErrorMessage),
+
+    #[error("A netlink request failed")]
+    RequestFailed(String),
+}

--- a/netlink-ethtool/handle.rs
+++ b/netlink-ethtool/handle.rs
@@ -1,0 +1,30 @@
+use futures::Stream;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::{sys::SocketAddr, ConnectionHandle};
+
+use crate::{EthtoolError, EthtoolMessage, PauseHandle};
+
+#[derive(Clone, Debug)]
+pub struct EthtoolHandle {
+    pub family_id: u16,
+    pub handle: ConnectionHandle<EthtoolMessage>,
+}
+
+impl EthtoolHandle {
+    pub(crate) fn new(handle: ConnectionHandle<EthtoolMessage>, family_id: u16) -> Self {
+        EthtoolHandle { family_id, handle }
+    }
+
+    pub fn pause(&mut self) -> PauseHandle {
+        PauseHandle::new(self.clone())
+    }
+
+    pub fn request(
+        &mut self,
+        message: NetlinkMessage<EthtoolMessage>,
+    ) -> Result<impl Stream<Item = NetlinkMessage<EthtoolMessage>>, EthtoolError> {
+        self.handle
+            .request(message, SocketAddr::new(0, 0))
+            .map_err(|e| EthtoolError::RequestFailed(format!("BUG: Request failed with {}", e)))
+    }
+}

--- a/netlink-ethtool/header.rs
+++ b/netlink-ethtool/header.rs
@@ -1,0 +1,85 @@
+use std::ffi::CString;
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer},
+    parsers::{parse_string, parse_u32},
+    DecodeError,
+    Parseable,
+};
+
+const ALTIFNAMSIZ: usize = 128;
+const ETHTOOL_A_HEADER_DEV_INDEX: u16 = 1;
+const ETHTOOL_A_HEADER_DEV_NAME: u16 = 2;
+const ETHTOOL_A_HEADER_FLAGS: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolHeader {
+    DevIndex(u32),
+    DevName(String),
+    Flags(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for EthtoolHeader {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::DevIndex(_) | Self::Flags(_) => 4,
+            Self::DevName(s) => {
+                if s.len() + 1 > ALTIFNAMSIZ {
+                    ALTIFNAMSIZ
+                } else {
+                    s.len() + 1
+                }
+            }
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::DevIndex(_) => ETHTOOL_A_HEADER_DEV_INDEX,
+            Self::DevName(_) => ETHTOOL_A_HEADER_DEV_NAME,
+            Self::Flags(_) => ETHTOOL_A_HEADER_FLAGS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::DevIndex(value) | Self::Flags(value) => NativeEndian::write_u32(buffer, *value),
+            Self::DevName(s) => str_to_zero_ended_u8_array(&s, buffer, ALTIFNAMSIZ),
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for EthtoolHeader {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_HEADER_DEV_INDEX => Self::DevIndex(
+                parse_u32(payload).context("invalid ETHTOOL_A_HEADER_DEV_INDEX value")?,
+            ),
+            ETHTOOL_A_HEADER_FLAGS => {
+                Self::Flags(parse_u32(payload).context("invalid ETHTOOL_A_HEADER_FLAGS value")?)
+            }
+            ETHTOOL_A_HEADER_DEV_NAME => Self::DevName(
+                parse_string(payload).context("invalid ETHTOOL_A_HEADER_DEV_NAME value")?,
+            ),
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+fn str_to_zero_ended_u8_array(src_str: &str, buffer: &mut [u8], max_size: usize) {
+    if let Ok(src_cstring) = CString::new(src_str.as_bytes()) {
+        let src_null_ended_str = src_cstring.into_bytes_with_nul();
+        if src_null_ended_str.len() > max_size {
+            buffer[..max_size].clone_from_slice(&src_null_ended_str[..max_size])
+        } else {
+            buffer[..src_null_ended_str.len()].clone_from_slice(&src_null_ended_str)
+        }
+    }
+}

--- a/netlink-ethtool/lib.rs
+++ b/netlink-ethtool/lib.rs
@@ -1,0 +1,14 @@
+mod connection;
+mod error;
+mod handle;
+mod header;
+mod macros;
+mod message;
+mod pause;
+
+pub use connection::new_connection;
+pub use error::EthtoolError;
+pub use handle::EthtoolHandle;
+pub use header::EthtoolHeader;
+pub use message::{EthoolAttr, EthtoolMessage};
+pub use pause::{PauseAttr, PauseGetRequest, PauseHandle};

--- a/netlink-ethtool/message.rs
+++ b/netlink-ethtool/message.rs
@@ -1,0 +1,115 @@
+use anyhow::Context;
+use netlink_generic::{GenericNetlinkHeader, GenericNetlinkMessageBuffer};
+use netlink_packet_core::{
+    DecodeError,
+    NetlinkDeserializable,
+    NetlinkHeader,
+    NetlinkPayload,
+    NetlinkSerializable,
+};
+use netlink_packet_utils::{nla::NlasIterator, Emitable, Parseable};
+
+use crate::{EthtoolHeader, PauseAttr};
+
+const ETHTOOL_MSG_PAUSE_GET: u8 = 21;
+const ETHTOOL_MSG_PAUSE_GET_REPLY: u8 = 22;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthoolAttr {
+    Pause(Vec<PauseAttr>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EthtoolMessage {
+    pub message_type: u16,
+    pub header: GenericNetlinkHeader,
+    pub nlas: EthoolAttr,
+}
+
+impl EthtoolMessage {
+    pub fn new_pause_get(message_type: u16, iface_name: &str) -> Self {
+        EthtoolMessage {
+            message_type,
+            header: GenericNetlinkHeader {
+                cmd: ETHTOOL_MSG_PAUSE_GET,
+                version: 1, // No idea the correct version.
+            },
+            nlas: EthoolAttr::Pause(vec![PauseAttr::Header(vec![EthtoolHeader::DevName(
+                iface_name.to_string(),
+            )])]),
+        }
+    }
+    fn message_type(&self) -> u16 {
+        self.message_type
+    }
+}
+
+impl Emitable for EthtoolMessage {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len()
+            + match &self.nlas {
+                EthoolAttr::Pause(nlas) => nlas.as_slice().buffer_len(),
+            }
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        match &self.nlas {
+            EthoolAttr::Pause(nlas) => nlas
+                .as_slice()
+                .emit(&mut buffer[self.header.buffer_len()..]),
+        };
+        println!("EthtoolMessage buffer: {:?}", buffer);
+    }
+}
+
+impl NetlinkSerializable<EthtoolMessage> for EthtoolMessage {
+    fn message_type(&self) -> u16 {
+        self.message_type()
+    }
+
+    fn buffer_len(&self) -> usize {
+        <Self as Emitable>::buffer_len(self)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.emit(buffer)
+    }
+}
+
+impl NetlinkDeserializable<EthtoolMessage> for EthtoolMessage {
+    type Error = DecodeError;
+    fn deserialize(nl_header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
+        let buf = GenericNetlinkMessageBuffer::new(payload);
+        let header = GenericNetlinkHeader::parse(&buf)
+            .context("failed to parse generic netlink message header")?;
+
+        let nlas = match header.cmd {
+            ETHTOOL_MSG_PAUSE_GET_REPLY => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse ethtool message attributes";
+                for nla in NlasIterator::new(buf.payload()) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed = PauseAttr::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                EthoolAttr::Pause(nlas)
+            }
+            _ => {
+                return Err(format!("Unknown command {}", header.cmd).into());
+            }
+        };
+
+        Ok(EthtoolMessage {
+            message_type: nl_header.message_type,
+            header,
+            nlas,
+        })
+    }
+}
+
+impl From<EthtoolMessage> for NetlinkPayload<EthtoolMessage> {
+    fn from(message: EthtoolMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}

--- a/netlink-ethtool/pause/get.rs
+++ b/netlink-ethtool/pause/get.rs
@@ -1,0 +1,52 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{NetlinkMessage, NLM_F_REQUEST};
+
+use netlink_packet_utils::Emitable; // debug only
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct PauseGetRequest {
+    handle: EthtoolHandle,
+    iface_name: String,
+}
+
+impl PauseGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: &str) -> Self {
+        PauseGetRequest {
+            handle,
+            iface_name: iface_name.to_string(),
+        }
+    }
+
+    pub fn execute(self) -> impl TryStream<Ok = EthtoolMessage, Error = EthtoolError> {
+        let PauseGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let ethtool_msg = EthtoolMessage::new_pause_get(handle.family_id, &iface_name);
+
+        println!("ethtool_msg_len: {:?}", ethtool_msg.buffer_len());
+        let mut buffer = vec![0; ethtool_msg.buffer_len()];
+        ethtool_msg.emit(&mut buffer);
+        println!("ethtool_msg: {:?}", buffer);
+
+        let mut nl_msg = NetlinkMessage::from(ethtool_msg);
+
+        nl_msg.header.flags = NLM_F_REQUEST;
+        // req.header.message_type = handle.family_id;
+        nl_msg.finalize();
+
+        println!("nl_msg_len: {:?}", nl_msg.buffer_len());
+        let mut buffer = vec![0; nl_msg.buffer_len()];
+        nl_msg.emit(&mut buffer);
+        println!("nl_msg: {:?}", buffer);
+
+        match handle.request(nl_msg) {
+            Ok(response) => Either::Left(response.map(move |msg| Ok(try_ethtool!(msg)))),
+            Err(e) => {
+                Either::Right(futures::future::err::<EthtoolMessage, EthtoolError>(e).into_stream())
+            }
+        }
+    }
+}

--- a/netlink-ethtool/pause/handle.rs
+++ b/netlink-ethtool/pause/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolHandle, PauseGetRequest};
+
+pub struct PauseHandle(EthtoolHandle);
+
+impl PauseHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        PauseHandle(handle)
+    }
+
+    /// Retrieve the pause setting of a interface (equivalent to `ethtool -a eth1`)
+    pub fn get(&mut self, iface_name: &str) -> PauseGetRequest {
+        PauseGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/netlink-ethtool/pause/mod.rs
+++ b/netlink-ethtool/pause/mod.rs
@@ -1,0 +1,7 @@
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::PauseAttr;
+pub use get::PauseGetRequest;
+pub use handle::PauseHandle;

--- a/netlink-generic/Cargo.toml
+++ b/netlink-generic/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "netlink-generic"
+version = "0.1.0"
+authors = ["Gris Ge <cnfourt@gmail.com>"]
+license = "MIT"
+edition = "2018"
+description = "Linux Generic Netlink Communication Library"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+
+[lib]
+name = "netlink_generic"
+path = "lib.rs"
+crate-type = ["lib"]
+
+[dependencies]
+netlink-packet-route = {path="../netlink-packet-route"}
+netlink-sys = {path="../netlink-sys"}
+netlink-packet-utils = {path="../netlink-packet-utils"}
+netlink-packet-core = {path="../netlink-packet-core"}
+netlink-proto = {path="../netlink-proto"}
+tokio = { version = "1.0.1", features = ["rt"], optional = true}
+futures = "0.3.11"
+anyhow = "1.0.31"
+thiserror = "1"
+byteorder = "1.3.2"
+
+[dev-dependencies]
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }
+async-std = { version = "1.9.0", features = ["attributes"]}

--- a/netlink-generic/buffer.rs
+++ b/netlink-generic/buffer.rs
@@ -1,0 +1,19 @@
+use netlink_packet_utils::{
+    buffer,
+    buffer_check_length,
+    buffer_common,
+    fields,
+    getter,
+    setter,
+    DecodeError,
+};
+
+pub(crate) const GENL_HEADER_LEN: usize = 4;
+pub const GENL_ID_CTRL: u16 = 0x10;
+
+buffer!(GenericNetlinkMessageBuffer(GENL_HEADER_LEN) {
+    cmd: (u8, 0),
+    version: (u8, 1),
+    reserve_1: (u8, 2),
+    payload: (slice, GENL_HEADER_LEN..),
+});

--- a/netlink-generic/connection.rs
+++ b/netlink-generic/connection.rs
@@ -1,0 +1,18 @@
+use std::io;
+
+use futures::channel::mpsc::UnboundedReceiver;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::{self, Connection};
+use netlink_sys::{constants::NETLINK_GENERIC, SocketAddr};
+
+use crate::{GenericNetlinkHandle, GenericNetlinkMessage};
+
+#[allow(clippy::type_complexity)]
+pub fn new_connection() -> io::Result<(
+    Connection<GenericNetlinkMessage>,
+    GenericNetlinkHandle,
+    UnboundedReceiver<(NetlinkMessage<GenericNetlinkMessage>, SocketAddr)>,
+)> {
+    let (conn, handle, messages) = netlink_proto::new_connection(NETLINK_GENERIC)?;
+    Ok((conn, GenericNetlinkHandle::new(handle), messages))
+}

--- a/netlink-generic/ctrl.rs
+++ b/netlink-generic/ctrl.rs
@@ -1,0 +1,290 @@
+use std::ffi::CString;
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator},
+    parsers::{parse_string, parse_u16, parse_u32},
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+const GENL_NAMSIZ: usize = 16;
+
+const CTRL_ATTR_UNSPEC: u16 = 0;
+const CTRL_ATTR_FAMILY_ID: u16 = 1;
+const CTRL_ATTR_FAMILY_NAME: u16 = 2;
+const CTRL_ATTR_VERSION: u16 = 3;
+const CTRL_ATTR_HDRSIZE: u16 = 4;
+const CTRL_ATTR_MAXATTR: u16 = 5;
+const CTRL_ATTR_OPS: u16 = 6;
+const CTRL_ATTR_MCAST_GROUPS: u16 = 7;
+// const CTRL_ATTR_POLICY: u16 = 8; TODO
+// const CTRL_ATTR_OP_POLICY: u16 = 9;
+// const CTRL_ATTR_OP: u16 = 10;
+
+const CTRL_ATTR_OP_UNSPEC: u16 = 0;
+const CTRL_ATTR_OP_ID: u16 = 1;
+const CTRL_ATTR_OP_FLAGS: u16 = 2;
+
+const CTRL_ATTR_MCAST_GRP_UNSPEC: u16 = 0;
+const CTRL_ATTR_MCAST_GRP_NAME: u16 = 1;
+const CTRL_ATTR_MCAST_GRP_ID: u16 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+// for kernel `struct genl_ops`
+pub enum GenericNetlinkOp {
+    Unspec(Vec<u8>),
+    Id(u32),
+    Flags(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for GenericNetlinkOp {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Unspec(ref bytes) => bytes.len(),
+            Self::Id(_) | Self::Flags(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Unspec(_) => CTRL_ATTR_OP_UNSPEC,
+            Self::Id(_) => CTRL_ATTR_OP_ID,
+            Self::Flags(_) => CTRL_ATTR_OP_FLAGS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Self::Id(value) | Self::Flags(value) => NativeEndian::write_u32(buffer, *value),
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for GenericNetlinkOp {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            CTRL_ATTR_OP_UNSPEC => Self::Unspec(payload.to_vec()),
+            CTRL_ATTR_OP_ID => {
+                Self::Id(parse_u32(payload).context("invalid CTRL_ATTR_OP_ID value")?)
+            }
+            CTRL_ATTR_OP_FLAGS => {
+                Self::Flags(parse_u32(payload).context("invalid CTRL_ATTR_OP_FLAGS value")?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+// for kernel `struct genl_multicast_group`
+pub enum GenericNetlinkMulticastGroup {
+    Unspec(Vec<u8>),
+    Id(u32),
+    Name(String),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for GenericNetlinkMulticastGroup {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Unspec(ref bytes) => bytes.len(),
+            Self::Id(_) => 4,
+            Self::Name(_) => GENL_NAMSIZ,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Unspec(_) => CTRL_ATTR_MCAST_GRP_UNSPEC,
+            Self::Id(_) => CTRL_ATTR_MCAST_GRP_ID,
+            Self::Name(_) => CTRL_ATTR_MCAST_GRP_NAME,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Self::Id(value) => NativeEndian::write_u32(buffer, *value),
+            Self::Name(value) => str_to_zero_ended_u8_array(&value, buffer, GENL_NAMSIZ),
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for GenericNetlinkMulticastGroup {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            CTRL_ATTR_MCAST_GRP_UNSPEC => Self::Unspec(payload.to_vec()),
+            CTRL_ATTR_MCAST_GRP_NAME => {
+                Self::Name(parse_string(payload).context("invalid CTRL_ATTR_MCAST_GRP_NAME value")?)
+            }
+            CTRL_ATTR_MCAST_GRP_ID => {
+                Self::Id(parse_u32(payload).context("invalid CTRL_ATTR_MCAST_GRP_ID value")?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CtrlAttr {
+    Unspec(Vec<u8>),
+    FamilyId(u16),
+    FamilyName(String),
+    Version(u32),
+    HeaderSize(u32),
+    MaxAttr(u32),
+    Ops(Vec<Vec<GenericNetlinkOp>>),
+    MulticastGroups(Vec<Vec<GenericNetlinkMulticastGroup>>),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for CtrlAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Unspec(ref bytes) => bytes.len(),
+            Self::FamilyId(_) => 2,
+            Self::FamilyName(s) => {
+                if s.len() > GENL_NAMSIZ - 1 {
+                    GENL_NAMSIZ
+                } else {
+                    s.len() + 1
+                }
+            }
+            Self::Version(_) | Self::HeaderSize(_) | Self::MaxAttr(_) => 4,
+            Self::Ops(ref ops) => {
+                let mut len = 0;
+                for op in ops {
+                    len += op.as_slice().buffer_len()
+                }
+                len
+            }
+            Self::MulticastGroups(ref groups) => {
+                let mut len = 0;
+                for group in groups {
+                    len += group.as_slice().buffer_len()
+                }
+                len
+            }
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Unspec(_) => CTRL_ATTR_UNSPEC,
+            Self::FamilyId(_) => CTRL_ATTR_FAMILY_ID,
+            Self::FamilyName(_) => CTRL_ATTR_FAMILY_NAME,
+            Self::Version(_) => CTRL_ATTR_VERSION,
+            Self::HeaderSize(_) => CTRL_ATTR_HDRSIZE,
+            Self::MaxAttr(_) => CTRL_ATTR_MAXATTR,
+            Self::Ops(_) => CTRL_ATTR_OPS,
+            Self::MulticastGroups(_) => CTRL_ATTR_MCAST_GROUPS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Self::FamilyId(value) => NativeEndian::write_u16(buffer, *value),
+            Self::FamilyName(value) => str_to_zero_ended_u8_array(&value, buffer, GENL_NAMSIZ),
+            Self::Version(value) | Self::HeaderSize(value) | Self::MaxAttr(value) => {
+                NativeEndian::write_u32(buffer, *value)
+            }
+            Self::Ops(ref ops) => {
+                let mut len = 0;
+                for op in ops {
+                    op.as_slice().emit(&mut buffer[len..]);
+                    len += op.as_slice().buffer_len();
+                }
+            }
+            Self::MulticastGroups(ref groups) => {
+                let mut len = 0;
+                for group in groups {
+                    group.as_slice().emit(&mut buffer[len..]);
+                    len += group.as_slice().buffer_len();
+                }
+            }
+            Self::Other(attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for CtrlAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            CTRL_ATTR_UNSPEC => Self::Unspec(payload.to_vec()),
+            CTRL_ATTR_FAMILY_ID => {
+                Self::FamilyId(parse_u16(payload).context("invalid CTRL_ATTR_FAMILY_ID value")?)
+            }
+            CTRL_ATTR_FAMILY_NAME => Self::FamilyName(
+                parse_string(payload).context("invalid CTRL_ATTR_FAMILY_NAME value")?,
+            ),
+            CTRL_ATTR_VERSION => {
+                Self::Version(parse_u32(payload).context("invalid CTRL_ATTR_VERSION value")?)
+            }
+            CTRL_ATTR_HDRSIZE => {
+                Self::HeaderSize(parse_u32(payload).context("invalid CTRL_ATTR_HDRSIZE value")?)
+            }
+            CTRL_ATTR_MAXATTR => {
+                Self::MaxAttr(parse_u32(payload).context("invalid CTRL_ATTR_MAXATTR value")?)
+            }
+            CTRL_ATTR_OPS => {
+                let mut ops = Vec::new();
+                let error_msg = "failed to parse CTRL_ATTR_OPS";
+                for nlas in NlasIterator::new(payload) {
+                    let nlas = &nlas.context(error_msg)?;
+                    let mut op = Vec::new();
+                    for nla in NlasIterator::new(nlas.value()) {
+                        let nla = &nla.context(error_msg)?;
+                        let parsed = GenericNetlinkOp::parse(nla).context(error_msg)?;
+                        op.push(parsed);
+                    }
+                    ops.push(op);
+                }
+                Self::Ops(ops)
+            }
+            CTRL_ATTR_MCAST_GROUPS => {
+                let mut groups = Vec::new();
+                let error_msg = "failed to parse CTRL_ATTR_MCAST_GROUPS";
+                for nlas in NlasIterator::new(payload) {
+                    let nlas = &nlas.context(error_msg)?;
+                    let mut group = Vec::new();
+                    for nla in NlasIterator::new(nlas.value()) {
+                        let nla = &nla.context(error_msg)?;
+                        let parsed = GenericNetlinkMulticastGroup::parse(nla).context(error_msg)?;
+                        group.push(parsed);
+                    }
+                    groups.push(group);
+                }
+                Self::MulticastGroups(groups)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+fn str_to_zero_ended_u8_array(src_str: &str, buffer: &mut [u8], max_size: usize) {
+    if let Ok(src_cstring) = CString::new(src_str.as_bytes()) {
+        let src_null_ended_str = src_cstring.into_bytes_with_nul();
+        if src_null_ended_str.len() > max_size {
+            buffer[..max_size].clone_from_slice(&src_null_ended_str[..max_size])
+        } else {
+            buffer[..src_null_ended_str.len()].clone_from_slice(&src_null_ended_str)
+        }
+    }
+}

--- a/netlink-generic/ctrl.rs
+++ b/netlink-generic/ctrl.rs
@@ -156,13 +156,7 @@ impl nla::Nla for CtrlAttr {
         match self {
             Self::Unspec(ref bytes) => bytes.len(),
             Self::FamilyId(_) => 2,
-            Self::FamilyName(s) => {
-                if s.len() > GENL_NAMSIZ - 1 {
-                    GENL_NAMSIZ
-                } else {
-                    s.len() + 1
-                }
-            }
+            Self::FamilyName(_) => GENL_NAMSIZ,
             Self::Version(_) | Self::HeaderSize(_) | Self::MaxAttr(_) => 4,
             Self::Ops(ref ops) => {
                 let mut len = 0;

--- a/netlink-generic/error.rs
+++ b/netlink-generic/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+use netlink_packet_core::{ErrorMessage, NetlinkMessage};
+
+use crate::GenericNetlinkMessage;
+
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum GenericNetlinkError {
+    #[error("Received an unexpected message {0:?}")]
+    UnexpectedMessage(NetlinkMessage<GenericNetlinkMessage>),
+
+    #[error("Received a netlink error message {0}")]
+    NetlinkError(ErrorMessage),
+
+    #[error("A netlink request failed")]
+    RequestFailed(String),
+}

--- a/netlink-generic/handle.rs
+++ b/netlink-generic/handle.rs
@@ -1,0 +1,101 @@
+use futures::{self, FutureExt, Stream, StreamExt};
+
+use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NLM_F_REQUEST};
+use netlink_proto::{sys::SocketAddr, ConnectionHandle};
+
+use crate::{
+    try_genl,
+    CtrlAttr,
+    GenericNetlinkAttr,
+    GenericNetlinkError,
+    GenericNetlinkHeader,
+    GenericNetlinkMessage,
+    GENL_ID_CTRL,
+};
+
+#[derive(Clone, Debug)]
+pub struct GenericNetlinkHandle(ConnectionHandle<GenericNetlinkMessage>);
+
+const CTRL_CMD_GETFAMILY: u8 = 3;
+// libnl is using hardcoded number 1 and kernel does not verify the version
+const CTRL_CMD_GETFAMILY_VERSION: u8 = 1;
+
+impl GenericNetlinkHandle {
+    pub(crate) fn new(conn: ConnectionHandle<GenericNetlinkMessage>) -> Self {
+        GenericNetlinkHandle(conn)
+    }
+
+    pub async fn resolve_family_name(
+        &mut self,
+        family_name: &str,
+    ) -> Result<u16, GenericNetlinkError> {
+        let nl_msg = NetlinkMessage {
+            header: NetlinkHeader {
+                message_type: GENL_ID_CTRL,
+                flags: NLM_F_REQUEST,
+                sequence_number: 0,
+                port_number: 0,
+                ..Default::default()
+            },
+            payload: GenericNetlinkMessage {
+                message_type: GENL_ID_CTRL,
+                header: GenericNetlinkHeader {
+                    cmd: CTRL_CMD_GETFAMILY,
+                    version: CTRL_CMD_GETFAMILY_VERSION,
+                },
+                nlas: GenericNetlinkAttr::Ctrl(vec![CtrlAttr::FamilyName(family_name.into())]),
+            }
+            .into(),
+        };
+
+        let mut response = match self.0.request(nl_msg, SocketAddr::new(0, 0)) {
+            Ok(response) => {
+                futures::future::Either::Left(response.map(move |msg| Ok(try_genl!(msg))))
+            }
+            Err(e) => futures::future::Either::Right(
+                futures::future::err::<GenericNetlinkMessage, GenericNetlinkError>(
+                    GenericNetlinkError::RequestFailed(format!("{}", e)),
+                )
+                .into_stream(),
+            ),
+        };
+
+        match response.next().await {
+            Some(Ok(genl_msg)) => {
+                match &genl_msg.nlas {
+                    GenericNetlinkAttr::Ctrl(nlas) => {
+                        for nla in nlas {
+                            if let CtrlAttr::FamilyId(family_id) = nla {
+                                return Ok(*family_id);
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(GenericNetlinkError::RequestFailed(format!(
+                            "The NLA reply is not GenericNetlinkAttr::Ctrl: {:?}",
+                            &genl_msg
+                        )));
+                    }
+                };
+                Err(GenericNetlinkError::RequestFailed(format!(
+                    "The NLA reply is not GenericNetlinkAttr::Ctrl: {:?}",
+                    &genl_msg
+                )))
+            }
+            Some(Err(e)) => Err(e),
+            None => Err(GenericNetlinkError::RequestFailed(
+                "No reply got for CTRL_CMD_GETFAMILY".into(),
+            )),
+        }
+    }
+
+    pub fn request(
+        &mut self,
+        message: NetlinkMessage<GenericNetlinkMessage>,
+    ) -> Result<impl Stream<Item = NetlinkMessage<GenericNetlinkMessage>>, GenericNetlinkError>
+    {
+        self.0.request(message, SocketAddr::new(0, 0)).map_err(|_| {
+            GenericNetlinkError::RequestFailed("Failed to send netlink request".into())
+        })
+    }
+}

--- a/netlink-generic/header.rs
+++ b/netlink-generic/header.rs
@@ -1,0 +1,33 @@
+use netlink_packet_utils::{DecodeError, Emitable, Parseable};
+
+use crate::{buffer::GENL_HEADER_LEN, GenericNetlinkMessageBuffer};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub struct GenericNetlinkHeader {
+    pub cmd: u8,
+    pub version: u8,
+    // there is an u16 reserverd in kernel `struct genlmsghdr`
+}
+
+impl Emitable for GenericNetlinkHeader {
+    fn buffer_len(&self) -> usize {
+        GENL_HEADER_LEN
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let mut packet = GenericNetlinkMessageBuffer::new(buffer);
+        packet.set_cmd(self.cmd);
+        packet.set_version(self.version);
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<GenericNetlinkMessageBuffer<&'a T>>
+    for GenericNetlinkHeader
+{
+    fn parse(buf: &GenericNetlinkMessageBuffer<&'a T>) -> Result<Self, DecodeError> {
+        Ok(GenericNetlinkHeader {
+            cmd: buf.cmd(),
+            version: buf.version(),
+        })
+    }
+}

--- a/netlink-generic/lib.rs
+++ b/netlink-generic/lib.rs
@@ -1,0 +1,16 @@
+mod buffer;
+mod connection;
+mod ctrl;
+mod error;
+mod handle;
+mod header;
+mod macros;
+mod message;
+
+pub use buffer::{GenericNetlinkMessageBuffer, GENL_ID_CTRL};
+pub use connection::new_connection;
+pub use ctrl::CtrlAttr;
+pub use error::GenericNetlinkError;
+pub use handle::GenericNetlinkHandle;
+pub use header::GenericNetlinkHeader;
+pub use message::{GenericNetlinkAttr, GenericNetlinkMessage};

--- a/netlink-generic/message.rs
+++ b/netlink-generic/message.rs
@@ -1,0 +1,112 @@
+use anyhow::Context;
+use netlink_packet_core::{
+    DecodeError,
+    NetlinkDeserializable,
+    NetlinkHeader,
+    NetlinkPayload,
+    NetlinkSerializable,
+};
+use netlink_packet_utils::{
+    nla::{DefaultNla, NlasIterator},
+    Emitable,
+    Parseable,
+    ParseableParametrized,
+};
+
+use crate::{buffer::GENL_ID_CTRL, CtrlAttr, GenericNetlinkHeader, GenericNetlinkMessageBuffer};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum GenericNetlinkAttr {
+    Ctrl(Vec<CtrlAttr>),
+    Other(Vec<DefaultNla>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct GenericNetlinkMessage {
+    pub message_type: u16,
+    pub header: GenericNetlinkHeader,
+    pub nlas: GenericNetlinkAttr,
+}
+
+impl Emitable for GenericNetlinkMessage {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len()
+            + match &self.nlas {
+                GenericNetlinkAttr::Ctrl(nlas) => nlas.as_slice().buffer_len(),
+                GenericNetlinkAttr::Other(nlas) => nlas.as_slice().buffer_len(),
+            }
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        match &self.nlas {
+            GenericNetlinkAttr::Ctrl(nlas) => nlas
+                .as_slice()
+                .emit(&mut buffer[self.header.buffer_len()..]),
+            GenericNetlinkAttr::Other(nlas) => nlas
+                .as_slice()
+                .emit(&mut buffer[self.header.buffer_len()..]),
+        }
+    }
+}
+
+impl NetlinkSerializable<GenericNetlinkMessage> for GenericNetlinkMessage {
+    fn message_type(&self) -> u16 {
+        self.message_type
+    }
+
+    fn buffer_len(&self) -> usize {
+        <Self as Emitable>::buffer_len(self)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.emit(buffer)
+    }
+}
+
+impl NetlinkDeserializable<GenericNetlinkMessage> for GenericNetlinkMessage {
+    type Error = DecodeError;
+    fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
+        let buf = GenericNetlinkMessageBuffer::new(payload);
+        GenericNetlinkMessage::parse_with_param(&buf, header.message_type)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> ParseableParametrized<GenericNetlinkMessageBuffer<&'a T>, u16>
+    for GenericNetlinkMessage
+{
+    fn parse_with_param(
+        buf: &GenericNetlinkMessageBuffer<&'a T>,
+        message_type: u16,
+    ) -> Result<Self, DecodeError> {
+        let header = GenericNetlinkHeader::parse(buf)
+            .context("failed to parse generic netlink message header")?;
+
+        match message_type {
+            GENL_ID_CTRL => match GenericNetlinkMessageBuffer::new_checked(&buf.inner()) {
+                Ok(buf) => Ok(GenericNetlinkMessage {
+                    message_type,
+                    header,
+                    nlas: {
+                        let mut nlas = Vec::new();
+                        let error_msg = "failed to parse control message attributes";
+                        for nla in NlasIterator::new(buf.payload()) {
+                            let nla = &nla.context(error_msg)?;
+                            let parsed = CtrlAttr::parse(nla).context(error_msg)?;
+                            nlas.push(parsed);
+                        }
+                        GenericNetlinkAttr::Ctrl(nlas)
+                    },
+                }),
+                Err(e) => Err(e),
+            },
+            _ => Err(format!("Unknown message type: {}", message_type).into()),
+        }
+    }
+}
+
+impl From<GenericNetlinkMessage> for NetlinkPayload<GenericNetlinkMessage> {
+    fn from(message: GenericNetlinkMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}

--- a/netlink-generic/tests/genl_ctrl_resolve_ethtool.rs
+++ b/netlink-generic/tests/genl_ctrl_resolve_ethtool.rs
@@ -1,0 +1,20 @@
+use netlink_generic::new_connection;
+use tokio;
+
+#[test]
+fn test_genl_ctrl_resolve_ethtool() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(genl_ctrl_resolve_ethtool());
+}
+
+async fn genl_ctrl_resolve_ethtool() {
+    let (connection, mut handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    assert!(family_id > 0);
+}


### PR DESCRIPTION
Introduced ethtool PAUSE query support as

   EthtoolHandle::pause().get().execute()

The example code is `examples/get_pause.rs` and tested against netdevsim.

TODO:
* Handle not supported error.