### PR TITLE
netlink-sys: Add the SOCK_CLOEXEC for the socket

### DIFF
--- a/netlink-sys/src/socket.rs
+++ b/netlink-sys/src/socket.rs
@@ -76,8 +76,13 @@ impl Socket {
     ///
     /// [protos]: crate::protocols
     pub fn new(protocol: isize) -> Result<Self> {
-        let res =
-            unsafe { libc::socket(libc::PF_NETLINK, libc::SOCK_DGRAM, protocol as libc::c_int) };
+        let res = unsafe {
+            libc::socket(
+                libc::PF_NETLINK,
+                libc::SOCK_DGRAM | libc::SOCK_CLOEXEC,
+                protocol as libc::c_int,
+            )
+        };
         if res < 0 {
             return Err(Error::last_os_error());
         }


### PR DESCRIPTION
To prevent the socket fd from leaking to child processes.

Signed-off-by: Tim Zhang <tim@hyper.sh>