### PR TITLE
Support batch messages

### DIFF
--- a/netlink-proto/src/codecs.rs
+++ b/netlink-proto/src/codecs.rs
@@ -187,3 +187,21 @@ where
         Ok(())
     }
 }
+
+impl<T> Encoder<Vec<NetlinkMessage<T>>> for NetlinkCodec<NetlinkMessage<T>>
+where
+    T: Debug + Eq + PartialEq + Clone + NetlinkSerializable<T>,
+{
+    type Error = io::Error;
+
+    fn encode(
+        &mut self,
+        batch: Vec<NetlinkMessage<T>>,
+        buf: &mut BytesMut,
+    ) -> Result<(), Self::Error> {
+        for msg in batch {
+            self.encode(msg, buf)?;
+        }
+        Ok(())
+    }
+}

--- a/netlink-proto/src/connection.rs
+++ b/netlink-proto/src/connection.rs
@@ -23,6 +23,7 @@ use crate::{
     codecs::NetlinkCodec,
     framed::NetlinkFramed,
     sys::{Socket, SocketAddr},
+    BatchQueueElem,
     Protocol,
     Request,
     Response,
@@ -92,14 +93,29 @@ where
                 return;
             }
 
-            let (mut message, addr) = protocol.outgoing_messages.pop_front().unwrap();
-            message.finalize();
+            match protocol.outgoing_messages.pop_front().unwrap() {
+                BatchQueueElem::Single(mut message, addr) => {
+                    message.finalize();
 
-            trace!("sending outgoing message");
-            if let Err(e) = Pin::as_mut(&mut socket).start_send((message, addr)) {
-                error!("failed to send message: {:?}", e);
-                self.socket_closed = true;
-                return;
+                    trace!("sending outgoing message");
+                    if let Err(e) = Pin::as_mut(&mut socket).start_send((message, addr)) {
+                        error!("failed to send message: {:?}", e);
+                        self.socket_closed = true;
+                        return;
+                    }
+                }
+                BatchQueueElem::Batch(mut messages, addr) => {
+                    for message in &mut messages {
+                        message.finalize();
+                    }
+
+                    trace!("sending outgoing message");
+                    if let Err(e) = Pin::as_mut(&mut socket).start_send((messages, addr)) {
+                        error!("failed to send message: {:?}", e);
+                        self.socket_closed = true;
+                        return;
+                    }
+                }
             }
         }
 

--- a/netlink-proto/src/framed.rs
+++ b/netlink-proto/src/framed.rs
@@ -22,6 +22,60 @@ pub struct NetlinkFramed<C> {
     flushed: bool,
 }
 
+impl<C> NetlinkFramed<C>
+where
+    C: Unpin,
+{
+    // independent of Sink item type
+    pub(crate) fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if !self.flushed {
+            match self.poll_flush(cx)? {
+                Poll::Ready(()) => {}
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    // independent of Sink item type
+    pub(crate) fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.flushed {
+            return Poll::Ready(Ok(()));
+        }
+
+        trace!("flushing frame; length={}", self.writer.len());
+        let Self {
+            ref mut socket,
+            ref mut out_addr,
+            ref mut writer,
+            ..
+        } = *self;
+
+        let n = ready!(socket.poll_send_to(cx, &writer, &out_addr))?;
+        trace!("written {}", n);
+
+        let wrote_all = n == self.writer.len();
+        self.writer.clear();
+        self.flushed = true;
+
+        let res = if wrote_all {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            )
+            .into())
+        };
+
+        Poll::Ready(res)
+    }
+}
+
 impl<C> Stream for NetlinkFramed<C>
 where
     C: Decoder + Unpin,
@@ -78,13 +132,7 @@ impl<C: Encoder<Item> + Unpin, Item> Sink<(Item, SocketAddr)> for NetlinkFramed<
     type Error = C::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if !self.flushed {
-            match self.poll_flush(cx)? {
-                Poll::Ready(()) => {}
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-
+        ready!(Self::poll_ready(self, cx))?;
         Poll::Ready(Ok(()))
     }
 
@@ -99,41 +147,13 @@ impl<C: Encoder<Item> + Unpin, Item> Sink<(Item, SocketAddr)> for NetlinkFramed<
         Ok(())
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if self.flushed {
-            return Poll::Ready(Ok(()));
-        }
-
-        trace!("flushing frame; length={}", self.writer.len());
-        let Self {
-            ref mut socket,
-            ref mut out_addr,
-            ref mut writer,
-            ..
-        } = *self;
-
-        let n = ready!(socket.poll_send_to(cx, &writer, &out_addr))?;
-        trace!("written {}", n);
-
-        let wrote_all = n == self.writer.len();
-        self.writer.clear();
-        self.flushed = true;
-
-        let res = if wrote_all {
-            Ok(())
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "failed to write entire datagram to socket",
-            )
-            .into())
-        };
-
-        Poll::Ready(res)
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(Self::poll_flush(self, cx))?;
+        Poll::Ready(Ok(()))
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        ready!(self.poll_flush(cx))?;
+        ready!(Self::poll_flush(self, cx))?;
         Poll::Ready(Ok(()))
     }
 }

--- a/netlink-proto/src/handle.rs
+++ b/netlink-proto/src/handle.rs
@@ -40,7 +40,11 @@ where
         destination: SocketAddr,
     ) -> Result<impl Stream<Item = NetlinkMessage<T>>, Error<T>> {
         let (tx, rx) = unbounded::<NetlinkMessage<T>>();
-        let request = Request::from((message, destination, tx));
+        let request = Request::Single {
+            message,
+            destination,
+            metadata: tx,
+        };
         debug!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request).map_err(|e| {
             // the channel is unbounded, so it can't be full. If this
@@ -62,7 +66,11 @@ where
         destination: SocketAddr,
     ) -> Result<(), Error<T>> {
         let (tx, _rx) = unbounded::<NetlinkMessage<T>>();
-        let request = Request::from((message, destination, tx));
+        let request = Request::Single {
+            message,
+            destination,
+            metadata: tx,
+        };
         debug!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request)
             .map_err(|_| ErrorKind::ConnectionClosed.into())

--- a/netlink-proto/src/handle.rs
+++ b/netlink-proto/src/handle.rs
@@ -60,6 +60,18 @@ where
         Ok(rx)
     }
 
+    /// Start a batch of messages
+    ///
+    /// Collects multiple messages to be sent in one "request".
+    pub fn batch(&self, destination: SocketAddr) -> BatchHandle<T> {
+        BatchHandle {
+            handle: self.clone(),
+            destination,
+            messages: Vec::new(),
+            channels: Vec::new(),
+        }
+    }
+
     pub fn notify(
         &mut self,
         message: NetlinkMessage<T>,
@@ -74,5 +86,62 @@ where
         debug!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request)
             .map_err(|_| ErrorKind::ConnectionClosed.into())
+    }
+}
+
+/// A handle to create a batch request (multiple requests serialized in one buffer)
+#[derive(Debug)]
+#[must_use = "A batch of messages must be sent to actually do something"]
+pub struct BatchHandle<T>
+where
+    T: Debug + Clone + Eq + PartialEq,
+{
+    handle: ConnectionHandle<T>,
+    destination: SocketAddr,
+    messages: Vec<NetlinkMessage<T>>,
+    channels: Vec<UnboundedSender<NetlinkMessage<T>>>,
+}
+
+impl<T> BatchHandle<T>
+where
+    T: Debug + Clone + Eq + PartialEq,
+{
+    /// Add a new request to the batch and get the response as a stream of messages.
+    ///
+    /// Similar to [`ConnectionHandle::request`].
+    pub fn request(&mut self, message: NetlinkMessage<T>) -> impl Stream<Item = NetlinkMessage<T>> {
+        let (tx, rx) = unbounded::<NetlinkMessage<T>>();
+        self.messages.push(message);
+        self.channels.push(tx);
+        rx
+    }
+
+    /// Add a new request to the batch, but ignore response messages
+    ///
+    /// Similar to [`ConnectionHandle::notify`].
+    pub fn notify(&mut self, message: NetlinkMessage<T>) {
+        let _ = self.request(message);
+    }
+
+    /// Send of batch request
+    pub fn send(self) -> Result<(), Error<T>> {
+        debug!("handle: forwarding new request to connection");
+        let request = Request::Batch {
+            metadata: self.channels,
+            messages: self.messages,
+            destination: self.destination,
+        };
+        UnboundedSender::unbounded_send(&self.handle.requests_tx, request).map_err(|e| {
+            // the channel is unbounded, so it can't be full. If this
+            // failed, it means the Connection shut down.
+            if e.is_full() {
+                panic!("internal error: unbounded channel full?!");
+            } else if e.is_disconnected() {
+                Error::from(ErrorKind::ConnectionClosed)
+            } else {
+                panic!("unknown error: {:?}", e);
+            }
+        })?;
+        Ok(())
     }
 }

--- a/netlink-proto/src/lib.rs
+++ b/netlink-proto/src/lib.rs
@@ -164,7 +164,7 @@ mod framed;
 pub use crate::framed::*;
 
 mod protocol;
-pub(crate) use self::protocol::{Protocol, Response};
+pub(crate) use self::protocol::{BatchQueueElem, Protocol, Response};
 pub(crate) type Request<T> =
     self::protocol::Request<T, UnboundedSender<crate::packet::NetlinkMessage<T>>>;
 

--- a/netlink-proto/src/protocol/mod.rs
+++ b/netlink-proto/src/protocol/mod.rs
@@ -2,5 +2,5 @@
 mod protocol;
 mod request;
 
-pub use protocol::{Protocol, Response};
+pub use protocol::{BatchQueueElem, Protocol, Response};
 pub use request::Request;

--- a/netlink-proto/src/protocol/protocol.rs
+++ b/netlink-proto/src/protocol/protocol.rs
@@ -46,6 +46,15 @@ struct PendingRequest<M> {
     metadata: M,
 }
 
+#[derive(Debug)]
+pub enum BatchQueueElem<T>
+where
+    T: Debug + Clone + PartialEq + Eq + NetlinkSerializable<T> + NetlinkDeserializable<T>,
+{
+    Single(NetlinkMessage<T>, SocketAddr),
+    Batch(Vec<NetlinkMessage<T>>, SocketAddr),
+}
+
 #[derive(Debug, Default)]
 pub struct Protocol<T, M>
 where
@@ -66,7 +75,7 @@ where
     pub incoming_requests: VecDeque<(NetlinkMessage<T>, SocketAddr)>,
 
     /// The messages to be sent out
-    pub outgoing_messages: VecDeque<(NetlinkMessage<T>, SocketAddr)>,
+    pub outgoing_messages: VecDeque<BatchQueueElem<T>>,
 }
 
 impl<T, M> Protocol<T, M>
@@ -136,17 +145,15 @@ where
         debug!("done handling response to request {:?}", request_id);
     }
 
-    pub fn request(&mut self, request: Request<T, M>) {
-        let Request::Single {
-            mut message,
-            metadata,
-            destination,
-        } = request;
-
-        self.set_sequence_id(&mut message);
+    fn request_single(
+        &mut self,
+        message: &mut NetlinkMessage<T>,
+        metadata: M,
+        destination: &SocketAddr,
+    ) {
+        self.set_sequence_id(message);
         let request_id = RequestId::new(self.sequence_id, destination.port_number());
         let flags = message.header.flags;
-        self.outgoing_messages.push_back((message, destination));
 
         // If we expect a response, we store the request id so that we
         // can map the response to this specific request.
@@ -167,6 +174,32 @@ where
                     metadata,
                 },
             );
+        }
+    }
+
+    pub fn request(&mut self, request: Request<T, M>) {
+        match request {
+            Request::Single {
+                mut message,
+                metadata,
+                destination,
+            } => {
+                self.request_single(&mut message, metadata, &destination);
+                self.outgoing_messages
+                    .push_back(BatchQueueElem::Single(message, destination));
+            }
+            Request::Batch {
+                mut messages,
+                metadata,
+                destination,
+            } => {
+                assert_eq!(messages.len(), metadata.len());
+                for (msg, md) in messages.iter_mut().zip(metadata.into_iter()) {
+                    self.request_single(msg, md, &destination);
+                }
+                self.outgoing_messages
+                    .push_back(BatchQueueElem::Batch(messages, destination));
+            }
         }
     }
 

--- a/netlink-proto/src/protocol/protocol.rs
+++ b/netlink-proto/src/protocol/protocol.rs
@@ -137,7 +137,7 @@ where
     }
 
     pub fn request(&mut self, request: Request<T, M>) {
-        let Request {
+        let Request::Single {
             mut message,
             metadata,
             destination,

--- a/netlink-proto/src/protocol/request.rs
+++ b/netlink-proto/src/protocol/request.rs
@@ -5,36 +5,14 @@ use netlink_packet_core::NetlinkMessage;
 use crate::sys::SocketAddr;
 
 #[derive(Debug)]
-pub struct Request<T, M>
+pub enum Request<T, M>
 where
     T: Debug + Clone + Eq + PartialEq,
     M: Debug,
 {
-    pub metadata: M,
-    pub message: NetlinkMessage<T>,
-    pub destination: SocketAddr,
-}
-
-impl<T, M> From<(NetlinkMessage<T>, SocketAddr, M)> for Request<T, M>
-where
-    T: Debug + PartialEq + Eq + Clone,
-    M: Debug,
-{
-    fn from(parts: (NetlinkMessage<T>, SocketAddr, M)) -> Self {
-        Request {
-            message: parts.0,
-            destination: parts.1,
-            metadata: parts.2,
-        }
-    }
-}
-
-impl<T, M> From<Request<T, M>> for (NetlinkMessage<T>, SocketAddr, M)
-where
-    T: Debug + PartialEq + Eq + Clone,
-    M: Debug,
-{
-    fn from(req: Request<T, M>) -> (NetlinkMessage<T>, SocketAddr, M) {
-        (req.message, req.destination, req.metadata)
-    }
+    Single {
+        metadata: M,
+        message: NetlinkMessage<T>,
+        destination: SocketAddr,
+    },
 }

--- a/netlink-proto/src/protocol/request.rs
+++ b/netlink-proto/src/protocol/request.rs
@@ -15,4 +15,9 @@ where
         message: NetlinkMessage<T>,
         destination: SocketAddr,
     },
+    Batch {
+        metadata: Vec<M>,
+        messages: Vec<NetlinkMessage<T>>,
+        destination: SocketAddr,
+    },
 }


### PR DESCRIPTION
This is motivated by netfilter; changes to netfilter must be done through a series of messages (started by `NFNL_MSG_BATCH_BEGIN`, ended by `NFNL_MSG_BATCH_END`).  The full batch needs to be submitted to the kernel in one write/sendto/..., otherwise the kernel will abort the batch.