### PR TITLE
rtnetlink: drop byteordered dependency

### DIFF
--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -23,7 +23,6 @@ log = "0.4.8"
 thiserror = "1"
 netlink-packet-route = "0.8"
 netlink-proto = { default-features = false, version = "0.7" }
-byteordered = "0.5.0"
 nix = "0.22.0"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-std = { version = "1.9.0", features = ["unstable"], optional = true}


### PR DESCRIPTION
byteordered dependency is not used anymore and if needed in the future
we should use byteorder instead.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>