### PR TITLE
New group release 20210927

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,38 @@
+# Changelog
+## On-going
+### Versioning
+### Breaking Changes
+### New Features
+### Bug fixes
+
+## [20210927] 2021-09-27
+### Versioning
+ * audit 0.4.0
+ * ethtool NULL -> 0.1.0
+ * genetlink NULL -> 0.1.0
+ * netlink-packet-audit 0.2.2
+ * netlink-packet-core 0.2.4
+ * netlink-packet-generic NULL -> 0.1.0
+ * netlink-packet-route 0.7.0 -> 0.8.0
+ * netlink-packet-sock-diag 0.1.0
+ * netlink-packet-utils 0.4.1
+ * netlink-proto 0.7.0
+ * netlink-sys 0.7.0
+ * rtnetlink 0.8.0 -> 0.8.1
+
+### Breaking Changes
+ * `netlink_packet_route::rtnl::link::nlas::Nla::PropList` changed from
+ `PropList(Vec<u8>)` to `PropList(Vec<Prop>)` (b4b3c46)
+
+### New Features
+ * ethtool: New crate for ethtool netlink protocol (7998f8c, 2b79197, bc43fd6,
+   2ec5f17, cb8738b)
+ * genetlink: New create for higher level abstraction of generic netlink
+   protocol (89ee697)
+ * netlink-packet-generic: New crate for generic netlink protocol (89ee697)
+ * netlink-packet-route: Add support of property addition and deletion (cc073b3)
+ * rtnetlink: Add support of preferred source address (720e764)
+
+### Bug fixes
+ * netlink-packet-route: vlan: Fix endianness when creating VLAN (b0fd2ea)
+ * rtnetlink: drop byteordered dependency (8bca238)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This project aims at providing building blocks for [netlink][man-netlink] (see `
   depends on `netlink-packet-core` for the `NetlinkMessage` type and `netlink-sys` for the socket.
 - the [`rtnetlink`](./rtnetlink) crate provides higher level abstraction for the [route protocol][man-rtnetlink]
 - the [`audit`](./audit) crate provides higher level abstractions for the audit protocol.
+- the [`netlink-packet-generic`](./netlink-packet-generic) crate provide
+  message for the [generic netlink][man-genl]
+- the [`genetlink`](./genetlink) crate provide higher level abstraction for the
+  [generic netlink protocol][man-genl]
+- the [`ethtool`](./ethtool) crate provide higher level abstraction for
+  [ethtool netlink protocol][ethtool-kernel-doc]
 
 
 ## Altnernatives
@@ -50,6 +56,7 @@ tool they are building, and the support they provide.
 [man-audit]: https://man7.org/linux/man-pages/man3/audit_open.3.html
 [man-sock-diag]: https://www.man7.org/linux/man-pages/man7/sock_diag.7.html
 [man-rtnetlink]: https://www.man7.org/linux/man-pages/man7/rtnetlink.7.html
+[man-genl]: https://www.man7.org/linux/man-pages/man8/genl.8.html
 [generic-netlink-lwn]: https://lwn.net/Articles/208755/
 [mio]: https://github.com/tokio-rs/mio
 [tokio]: https://github.com/tokio-rs/tokio
@@ -60,3 +67,4 @@ tool they are building, and the support they provide.
 [whitequark-1]: https://lab.whitequark.org/notes/2016-12-13/abstracting-over-mutability-in-rust
 [whitequark-2]: https://lab.whitequark.org/notes/2016-12-17/owning-collections-in-heap-less-rust
 [whitequark-3]: https://lab.whitequark.org/notes/2017-01-16/abstracting-over-mutability-in-rust-macros
+[ethtool-kernel-doc]: https://www.kernel.org/doc/html/latest/networking/ethtool-netlink.html

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -4,8 +4,14 @@
 
 - bump the versions in the Cargo.toml using `git blame` and `git log`,
   starting from the `netlink-packet-*` and `netlink-sys` crates
-- check that `cargo test` still works once your done
-- `cargo publish`
+- Update the `CHANGELOG` file with version changes, new features, bug fixes
+  and breaking changes
+- Check that `cargo test` still works once your done
+- Create pull request for the changes for CHANGELOG and version dumping.
+- Create new tag via command `git tag --sign $(date +%Y%m%d)`
+- Publish the tag to github via command `git push --tags upstream`
+- Create new release page at [github webpage][github_new_release]
+- Publish the crates via command `cargo publish` in changed crate folders
 
 ## Detailed process
 
@@ -15,7 +21,7 @@ First, distinguish three groups of crates:
 
 - `netlink-packet-*` crates
 - `netlink-sys`
-- `netlink-proto`, `audit` and `rtnetlink`, which depend on the the two other groups
+- `netlink-proto`, `audit` and `rtnetlink`, which depend on the two other groups
 
 Usually start by bumping the versions of the first group of crates,
 then `netlink-sys`, and then the last group of crates.
@@ -138,3 +144,5 @@ if `netlink-packet-utils` is bumped from 0.x to 0.x+1,
 then `cargo publish --dry-run` will not work for `netlink-packet-core`,
 because the crate depends on `netlink-packet-utils` 0.x+1, which hasn't be
 published yet.
+
+[github_new_release]: https://github.com/little-dude/netlink/releases/new

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -18,4 +18,4 @@ libc = "0.2.66"
 netlink-packet-utils = ">=0.3, <0.5"
 
 [dev-dependencies]
-netlink-packet-route = "0.7"
+netlink-packet-route = "0.8"

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -29,7 +29,7 @@ workaround-audit-bug = []
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = "0.7"
+netlink-packet-route = "0.8"
 netlink-packet-audit = "0.2"
 async-std = {version = "1.9.0", features = ["attributes"]}
 

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
### Versioning
 * ethtool NULL -> 0.1.0
 * genetlink NULL -> 0.1.0
 * netlink-packet-generic NULL -> 0.1.0
 * netlink-packet-route 0.7.0 -> 0.8.0
 * rtnetlink 0.8.0 -> 0.8.1

### Breaking Changes
 * `netlink_packet_route::rtnl::link::nlas::Nla::PropList` changed from
 `PropList(Vec<u8>)` to `PropList(Vec<Prop>)` (b4b3c46)

### New Features
 * ethtool: New crate for ethtool netlink protocol (7998f8c, 2b79197, bc43fd6,
   2ec5f17, cb8738b)
 * genetlink: New create for higher level abstraction of generic netlink
   protocol (89ee697)
 * netlink-packet-generic: New crate for generic netlink protocol (89ee697)
 * netlink-packet-route: Add support of property addition and deletion (cc073b3)
 * rtnetlink: Add support of preferred source address (720e764)

### Bug fixes
 * netlink-packet-route: vlan: Fix endianness when creating VLAN (b0fd2ea)
 * rtnetlink: drop byteordered dependency (8bca238)
