### PR TITLE
UnixRequest: fix protocol family

### DIFF
--- a/netlink-packet-sock-diag/src/unix/request.rs
+++ b/netlink-packet-sock-diag/src/unix/request.rs
@@ -99,7 +99,7 @@ impl Emitable for UnixRequest {
 
     fn emit(&self, buf: &mut [u8]) {
         let mut buffer = UnixRequestBuffer::new(buf);
-        buffer.set_family(0);
+        buffer.set_family(AF_UNIX);
         buffer.set_protocol(0);
         buffer.set_state_flags(self.state_flags.bits());
         buffer.set_inode(self.inode);


### PR DESCRIPTION
The family field in was incorrectly being filled in with 0, rather than
1 (AF_UNIX). Add a test for the serialization of UnixRequest.