### PR TITLE
Do not require `workaround-audit-bug` feature on rtnetlink

### DIFF
--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -19,9 +19,8 @@ netlink-proto = { default-features = false, version = "0.7" }
 
 [features]
 default = ["tokio_socket"]
-tokio_socket = ["netlink-proto/tokio_socket","netlink-proto/workaround-audit-bug"]
-smol_socket = ["netlink-proto/smol_socket","netlink-proto/workaround-audit-bug"]
-
+tokio_socket = ["netlink-proto/tokio_socket", "netlink-proto/workaround-audit-bug"]
+smol_socket = ["netlink-proto/smol_socket", "netlink-proto/workaround-audit-bug"]
 
 [dev-dependencies]
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -14,9 +14,8 @@ description = "manipulate linux networking resources via netlink"
 [features]
 test_as_root = []
 default = ["tokio_socket"]
-tokio_socket = ["netlink-proto/tokio_socket","netlink-proto/workaround-audit-bug", "tokio"]
-smol_socket = ["netlink-proto/smol_socket","netlink-proto/workaround-audit-bug","async-std"]
-
+tokio_socket = ["netlink-proto/tokio_socket", "tokio"]
+smol_socket = ["netlink-proto/smol_socket", "async-std"]
 
 [dependencies]
 futures = "0.3.11"


### PR DESCRIPTION
It was introduced by #144 (mistakenly, I guess). I assume it's a copy/paste error from the `audit` crate.
Fixes #173