### PR TITLE
ethtool: Add link mode support

### DIFF
--- a/ethtool/examples/dump_link_mode.rs
+++ b/ethtool/examples/dump_link_mode.rs
@@ -1,0 +1,29 @@
+use ethtool;
+use futures::stream::TryStreamExt;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(get_link_mode(None));
+}
+
+async fn get_link_mode(iface_name: Option<&str>) {
+    let (connection, mut handle, _) = ethtool::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut link_mode_handle = handle.link_mode().get(iface_name).execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = link_mode_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() > 0);
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/ethtool/src/header.rs
+++ b/ethtool/src/header.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{
-    nla::{self, DefaultNla, NlaBuffer},
+    nla::{DefaultNla, Nla, NlaBuffer},
     parsers::{parse_string, parse_u32},
     DecodeError,
     Parseable,
@@ -22,7 +22,7 @@ pub enum EthtoolHeader {
     Other(DefaultNla),
 }
 
-impl nla::Nla for EthtoolHeader {
+impl Nla for EthtoolHeader {
     fn value_len(&self) -> usize {
         match self {
             Self::DevIndex(_) | Self::Flags(_) => 4,

--- a/ethtool/src/lib.rs
+++ b/ethtool/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 mod feature;
 mod handle;
 mod header;
+mod link_mode;
 mod macros;
 mod message;
 mod pause;
@@ -17,6 +18,12 @@ pub use feature::{
 };
 pub use handle::EthtoolHandle;
 pub use header::EthtoolHeader;
+pub use link_mode::{
+    EthtoolLinkModeAttr,
+    EthtoolLinkModeDuplex,
+    EthtoolLinkModeGetRequest,
+    EthtoolLinkModeHandle,
+};
 pub use message::{EthtoolAttr, EthtoolCmd, EthtoolMessage};
 pub use pause::{
     EthtoolPauseAttr,
@@ -24,3 +31,5 @@ pub use pause::{
     EthtoolPauseHandle,
     EthtoolPauseStatAttr,
 };
+
+pub(crate) use handle::ethtool_execute;

--- a/ethtool/src/link_mode/attr.rs
+++ b/ethtool/src/link_mode/attr.rs
@@ -1,0 +1,220 @@
+use anyhow::Context;
+use log::warn;
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::{parse_string, parse_u32, parse_u8},
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+use crate::{EthtoolAttr, EthtoolHeader};
+
+const ETHTOOL_A_LINKMODES_HEADER: u16 = 1;
+const ETHTOOL_A_LINKMODES_AUTONEG: u16 = 2;
+const ETHTOOL_A_LINKMODES_OURS: u16 = 3;
+const ETHTOOL_A_LINKMODES_PEER: u16 = 4;
+const ETHTOOL_A_LINKMODES_SPEED: u16 = 5;
+const ETHTOOL_A_LINKMODES_DUPLEX: u16 = 6;
+const ETHTOOL_A_LINKMODES_SUBORDINATE_CFG: u16 = 7;
+const ETHTOOL_A_LINKMODES_SUBORDINATE_STATE: u16 = 8;
+const ETHTOOL_A_LINKMODES_LANES: u16 = 9;
+
+const ETHTOOL_A_BITSET_BITS: u16 = 3;
+
+const ETHTOOL_A_BITSET_BITS_BIT: u16 = 1;
+
+const ETHTOOL_A_BITSET_BIT_INDEX: u16 = 1;
+const ETHTOOL_A_BITSET_BIT_NAME: u16 = 2;
+const ETHTOOL_A_BITSET_BIT_VALUE: u16 = 3;
+
+const DUPLEX_HALF: u8 = 0x00;
+const DUPLEX_FULL: u8 = 0x01;
+const DUPLEX_UNKNOWN: u8 = 0xff;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolLinkModeDuplex {
+    Half,
+    Full,
+    Unknown,
+    Other(u8),
+}
+
+impl From<u8> for EthtoolLinkModeDuplex {
+    fn from(d: u8) -> Self {
+        match d {
+            DUPLEX_HALF => Self::Half,
+            DUPLEX_FULL => Self::Full,
+            DUPLEX_UNKNOWN => Self::Unknown,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolLinkModeAttr {
+    Header(Vec<EthtoolHeader>),
+    Autoneg(bool),
+    Ours(Vec<String>),
+    Peer(Vec<String>),
+    Speed(u32),
+    Duplex(EthtoolLinkModeDuplex),
+    ControllerSubordinateCfg(u8),
+    ControllerSubordinateState(u8),
+    Lanes(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolLinkModeAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::Autoneg(_)
+            | Self::Duplex(_)
+            | Self::ControllerSubordinateCfg(_)
+            | Self::ControllerSubordinateState(_) => 1,
+            Self::Ours(_) => {
+                todo!("Does not support changing ethtool link mode yet")
+            }
+            Self::Peer(_) => {
+                todo!("Does not support changing ethtool link mode yet")
+            }
+            Self::Speed(_) | Self::Lanes(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_LINKMODES_HEADER | NLA_F_NESTED,
+            Self::Autoneg(_) => ETHTOOL_A_LINKMODES_AUTONEG,
+            Self::Ours(_) => ETHTOOL_A_LINKMODES_OURS,
+            Self::Peer(_) => ETHTOOL_A_LINKMODES_PEER,
+            Self::Speed(_) => ETHTOOL_A_LINKMODES_SPEED,
+            Self::Duplex(_) => ETHTOOL_A_LINKMODES_DUPLEX,
+            Self::ControllerSubordinateCfg(_) => ETHTOOL_A_LINKMODES_SUBORDINATE_CFG,
+            Self::ControllerSubordinateState(_) => ETHTOOL_A_LINKMODES_SUBORDINATE_STATE,
+            Self::Lanes(_) => ETHTOOL_A_LINKMODES_LANES,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+            _ => todo!("Does not support changing ethtool link mode yet"),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for EthtoolLinkModeAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_LINKMODES_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse link_mode header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed = EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_LINKMODES_AUTONEG => Self::Autoneg(
+                parse_u8(payload).context("Invalid ETHTOOL_A_LINKMODES_AUTONEG value")? == 1,
+            ),
+
+            ETHTOOL_A_LINKMODES_OURS => Self::Ours(parse_bitset_bits_nlas(payload)?),
+            ETHTOOL_A_LINKMODES_PEER => Self::Peer(parse_bitset_bits_nlas(payload)?),
+            ETHTOOL_A_LINKMODES_SPEED => {
+                Self::Speed(parse_u32(payload).context("Invalid ETHTOOL_A_LINKMODES_SPEED value")?)
+            }
+            ETHTOOL_A_LINKMODES_DUPLEX => Self::Duplex(
+                parse_u8(payload)
+                    .context("Invalid ETHTOOL_A_LINKMODES_DUPLEX value")?
+                    .into(),
+            ),
+            ETHTOOL_A_LINKMODES_SUBORDINATE_CFG => Self::ControllerSubordinateCfg(
+                parse_u8(payload).context("Invalid ETHTOOL_A_LINKMODES_SUBORDINATE_CFG value")?,
+            ),
+            ETHTOOL_A_LINKMODES_SUBORDINATE_STATE => Self::ControllerSubordinateState(
+                parse_u8(payload).context("Invalid ETHTOOL_A_LINKMODES_SUBORDINATE_STATE value")?,
+            ),
+            ETHTOOL_A_LINKMODES_LANES => {
+                Self::Lanes(parse_u32(payload).context("Invalid ETHTOOL_A_LINKMODES_LANES value")?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+fn parse_bitset_bits_nlas(raw: &[u8]) -> Result<Vec<String>, DecodeError> {
+    let error_msg = "failed to parse mode bit sets";
+    for nla in NlasIterator::new(raw) {
+        let nla = &nla.context(error_msg)?;
+        if nla.kind() == ETHTOOL_A_BITSET_BITS {
+            return parse_bitset_bits_nla(nla.value());
+        }
+    }
+    Err("No ETHTOOL_A_BITSET_BITS NLA found".into())
+}
+
+fn parse_bitset_bits_nla(raw: &[u8]) -> Result<Vec<String>, DecodeError> {
+    let mut modes = Vec::new();
+    let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS attributes";
+    for bit_nla in NlasIterator::new(raw) {
+        let bit_nla = &bit_nla.context(error_msg)?;
+        match bit_nla.kind() {
+            ETHTOOL_A_BITSET_BITS_BIT => {
+                let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS_BIT attributes";
+                let nlas = NlasIterator::new(bit_nla.value());
+                for nla in nlas {
+                    let nla = &nla.context(error_msg)?;
+                    let payload = nla.value();
+                    match nla.kind() {
+                        ETHTOOL_A_BITSET_BIT_INDEX | ETHTOOL_A_BITSET_BIT_VALUE => {
+                            // ignored
+                        }
+                        ETHTOOL_A_BITSET_BIT_NAME => {
+                            modes.push(
+                                parse_string(payload)
+                                    .context("Invald ETHTOOL_A_BITSET_BIT_NAME value")?,
+                            );
+                        }
+                        _ => {
+                            warn!(
+                                "Unknown ETHTOOL_A_BITSET_BITS_BIT {} {:?}",
+                                nla.kind(),
+                                nla.value(),
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {
+                warn!(
+                    "Unknown ETHTOOL_A_BITSET_BITS kind {}, {:?}",
+                    bit_nla.kind(),
+                    bit_nla.value()
+                );
+            }
+        };
+    }
+    Ok(modes)
+}
+
+pub(crate) fn parse_link_mode_nlas(buffer: &[u8]) -> Result<Vec<EthtoolAttr>, DecodeError> {
+    let mut nlas = Vec::new();
+    for nla in NlasIterator::new(buffer) {
+        let error_msg = format!(
+            "Failed to parse ethtool link_mode message attribute {:?}",
+            nla
+        );
+        let nla = &nla.context(error_msg.clone())?;
+        let parsed = EthtoolLinkModeAttr::parse(nla).context(error_msg)?;
+        nlas.push(EthtoolAttr::LinkMode(parsed));
+    }
+    Ok(nlas)
+}

--- a/ethtool/src/link_mode/get.rs
+++ b/ethtool/src/link_mode/get.rs
@@ -3,14 +3,14 @@ use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};
 
-pub struct EthtoolFeatureGetRequest {
+pub struct EthtoolLinkModeGetRequest {
     handle: EthtoolHandle,
     iface_name: Option<String>,
 }
 
-impl EthtoolFeatureGetRequest {
+impl EthtoolLinkModeGetRequest {
     pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
-        EthtoolFeatureGetRequest {
+        EthtoolLinkModeGetRequest {
             handle,
             iface_name: iface_name.map(|i| i.to_string()),
         }
@@ -19,12 +19,12 @@ impl EthtoolFeatureGetRequest {
     pub async fn execute(
         self,
     ) -> impl TryStream<Ok = GenlMessage<EthtoolMessage>, Error = EthtoolError> {
-        let EthtoolFeatureGetRequest {
+        let EthtoolLinkModeGetRequest {
             mut handle,
             iface_name,
         } = self;
 
-        let ethtool_msg = EthtoolMessage::new_feature_get(iface_name.as_deref());
+        let ethtool_msg = EthtoolMessage::new_link_mode_get(iface_name.as_deref());
         ethtool_execute(&mut handle, iface_name.is_none(), ethtool_msg).await
     }
 }

--- a/ethtool/src/link_mode/handle.rs
+++ b/ethtool/src/link_mode/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolHandle, EthtoolLinkModeGetRequest};
+
+pub struct EthtoolLinkModeHandle(EthtoolHandle);
+
+impl EthtoolLinkModeHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        EthtoolLinkModeHandle(handle)
+    }
+
+    /// Retrieve the ethtool link_modes(duplex, link speed and etc) of a interface
+    pub fn get(&mut self, iface_name: Option<&str>) -> EthtoolLinkModeGetRequest {
+        EthtoolLinkModeGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/ethtool/src/link_mode/mod.rs
+++ b/ethtool/src/link_mode/mod.rs
@@ -1,0 +1,8 @@
+mod attr;
+mod get;
+mod handle;
+
+pub(crate) use attr::parse_link_mode_nlas;
+pub use attr::{EthtoolLinkModeAttr, EthtoolLinkModeDuplex};
+pub use get::EthtoolLinkModeGetRequest;
+pub use handle::EthtoolLinkModeHandle;

--- a/ethtool/tests/dump_link_modes.rs
+++ b/ethtool/tests/dump_link_modes.rs
@@ -1,0 +1,29 @@
+use futures::stream::TryStreamExt;
+
+#[test]
+// CI container normally have a veth for external communication which support link modes of ethtool.
+fn test_dump_link_modes() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(dump_link_modes());
+}
+
+async fn dump_link_modes() {
+    let (connection, mut handle, _) = ethtool::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut link_modes_handle = handle.link_mode().get(None).execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = link_modes_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() >= 1);
+    let ethtool_msg = &msgs[0].payload;
+    println!("ethtool_msg {:?}", &ethtool_msg);
+
+    assert!(ethtool_msg.cmd == ethtool::EthtoolCmd::LinkModeGetReply);
+    assert!(ethtool_msg.nlas.len() > 1);
+}


### PR DESCRIPTION
Some information of `ethtool <nic_name>` is from link mode, like link
speed, duplex mode and etc.

Example code and integration test case included.
#