### PR TITLE
bump versions

### DIFF
--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ description = "linux audit via netlink"
 futures = "0.3.11"
 thiserror = "1"
 netlink-packet-audit = "0.2"
-netlink-proto = { default-features = false, version = "0.6" }
+netlink-proto = { default-features = false, version = "0.7" }
 
 [features]
 default = ["tokio_socket"]

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -26,7 +26,7 @@ name = "dump_links"
 criterion = "0.3.0"
 pcap-file = "1.1.1"
 lazy_static = "1.4.0"
-netlink-sys = "0.6"
+netlink-sys = "0.7"
 
 [[bench]]
 name = "link_message"

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -22,4 +22,4 @@ smallvec = "1.4.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-netlink-sys = "0.6"
+netlink-sys = "0.7"

--- a/netlink-packet-utils/Cargo.toml
+++ b/netlink-packet-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-utils"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.6", default-features = false, features = ["codec"] }
 netlink-packet-core = "0.2"
-netlink-sys = { default-features = false, version = "0.6" }
+netlink-sys = { default-features = false, version = "0.7" }
 
 [features]
 default = ["tokio_socket"]

--- a/netlink-sys/Cargo.toml
+++ b/netlink-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-sys"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -23,7 +23,7 @@ futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-packet-route = "0.7"
-netlink-proto = { default-features = false, version = "0.6" }
+netlink-proto = { default-features = false, version = "0.7" }
 byteordered = "0.5.0"
 nix = "0.19.0"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}


### PR DESCRIPTION
- netlink-packet-utils: 0.4.0 -> 0.4.1
- netlink-packet-route: 0.7.0 -> 0.7.1
- netlink-sys: 0.6 -> 0.7
- netlink-proto: 0.6 -> 0.7
- audit: 0.3.1 -> 0.4
- rtnetlink 0.7 -> 0.8