### PR TITLE
ethtool: Include feature query support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,3 +80,8 @@ jobs:
         run: |
           cd genetlink
           cargo test --features tokio_socket
+
+      - name: test (ethtool)
+        run: |
+          cd ethtool
+          cargo test

--- a/ethtool/examples/dump_features.rs
+++ b/ethtool/examples/dump_features.rs
@@ -1,0 +1,29 @@
+use ethtool;
+use futures::stream::TryStreamExt;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(get_feature(None));
+}
+
+async fn get_feature(iface_name: Option<&str>) {
+    let (connection, mut handle, _) = ethtool::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut feature_handle = handle.feature().get(iface_name).execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = feature_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() > 0);
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/ethtool/src/feature/attr.rs
+++ b/ethtool/src/feature/attr.rs
@@ -1,0 +1,219 @@
+use anyhow::Context;
+use log::warn;
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::{parse_string, parse_u32},
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+use crate::{EthtoolAttr, EthtoolHeader};
+
+const ETHTOOL_A_FEATURES_HEADER: u16 = 1;
+const ETHTOOL_A_FEATURES_HW: u16 = 2; // User changable features
+const ETHTOOL_A_FEATURES_WANTED: u16 = 3; // User requested fatures
+const ETHTOOL_A_FEATURES_ACTIVE: u16 = 4; // Active features
+const ETHTOOL_A_FEATURES_NOCHANGE: u16 = 5;
+
+const ETHTOOL_A_BITSET_BITS: u16 = 3;
+
+const ETHTOOL_A_BITSET_BITS_BIT: u16 = 1;
+
+const ETHTOOL_A_BITSET_BIT_INDEX: u16 = 1;
+const ETHTOOL_A_BITSET_BIT_NAME: u16 = 2;
+const ETHTOOL_A_BITSET_BIT_VALUE: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EthtoolFeatureBit {
+    pub index: u32,
+    pub name: String,
+    pub value: bool,
+}
+
+impl EthtoolFeatureBit {
+    fn new(has_mask: bool) -> Self {
+        Self {
+            index: 0,
+            name: "".into(),
+            value: !has_mask,
+        }
+    }
+}
+
+fn feature_bits_len(_feature_bits: &[EthtoolFeatureBit]) -> usize {
+    todo!("Does not support changing ethtool feature yet")
+}
+
+fn feature_bits_emit(_feature_bits: &[EthtoolFeatureBit], _buffer: &mut [u8]) {
+    todo!("Does not support changing ethtool feature yet")
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolFeatureAttr {
+    Header(Vec<EthtoolHeader>),
+    Hw(Vec<EthtoolFeatureBit>),
+    Wanted(Vec<EthtoolFeatureBit>),
+    Active(Vec<EthtoolFeatureBit>),
+    NoChange(Vec<EthtoolFeatureBit>),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolFeatureAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::Hw(feature_bits)
+            | Self::Wanted(feature_bits)
+            | Self::Active(feature_bits)
+            | Self::NoChange(feature_bits) => feature_bits_len(feature_bits.as_slice()),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_FEATURES_HEADER | NLA_F_NESTED,
+            Self::Hw(_) => ETHTOOL_A_FEATURES_HW | NLA_F_NESTED,
+            Self::Wanted(_) => ETHTOOL_A_FEATURES_WANTED | NLA_F_NESTED,
+            Self::Active(_) => ETHTOOL_A_FEATURES_ACTIVE | NLA_F_NESTED,
+            Self::NoChange(_) => ETHTOOL_A_FEATURES_NOCHANGE | NLA_F_NESTED,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Hw(feature_bits)
+            | Self::Wanted(feature_bits)
+            | Self::Active(feature_bits)
+            | Self::NoChange(feature_bits) => feature_bits_emit(feature_bits.as_slice(), buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for EthtoolFeatureAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_FEATURES_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse feature header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed = EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_FEATURES_HW => {
+                Self::Hw(parse_bitset_bits_nlas(
+                    payload, true, /* ETHTOOL_A_FEATURES_HW is using mask */
+                )?)
+            }
+            ETHTOOL_A_FEATURES_WANTED => {
+                Self::Wanted(parse_bitset_bits_nlas(
+                    payload, false, /* ETHTOOL_A_FEATURES_WANTED does not use mask */
+                )?)
+            }
+            ETHTOOL_A_FEATURES_ACTIVE => {
+                Self::Active(parse_bitset_bits_nlas(
+                    payload, false, /* ETHTOOL_A_FEATURES_ACTIVE does not use mask */
+                )?)
+            }
+            ETHTOOL_A_FEATURES_NOCHANGE => {
+                Self::NoChange(parse_bitset_bits_nlas(
+                    payload, false, /* ETHTOOL_A_FEATURES_NOCHANGE does not use mask */
+                )?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+fn parse_bitset_bits_nlas(
+    raw: &[u8],
+    has_mask: bool,
+) -> Result<Vec<EthtoolFeatureBit>, DecodeError> {
+    let error_msg = "failed to parse feature bit sets";
+    for nla in NlasIterator::new(raw) {
+        let nla = &nla.context(error_msg)?;
+        if nla.kind() == ETHTOOL_A_BITSET_BITS {
+            return parse_bitset_bits_nla(nla.value(), has_mask);
+        }
+    }
+    Err("No ETHTOOL_A_BITSET_BITS NLA found".into())
+}
+
+fn parse_bitset_bits_nla(
+    raw: &[u8],
+    has_mask: bool,
+) -> Result<Vec<EthtoolFeatureBit>, DecodeError> {
+    let mut feature_bits = Vec::new();
+    let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS attributes";
+    for bit_nla in NlasIterator::new(raw) {
+        let bit_nla = &bit_nla.context(error_msg)?;
+        match bit_nla.kind() {
+            ETHTOOL_A_BITSET_BITS_BIT => {
+                let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS_BIT attributes";
+                let nlas = NlasIterator::new(bit_nla.value());
+                let mut cur_bit_info = EthtoolFeatureBit::new(has_mask);
+                for nla in nlas {
+                    let nla = &nla.context(error_msg)?;
+                    let payload = nla.value();
+                    match nla.kind() {
+                        ETHTOOL_A_BITSET_BIT_INDEX => {
+                            if cur_bit_info.index != 0 && !&cur_bit_info.name.is_empty() {
+                                feature_bits.push(cur_bit_info);
+                                cur_bit_info = EthtoolFeatureBit::new(has_mask);
+                            }
+                            cur_bit_info.index = parse_u32(payload)
+                                .context("Invald ETHTOOL_A_BITSET_BIT_INDEX value")?;
+                        }
+                        ETHTOOL_A_BITSET_BIT_NAME => {
+                            cur_bit_info.name = parse_string(payload)
+                                .context("Invald ETHTOOL_A_BITSET_BIT_NAME value")?;
+                        }
+                        ETHTOOL_A_BITSET_BIT_VALUE => {
+                            cur_bit_info.value = true;
+                        }
+                        _ => {
+                            warn!(
+                                "Unknown ETHTOOL_A_BITSET_BITS_BIT {} {:?}",
+                                nla.kind(),
+                                nla.value(),
+                            );
+                        }
+                    }
+                }
+                if cur_bit_info.index != 0 && !&cur_bit_info.name.is_empty() {
+                    feature_bits.push(cur_bit_info);
+                }
+            }
+            _ => {
+                warn!(
+                    "Unknown ETHTOOL_A_BITSET_BITS kind {}, {:?}",
+                    bit_nla.kind(),
+                    bit_nla.value()
+                );
+            }
+        };
+    }
+    Ok(feature_bits)
+}
+
+pub(crate) fn parse_feature_nlas(buffer: &[u8]) -> Result<Vec<EthtoolAttr>, DecodeError> {
+    let mut nlas = Vec::new();
+    for nla in NlasIterator::new(buffer) {
+        let error_msg = format!(
+            "Failed to parse ethtool feature message attribute {:?}",
+            nla
+        );
+        let nla = &nla.context(error_msg.clone())?;
+        let parsed = EthtoolFeatureAttr::parse(nla).context(error_msg)?;
+        nlas.push(EthtoolAttr::Feature(parsed));
+    }
+    Ok(nlas)
+}

--- a/ethtool/src/feature/get.rs
+++ b/ethtool/src/feature/get.rs
@@ -1,0 +1,52 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct EthtoolFeatureGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl EthtoolFeatureGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        EthtoolFeatureGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<EthtoolMessage>, Error = EthtoolError> {
+        let EthtoolFeatureGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let nl_header_flags = match iface_name {
+            // The NLM_F_ACK is required due to bug of kernel:
+            //  https://bugzilla.redhat.com/show_bug.cgi?id=1953847
+            // without `NLM_F_MULTI`, rust-netlink will not parse
+            // multiple netlink message in single socket reply.
+            // Using NLM_F_ACK will force rust-netlink to parse all till
+            // acked at the end.
+            None => NLM_F_DUMP | NLM_F_REQUEST | NLM_F_ACK,
+            Some(_) => NLM_F_REQUEST,
+        };
+
+        let ethtool_msg = EthtoolMessage::new_feature_get(iface_name.as_deref());
+
+        let mut nl_msg = NetlinkMessage::from(GenlMessage::from_payload(ethtool_msg));
+
+        nl_msg.header.flags = nl_header_flags;
+
+        match handle.request(nl_msg).await {
+            Ok(response) => Either::Left(response.map(move |msg| Ok(try_ethtool!(msg)))),
+            Err(e) => Either::Right(
+                futures::future::err::<GenlMessage<EthtoolMessage>, EthtoolError>(e).into_stream(),
+            ),
+        }
+    }
+}

--- a/ethtool/src/feature/handle.rs
+++ b/ethtool/src/feature/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolFeatureGetRequest, EthtoolHandle};
+
+pub struct EthtoolFeatureHandle(EthtoolHandle);
+
+impl EthtoolFeatureHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        EthtoolFeatureHandle(handle)
+    }
+
+    /// Retrieve the ethtool features of a interface (equivalent to `ethtool -k eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>) -> EthtoolFeatureGetRequest {
+        EthtoolFeatureGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/ethtool/src/feature/mod.rs
+++ b/ethtool/src/feature/mod.rs
@@ -1,0 +1,8 @@
+mod attr;
+mod get;
+mod handle;
+
+pub(crate) use attr::parse_feature_nlas;
+pub use attr::{EthtoolFeatureAttr, EthtoolFeatureBit};
+pub use get::EthtoolFeatureGetRequest;
+pub use handle::EthtoolFeatureHandle;

--- a/ethtool/src/handle.rs
+++ b/ethtool/src/handle.rs
@@ -4,7 +4,7 @@ use netlink_packet_core::NetlinkMessage;
 use netlink_packet_generic::GenlMessage;
 use netlink_packet_utils::DecodeError;
 
-use crate::{EthtoolError, EthtoolMessage, EthtoolPauseHandle};
+use crate::{EthtoolError, EthtoolFeatureHandle, EthtoolMessage, EthtoolPauseHandle};
 
 #[derive(Clone, Debug)]
 pub struct EthtoolHandle {
@@ -18,6 +18,10 @@ impl EthtoolHandle {
 
     pub fn pause(&mut self) -> EthtoolPauseHandle {
         EthtoolPauseHandle::new(self.clone())
+    }
+
+    pub fn feature(&mut self) -> EthtoolFeatureHandle {
+        EthtoolFeatureHandle::new(self.clone())
     }
 
     pub async fn request(

--- a/ethtool/src/lib.rs
+++ b/ethtool/src/lib.rs
@@ -1,5 +1,6 @@
 mod connection;
 mod error;
+mod feature;
 mod handle;
 mod header;
 mod macros;
@@ -8,9 +9,15 @@ mod pause;
 
 pub use connection::new_connection;
 pub use error::EthtoolError;
+pub use feature::{
+    EthtoolFeatureAttr,
+    EthtoolFeatureBit,
+    EthtoolFeatureGetRequest,
+    EthtoolFeatureHandle,
+};
 pub use handle::EthtoolHandle;
 pub use header::EthtoolHeader;
-pub use message::{EthtoolAttr, EthtoolMessage};
+pub use message::{EthtoolAttr, EthtoolCmd, EthtoolMessage};
 pub use pause::{
     EthtoolPauseAttr,
     EthtoolPauseGetRequest,

--- a/ethtool/tests/get_features_lo.rs
+++ b/ethtool/tests/get_features_lo.rs
@@ -1,0 +1,34 @@
+use futures::stream::TryStreamExt;
+
+#[test]
+fn test_get_features_of_loopback() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(get_feature(Some("lo")));
+}
+
+async fn get_feature(iface_name: Option<&str>) {
+    let (connection, mut handle, _) = ethtool::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut feature_handle = handle.feature().get(iface_name).execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = feature_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() == 1);
+    let ethtool_msg = &msgs[0].payload;
+
+    assert!(ethtool_msg.cmd == ethtool::EthtoolCmd::FeatureGetReply);
+    assert!(ethtool_msg.nlas.len() > 1);
+    assert!(
+        ethtool_msg.nlas[0]
+            == ethtool::EthtoolAttr::Feature(ethtool::EthtoolFeatureAttr::Header(vec![
+                ethtool::EthtoolHeader::DevIndex(1),
+                ethtool::EthtoolHeader::DevName("lo".into())
+            ]))
+    );
+}


### PR DESCRIPTION
Equivalent to `ethtool -k` command.

Example code been places at 'ethtool/examples/dump_features.rs'
Integration test case included and enabled in CI.