### PR TITLE
LinkAddRequest: Allow adding `macvlan` on a  specified link.

### DIFF
--- a/rtnetlink/examples/create_macvlan.rs
+++ b/rtnetlink/examples/create_macvlan.rs
@@ -1,0 +1,55 @@
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let link_name = &args[1];
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    create_macvlan(handle, link_name.to_string())
+        .await
+        .map_err(|e| format!("{}", e))
+}
+
+async fn create_macvlan(handle: Handle, veth_name: String) -> Result<(), Error> {
+    let mut links = handle
+        .link()
+        .get()
+        .set_name_filter(veth_name.clone())
+        .execute();
+    if let Some(link) = links.try_next().await? {
+        // hard code mode: 4u32 i.e bridge mode
+        let request = handle
+            .link()
+            .add()
+            .macvlan("test_macvlan".into(), link.header.index, 4u32);
+        request.execute().await?
+    } else {
+        println!("no link link {} found", veth_name);
+    }
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example create_macvlan -- <link name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd netlink-ip ; cargo build --example create_macvlan
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./create_macvlan <link_name>"
+    );
+}

--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -2,7 +2,7 @@ use futures::stream::StreamExt;
 
 use crate::{
     packet::{
-        nlas::link::{Info, InfoData, InfoKind, InfoVlan, InfoVxlan, Nla, VethInfo},
+        nlas::link::{Info, InfoData, InfoKind, InfoMacVlan, InfoVlan, InfoVxlan, Nla, VethInfo},
         LinkMessage,
         NetlinkMessage,
         RtnlMessage,
@@ -329,6 +329,19 @@ impl LinkAddRequest {
             .link_info(
                 InfoKind::Vlan,
                 Some(InfoData::Vlan(vec![InfoVlan::Id(vlan_id)])),
+            )
+            .append_nla(Nla::Link(index))
+            .up()
+    }
+
+    /// Create macvlan on a link.
+    /// This is equivalent to `ip link add NAME name link LINK type macvlan mode MACVLAN_MODE`,
+    /// but instead of specifying a link name (`LINK`), we specify a link index.
+    pub fn macvlan(self, name: String, index: u32, mode: u32) -> Self {
+        self.name(name)
+            .link_info(
+                InfoKind::MacVlan,
+                Some(InfoData::MacVlan(vec![InfoMacVlan::Mode(mode)])),
             )
             .append_nla(Nla::Link(index))
             .up()


### PR DESCRIPTION
Hi Team,

Thank you so much for porting and maintaining `netlink` bindings.

Following PR adds support to create MACVLAN on a link.
This is equivalent to `ip link add NAME name link LINK type macvlan mode MACVLAN_MODE`.
But instead of specifying a link name (LINK), we specify a link index
and a mode.

Veth must be already up for this to work. Following behaviour is
expected cause its same for `vxlan` and `vlan`.


Thanks again.

