### PR TITLE
CI: Fix rtnetlink example

### DIFF
--- a/rtnetlink/examples/ip_monitor.rs
+++ b/rtnetlink/examples/ip_monitor.rs
@@ -1,6 +1,6 @@
 use futures::stream::StreamExt;
 
-use netlink_proto::sys::constants::*;
+use netlink_packet_route::constants::*;
 use rtnetlink::{new_connection, sys::SocketAddr};
 
 #[tokio::main]


### PR DESCRIPTION
Got:

error[E0432]: unresolved import `netlink_proto::sys::constants`
 --> rtnetlink/examples/ip_monitor.rs:3:25
  |
3 | use netlink_proto::sys::constants::*;
  |                         ^^^^^^^^^ could not find `constants` in `sys`

When run `cd rtnetlink && cargo test`

This commit will fix this problem.

Signed-off-by: Tim Zhang <tim@hyper.sh>