### PR TITLE
Cargo dep paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,14 @@ members = [
     "rtnetlink",
     "audit",
 ]
+
+[patch.crates-io]
+netlink-sys = { path = "netlink-sys" }
+netlink-packet-core = { path = "netlink-packet-core" }
+netlink-packet-utils = { path = "netlink-packet-utils" }
+netlink-packet-route = { path = "netlink-packet-route" }
+netlink-packet-audit = { path = "netlink-packet-audit" }
+netlink-packet-sock-diag = { path = "netlink-packet-sock-diag" }
+netlink-proto = { path = "netlink-proto" }
+rtnetlink = { path = "rtnetlink" }
+audit = { path = "audit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,21 @@ members = [
     "netlink-packet-core",
     "netlink-packet-utils",
     "netlink-packet-route",
+    "netlink-packet-route/fuzz",
+    "netlink-packet-audit",
+    "netlink-packet-audit/fuzz",
+    "netlink-packet-sock-diag",
+    "netlink-proto",
+    "rtnetlink",
+    "audit",
+]
+
+# omit fuzz projects
+default-members = [
+    "netlink-sys",
+    "netlink-packet-core",
+    "netlink-packet-utils",
+    "netlink-packet-route",
     "netlink-packet-audit",
     "netlink-packet-sock-diag",
     "netlink-proto",

--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -14,8 +14,8 @@ description = "linux audit via netlink"
 [dependencies]
 futures = "0.3.11"
 thiserror = "1"
-netlink-packet-audit = { path = "../netlink-packet-audit", version = "0.2" }
-netlink-proto = { path = "../netlink-proto", default-features = false, version = "0.6" }
+netlink-packet-audit = "0.2"
+netlink-proto = { default-features = false, version = "0.6" }
 
 [features]
 default = ["tokio_socket"]

--- a/netlink-packet-audit/Cargo.toml
+++ b/netlink-packet-audit/Cargo.toml
@@ -14,8 +14,8 @@ description = "netlink packet types"
 [dependencies]
 anyhow = "1.0.31"
 byteorder = "1.3.2"
-netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }
-netlink-packet-utils = { path = "../netlink-packet-utils", version = ">= 0.3, <0.5" }
+netlink-packet-core = "0.2"
+netlink-packet-utils = ">= 0.3, <0.5"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/netlink-packet-audit/fuzz/Cargo.toml
+++ b/netlink-packet-audit/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "netlink-packet-fuzz"
+name = "netlink-packet-audit-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
@@ -13,15 +13,6 @@ netlink-packet-audit = "0.2"
 netlink-packet-core = "0.2"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "netlink-audit"
 path = "fuzz_targets/netlink.rs"
-
-[patch.crates-io]
-netlink-packet-core = { path = "../../netlink-packet-core" }
-netlink-packet-utils = { path = "../../netlink-packet-utils" }
-netlink-packet-audit = { path = ".." }

--- a/netlink-packet-audit/fuzz/Cargo.toml
+++ b/netlink-packet-audit/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-audit = { path = ".." }
-netlink-packet-core = { path = "../../netlink-packet-core" }
+netlink-packet-audit = "0.2"
+netlink-packet-core = "0.2"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 # Prevent this from interfering with workspaces
@@ -20,3 +20,8 @@ members = ["."]
 [[bin]]
 name = "netlink-audit"
 path = "fuzz_targets/netlink.rs"
+
+[patch.crates-io]
+netlink-packet-core = { path = "../../netlink-packet-core" }
+netlink-packet-utils = { path = "../../netlink-packet-utils" }
+netlink-packet-audit = { path = ".." }

--- a/netlink-packet-audit/fuzz/fuzz_targets/netlink.rs
+++ b/netlink-packet-audit/fuzz/fuzz_targets/netlink.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use netlink_packet_audit::{NetlinkMessage, AuditMessage};
+use netlink_packet_audit::{AuditMessage, NetlinkMessage};
 
 fuzz_target!(|data: &[u8]| {
     let _ = NetlinkMessage::<AuditMessage>::deserialize(&data);

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "netlink packet types"
 anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
-netlink-packet-utils = { path = "../netlink-packet-utils", version = ">=0.3, <0.5"}
+netlink-packet-utils = ">=0.3, <0.5"
 
 [dev-dependencies]
-netlink-packet-route = {path = "../netlink-packet-route" }
+netlink-packet-route = "0.7"

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -15,8 +15,8 @@ description = "netlink packet types"
 anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
-netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }
-netlink-packet-utils = { path = "../netlink-packet-utils", version = "0.4" }
+netlink-packet-core = "0.2"
+netlink-packet-utils = "0.4"
 bitflags = "1.2.1"
 
 [[example]]
@@ -26,7 +26,7 @@ name = "dump_links"
 criterion = "0.3.0"
 pcap-file = "1.1.1"
 lazy_static = "1.4.0"
-netlink-sys = { path = "../netlink-sys", version = "0.6" }
+netlink-sys = "0.6"
 
 [[bench]]
 name = "link_message"

--- a/netlink-packet-route/fuzz/Cargo.toml
+++ b/netlink-packet-route/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-route = { path = ".." }
+netlink-packet-route = "0.7"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 # Prevent this from interfering with workspaces
@@ -19,3 +19,8 @@ members = ["."]
 [[bin]]
 name = "netlink-route"
 path = "fuzz_targets/netlink.rs"
+
+[patch.crates-io]
+netlink-packet-core = { path = "../../netlink-packet-core" }
+netlink-packet-utils = { path = "../../netlink-packet-utils" }
+netlink-packet-route = { path = ".." }

--- a/netlink-packet-route/fuzz/Cargo.toml
+++ b/netlink-packet-route/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "netlink-packet-fuzz"
+name = "netlink-packet-route-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
@@ -12,15 +12,6 @@ cargo-fuzz = true
 netlink-packet-route = "0.7"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "netlink-route"
 path = "fuzz_targets/netlink.rs"
-
-[patch.crates-io]
-netlink-packet-core = { path = "../../netlink-packet-core" }
-netlink-packet-utils = { path = "../../netlink-packet-utils" }
-netlink-packet-route = { path = ".." }

--- a/netlink-packet-route/fuzz/fuzz_targets/netlink.rs
+++ b/netlink-packet-route/fuzz/fuzz_targets/netlink.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use netlink_packet_route::{RtnlMessage, NetlinkMessage};
+use netlink_packet_route::{NetlinkMessage, RtnlMessage};
 
 fuzz_target!(|data: &[u8]| {
     let _ = NetlinkMessage::<RtnlMessage>::deserialize(&data);

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -14,12 +14,12 @@ description = "netlink packet types for the sock_diag subprotocol"
 [dependencies]
 anyhow = "1.0.32"
 byteorder = "1.3.4"
-netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }
-netlink-packet-utils = { path = "../netlink-packet-utils", version = ">= 0.3, <0.5" }
+netlink-packet-core = "0.2"
+netlink-packet-utils = ">= 0.3, <0.5"
 bitflags = "1.2.1"
 libc = "0.2.77"
 smallvec = "1.4.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-netlink-sys = { path = "../netlink-sys", version = "0.6" }
+netlink-sys = "0.6"

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -17,8 +17,8 @@ log = "0.4.8"
 futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.6", default-features = false, features = ["codec"] }
-netlink-packet-core = { path = "../netlink-packet-core", version = "0.2" }
-netlink-sys = { path = "../netlink-sys", default-features = false, version = "0.6" }
+netlink-packet-core = "0.2"
+netlink-sys = { default-features = false, version = "0.6" }
 
 [features]
 default = ["tokio_socket"]
@@ -29,8 +29,8 @@ workaround-audit-bug = []
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = { path = "../netlink-packet-route" }
-netlink-packet-audit = { path = "../netlink-packet-audit" }
+netlink-packet-route = "0.7"
+netlink-packet-audit = "0.2"
 async-std = {version = "1.9.0", features = ["attributes"]}
 
 [[example]]

--- a/netlink-sys/Cargo.toml
+++ b/netlink-sys/Cargo.toml
@@ -36,7 +36,7 @@ tokio_socket = ["tokio", "futures"]
 smol_socket = ["async-io","futures"]
 
 [dev-dependencies]
-netlink-packet-audit = { path = "../netlink-packet-audit" }
+netlink-packet-audit = "0.2"
 
 [dev-dependencies.tokio]
 version = "1.0.1"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -22,8 +22,8 @@ smol_socket = ["netlink-proto/smol_socket","netlink-proto/workaround-audit-bug",
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
-netlink-packet-route = { path = "../netlink-packet-route", version = "0.7" }
-netlink-proto = { path = "../netlink-proto", default-features = false, version = "0.6" }
+netlink-packet-route = "0.7"
+netlink-proto = { default-features = false, version = "0.6" }
 byteordered = "0.5.0"
 nix = "0.19.0"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}


### PR DESCRIPTION
In my experience the best solution to link multiple crates in a single repository is using a `[patch.crates-io]` section in the virtual root manifest adding the paths to crates used by other crates in the repository.

This allows me for example to patch a single crate in the checkout into another project of mine without getting type conflicts from the other crates in the repo I didn't patch in the other project.

It also should be easier to publish crates as you don't need to hot-patch the `Crate.toml`s before release and using `--allow-dirty` or temporary commits.

A few [dev-]dependencies didn't specify a version before; I tried my best to guess something useful.

The second commit also adds the fuzz projects to the main workspace (but disables them for default build/... commands) and makes their names unique; specifying `--all` builds the fuzz projects too, so this also includes `fmt` updates in the fuzz code.