### PR TITLE
vlan: Fix endianness when creating VLAN

### DIFF
--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -748,7 +748,7 @@ impl Nla for InfoVlan {
 
             Id(ref value)
                 | Protocol(ref value)
-                => BigEndian::write_u16(buffer, *value),
+                => NativeEndian::write_u16(buffer, *value),
 
             Flags(ref flags) => {
                 NativeEndian::write_u32(buffer, flags.0);


### PR DESCRIPTION
According to kernel code, the VLAN ID is using native endianness:

linux/net/8021q/vlan_netlink.c

```c
	if (data[IFLA_VLAN_ID]) {
		id = nla_get_u16(data[IFLA_VLAN_ID]);
		if (id >= VLAN_VID_MASK) {
			NL_SET_ERR_MSG_MOD(extack, "Invalid VLAN id");
			return -ERANGE;
		}
	}
```