### PR TITLE
Various netlink-proto Encoder impl fixes

### DIFF
--- a/netlink-proto/src/codecs.rs
+++ b/netlink-proto/src/codecs.rs
@@ -147,12 +147,8 @@ where
 
     fn encode(&mut self, msg: NetlinkMessage<T>, buf: &mut BytesMut) -> Result<(), Self::Error> {
         let msg_len = msg.buffer_len();
-        // FIXME: we should have a max length for the buffer
-        while buf.remaining_mut() < msg_len {
-            let new_len = buf.len() + 2048;
-            buf.resize(new_len, 0);
-        }
         if buf.remaining_mut() < msg_len {
+            // BytesMut can expand till usize::MAX... unlikely to hit this one.
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!(
@@ -171,6 +167,7 @@ where
         // implementation to users, we cannot guarantee
         // anything. Therefore we have to initialize the buffer
         // here.
+        buf.reserve(msg_len);
         let bytes = &mut buf.chunk_mut()[..msg_len];
         for i in 0..bytes.len() {
             bytes.write_byte(i, 0);

--- a/netlink-proto/src/codecs.rs
+++ b/netlink-proto/src/codecs.rs
@@ -152,13 +152,12 @@ where
             let new_len = buf.len() + 2048;
             buf.resize(new_len, 0);
         }
-        let size = msg.buffer_len();
-        if buf.remaining_mut() < size {
+        if buf.remaining_mut() < msg_len {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!(
                     "message is {} bytes, but only {} bytes left in the buffer",
-                    size,
+                    msg_len,
                     buf.remaining_mut()
                 ),
             ));
@@ -172,7 +171,7 @@ where
         // implementation to users, we cannot guarantee
         // anything. Therefore we have to initialize the buffer
         // here.
-        let bytes = &mut buf.chunk_mut()[..size];
+        let bytes = &mut buf.chunk_mut()[..msg_len];
         for i in 0..bytes.len() {
             bytes.write_byte(i, 0);
         }
@@ -182,7 +181,7 @@ where
 
             msg.serialize(initialized_bytes);
             trace!(">>> {:?}", msg);
-            buf.advance_mut(size);
+            buf.advance_mut(msg_len);
         }
         Ok(())
     }


### PR DESCRIPTION
Afaict the missing `reserve` before line 175 might actually cause panics when serializing messages that need more space than the current buffer `capacity` provides.

Hitting `buf.remaining_mut() < msg_len` is quite unlikely, but would probably end in OOM (and loop until it does).