### PR TITLE
license: Include SPDX-License-Identifier: MIT to source file

### DIFF
--- a/audit/examples/add_rules.rs
+++ b/audit/examples/add_rules.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! In this example, we create two rules which is equivalent to the following commands:
 //!
 //! auditctl -w /etc/passwd -p rwxa -k my_key

--- a/audit/examples/dump_rules.rs
+++ b/audit/examples/dump_rules.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! In this example, we create a netlink connection, and send a request to retrieve the list of
 //! rules. We receive a stream of rule messages that we just prints to the terminal.
 use audit::{new_connection, Error, Handle};

--- a/audit/examples/events.rs
+++ b/audit/examples/events.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! This example opens a netlink socket, enables audit events, and prints the events that are being
 //! received.
 

--- a/audit/examples/events_async.rs
+++ b/audit/examples/events_async.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! This example opens a netlink socket, enables audit events, and prints the events that are being
 //! received.
 

--- a/audit/src/errors.rs
+++ b/audit/src/errors.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use thiserror::Error;
 
 use crate::packet::{AuditMessage, ErrorMessage, NetlinkMessage};

--- a/audit/src/handle.rs
+++ b/audit/src/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::process;
 
 use futures::{

--- a/audit/src/lib.rs
+++ b/audit/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use crate::handle::*;
 

--- a/ethtool/examples/dump_coalesce.rs
+++ b/ethtool/examples/dump_coalesce.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use ethtool;
 use futures::stream::TryStreamExt;
 use tokio;

--- a/ethtool/examples/dump_features.rs
+++ b/ethtool/examples/dump_features.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use ethtool;
 use futures::stream::TryStreamExt;
 use tokio;

--- a/ethtool/examples/dump_link_mode.rs
+++ b/ethtool/examples/dump_link_mode.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use ethtool;
 use futures::stream::TryStreamExt;
 use tokio;

--- a/ethtool/examples/dump_pause.rs
+++ b/ethtool/examples/dump_pause.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use env_logger;
 use ethtool;
 use futures::stream::TryStreamExt;

--- a/ethtool/examples/dump_rings.rs
+++ b/ethtool/examples/dump_rings.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use ethtool;
 use futures::stream::TryStreamExt;
 use tokio;

--- a/ethtool/src/coalesce/attr.rs
+++ b/ethtool/src/coalesce/attr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{

--- a/ethtool/src/coalesce/get.rs
+++ b/ethtool/src/coalesce/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::TryStream;
 use netlink_packet_generic::GenlMessage;
 

--- a/ethtool/src/coalesce/handle.rs
+++ b/ethtool/src/coalesce/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{EthtoolCoalesceGetRequest, EthtoolHandle};
 
 pub struct EthtoolCoalesceHandle(EthtoolHandle);

--- a/ethtool/src/coalesce/mod.rs
+++ b/ethtool/src/coalesce/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod attr;
 mod get;
 mod handle;

--- a/ethtool/src/connection.rs
+++ b/ethtool/src/connection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::io;
 
 use futures::channel::mpsc::UnboundedReceiver;

--- a/ethtool/src/error.rs
+++ b/ethtool/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use thiserror::Error;
 
 use netlink_packet_core::{ErrorMessage, NetlinkMessage};

--- a/ethtool/src/feature/attr.rs
+++ b/ethtool/src/feature/attr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use log::warn;
 use netlink_packet_utils::{

--- a/ethtool/src/feature/get.rs
+++ b/ethtool/src/feature/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::TryStream;
 use netlink_packet_generic::GenlMessage;
 

--- a/ethtool/src/feature/handle.rs
+++ b/ethtool/src/feature/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{EthtoolFeatureGetRequest, EthtoolHandle};
 
 pub struct EthtoolFeatureHandle(EthtoolHandle);

--- a/ethtool/src/feature/mod.rs
+++ b/ethtool/src/feature/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod attr;
 mod get;
 mod handle;

--- a/ethtool/src/handle.rs
+++ b/ethtool/src/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{future::Either, FutureExt, Stream, StreamExt, TryStream};
 use genetlink::GenetlinkHandle;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST};

--- a/ethtool/src/header.rs
+++ b/ethtool/src/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::ffi::CString;
 
 use anyhow::Context;

--- a/ethtool/src/lib.rs
+++ b/ethtool/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod coalesce;
 mod connection;
 mod error;

--- a/ethtool/src/link_mode/attr.rs
+++ b/ethtool/src/link_mode/attr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use log::warn;
 use netlink_packet_utils::{

--- a/ethtool/src/link_mode/get.rs
+++ b/ethtool/src/link_mode/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::TryStream;
 use netlink_packet_generic::GenlMessage;
 

--- a/ethtool/src/link_mode/handle.rs
+++ b/ethtool/src/link_mode/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{EthtoolHandle, EthtoolLinkModeGetRequest};
 
 pub struct EthtoolLinkModeHandle(EthtoolHandle);

--- a/ethtool/src/link_mode/mod.rs
+++ b/ethtool/src/link_mode/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod attr;
 mod get;
 mod handle;

--- a/ethtool/src/macros.rs
+++ b/ethtool/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_export]
 macro_rules! try_ethtool {
     ($msg: expr) => {{

--- a/ethtool/src/message.rs
+++ b/ethtool/src/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_core::DecodeError;
 use netlink_packet_generic::{GenlFamily, GenlHeader};
 use netlink_packet_utils::{nla::Nla, Emitable, ParseableParametrized};

--- a/ethtool/src/pause/attr.rs
+++ b/ethtool/src/pause/attr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{

--- a/ethtool/src/pause/get.rs
+++ b/ethtool/src/pause/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::TryStream;
 use netlink_packet_generic::GenlMessage;
 

--- a/ethtool/src/pause/handle.rs
+++ b/ethtool/src/pause/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{EthtoolHandle, EthtoolPauseGetRequest};
 
 pub struct EthtoolPauseHandle(EthtoolHandle);

--- a/ethtool/src/pause/mod.rs
+++ b/ethtool/src/pause/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod attr;
 mod get;
 mod handle;

--- a/ethtool/src/ring/attr.rs
+++ b/ethtool/src/ring/attr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_utils::{

--- a/ethtool/src/ring/get.rs
+++ b/ethtool/src/ring/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::TryStream;
 use netlink_packet_generic::GenlMessage;
 

--- a/ethtool/src/ring/handle.rs
+++ b/ethtool/src/ring/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{EthtoolHandle, EthtoolRingGetRequest};
 
 pub struct EthtoolRingHandle(EthtoolHandle);

--- a/ethtool/src/ring/mod.rs
+++ b/ethtool/src/ring/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod attr;
 mod get;
 mod handle;

--- a/ethtool/tests/dump_link_modes.rs
+++ b/ethtool/tests/dump_link_modes.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 
 #[test]

--- a/ethtool/tests/get_features_lo.rs
+++ b/ethtool/tests/get_features_lo.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 
 #[test]

--- a/genetlink/examples/dump_family_policy.rs
+++ b/genetlink/examples/dump_family_policy.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::env::args;
 
 use anyhow::{bail, Error};

--- a/genetlink/examples/list_generic_family.rs
+++ b/genetlink/examples/list_generic_family.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Example of listing generic families based on `netlink_proto`
 //!
 //! This example's functionality is same as the identical name example in `netlink_packet_generic`.

--- a/genetlink/src/connection.rs
+++ b/genetlink/src/connection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{message::RawGenlMessage, GenetlinkHandle};
 use futures::channel::mpsc::UnboundedReceiver;
 use netlink_packet_core::NetlinkMessage;

--- a/genetlink/src/error.rs
+++ b/genetlink/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::message::RawGenlMessage;
 
 /// Error type of genetlink

--- a/genetlink/src/handle.rs
+++ b/genetlink/src/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     error::GenetlinkError,
     message::{map_from_rawgenlmsg, map_to_rawgenlmsg, RawGenlMessage},

--- a/genetlink/src/lib.rs
+++ b/genetlink/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_use]
 extern crate thiserror;
 

--- a/genetlink/src/message.rs
+++ b/genetlink/src/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Raw generic netlink payload message
 //!
 //! # Design

--- a/genetlink/src/resolver.rs
+++ b/genetlink/src/resolver.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{error::GenetlinkError, GenetlinkHandle};
 use futures::{future::Either, StreamExt};
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_REQUEST};

--- a/netlink-packet-audit/fuzz/fuzz_targets/netlink.rs
+++ b/netlink-packet-audit/fuzz/fuzz_targets/netlink.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/netlink-packet-audit/src/buffer.rs
+++ b/netlink-packet-audit/src/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     rules::{RuleBuffer, RuleMessage},

--- a/netlink-packet-audit/src/codec.rs
+++ b/netlink-packet-audit/src/codec.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{fmt::Debug, io};
 
 use bytes::BytesMut;

--- a/netlink-packet-audit/src/constants.rs
+++ b/netlink-packet-audit/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub use netlink_packet_core::constants::*;
 
 // ==========================================

--- a/netlink-packet-audit/src/lib.rs
+++ b/netlink-packet-audit/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_use]
 extern crate log;
 

--- a/netlink-packet-audit/src/message.rs
+++ b/netlink-packet-audit/src/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     rules::RuleMessage,

--- a/netlink-packet-audit/src/rules/action.rs
+++ b/netlink-packet-audit/src/rules/action.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 
 #[derive(Copy, Debug, PartialEq, Eq, Clone)]

--- a/netlink-packet-audit/src/rules/buffer.rs
+++ b/netlink-packet-audit/src/rules/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 

--- a/netlink-packet-audit/src/rules/field.rs
+++ b/netlink-packet-audit/src/rules/field.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/netlink-packet-audit/src/rules/flags.rs
+++ b/netlink-packet-audit/src/rules/flags.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 
 #[derive(Copy, Debug, PartialEq, Eq, Clone)]

--- a/netlink-packet-audit/src/rules/mod.rs
+++ b/netlink-packet-audit/src/rules/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod action;
 pub use self::action::*;
 

--- a/netlink-packet-audit/src/rules/rule.rs
+++ b/netlink-packet-audit/src/rules/rule.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use byteorder::{ByteOrder, NativeEndian};
 
 use crate::{

--- a/netlink-packet-audit/src/rules/syscalls.rs
+++ b/netlink-packet-audit/src/rules/syscalls.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use byteorder::{ByteOrder, NativeEndian};
 
 use crate::{constants::*, DecodeError};

--- a/netlink-packet-audit/src/rules/tests.rs
+++ b/netlink-packet-audit/src/rules/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     rules::{
         RuleAction,

--- a/netlink-packet-audit/src/status.rs
+++ b/netlink-packet-audit/src/status.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use byteorder::{ByteOrder, NativeEndian};
 
 use crate::{

--- a/netlink-packet-core/examples/protocol.rs
+++ b/netlink-packet-core/examples/protocol.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{error::Error, fmt};
 
 use netlink_packet_core::{

--- a/netlink-packet-core/examples/rtnetlink.rs
+++ b/netlink-packet-core/examples/rtnetlink.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST};
 use netlink_packet_route::rtnl::{LinkMessage, RtnlMessage};
 

--- a/netlink-packet-core/src/buffer.rs
+++ b/netlink-packet-core/src/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use byteorder::{ByteOrder, NativeEndian};
 
 use crate::{DecodeError, Field, Rest};

--- a/netlink-packet-core/src/constants.rs
+++ b/netlink-packet-core/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 /// Must be set on all request messages (typically from user space to kernel space)
 pub const NLM_F_REQUEST: u16 = 1;
 ///  Indicates the message is part of a multipart message terminated by NLMSG_DONE

--- a/netlink-packet-core/src/error.rs
+++ b/netlink-packet-core/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{fmt, io, mem::size_of};
 
 use byteorder::{ByteOrder, NativeEndian};

--- a/netlink-packet-core/src/header.rs
+++ b/netlink-packet-core/src/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{buffer::NETLINK_HEADER_LEN, DecodeError, Emitable, NetlinkBuffer, Parseable};
 
 /// A Netlink header representation. A netlink header has the following structure:

--- a/netlink-packet-core/src/lib.rs
+++ b/netlink-packet-core/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! `netlink-packet-core` provides a generic netlink message
 //! `NetlinkMessage<T>` that is independant of the sub-protocol. Such
 //! messages are not very useful by themselves, since they are just

--- a/netlink-packet-core/src/message.rs
+++ b/netlink-packet-core/src/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use std::fmt::Debug;
 

--- a/netlink-packet-core/src/payload.rs
+++ b/netlink-packet-core/src/payload.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::fmt::Debug;
 
 use crate::{AckMessage, ErrorMessage, NetlinkSerializable};

--- a/netlink-packet-core/src/traits.rs
+++ b/netlink-packet-core/src/traits.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::NetlinkHeader;
 use std::error::Error;
 

--- a/netlink-packet-generic/examples/list_generic_family.rs
+++ b/netlink-packet-generic/examples/list_generic_family.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
 use netlink_packet_generic::{
     ctrl::{nlas::GenlCtrlAttrs, GenlCtrl, GenlCtrlCmd},

--- a/netlink-packet-generic/src/buffer.rs
+++ b/netlink-packet-generic/src/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Buffer definition of generic netlink packet
 use crate::{constants::GENL_HDRLEN, header::GenlHeader, message::GenlMessage};
 use netlink_packet_core::DecodeError;

--- a/netlink-packet-generic/src/constants.rs
+++ b/netlink-packet-generic/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Define constants related to generic netlink
 pub const GENL_ID_CTRL: u16 = libc::GENL_ID_CTRL as u16;
 pub const GENL_HDRLEN: usize = 4;

--- a/netlink-packet-generic/src/ctrl/mod.rs
+++ b/netlink-packet-generic/src/ctrl/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Generic netlink controller implementation
 //!
 //! This module provides the definition of the controller packet.

--- a/netlink-packet-generic/src/ctrl/nlas/mcast.rs
+++ b/netlink-packet-generic/src/ctrl/nlas/mcast.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};

--- a/netlink-packet-generic/src/ctrl/nlas/mod.rs
+++ b/netlink-packet-generic/src/ctrl/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};

--- a/netlink-packet-generic/src/ctrl/nlas/oppolicy.rs
+++ b/netlink-packet-generic/src/ctrl/nlas/oppolicy.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};

--- a/netlink-packet-generic/src/ctrl/nlas/ops.rs
+++ b/netlink-packet-generic/src/ctrl/nlas/ops.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};

--- a/netlink-packet-generic/src/ctrl/nlas/policy.rs
+++ b/netlink-packet-generic/src/ctrl/nlas/policy.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};

--- a/netlink-packet-generic/src/header.rs
+++ b/netlink-packet-generic/src/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! header definition of generic netlink packet
 use crate::{buffer::GenlBuffer, constants::GENL_HDRLEN};
 use netlink_packet_core::DecodeError;

--- a/netlink-packet-generic/src/lib.rs
+++ b/netlink-packet-generic/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! This crate provides the packet of generic netlink family and its controller.
 //!
 //! The `[GenlMessage]` provides a generic netlink family message which is

--- a/netlink-packet-generic/src/message.rs
+++ b/netlink-packet-generic/src/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Message definition and method implementations
 
 use crate::{buffer::GenlBuffer, header::GenlHeader, traits::*};

--- a/netlink-packet-generic/src/traits.rs
+++ b/netlink-packet-generic/src/traits.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Traits for implementing generic netlink family
 
 /// Provide the definition for generic netlink family

--- a/netlink-packet-generic/tests/query_family_id.rs
+++ b/netlink-packet-generic/tests/query_family_id.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_REQUEST};
 use netlink_packet_generic::{
     ctrl::{nlas::GenlCtrlAttrs, GenlCtrl, GenlCtrlCmd},

--- a/netlink-packet-route/benches/link_message.rs
+++ b/netlink-packet-route/benches/link_message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use netlink_packet_route::{

--- a/netlink-packet-route/benches/rtnetlink_dump.rs
+++ b/netlink-packet-route/benches/rtnetlink_dump.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::fs::File;
 
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/netlink-packet-route/examples/dump_links.rs
+++ b/netlink-packet-route/examples/dump_links.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_route::{
     LinkMessage,
     NetlinkHeader,

--- a/netlink-packet-route/examples/dump_neighbours.rs
+++ b/netlink-packet-route/examples/dump_neighbours.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{convert::TryFrom, net::IpAddr, string::ToString};
 
 use netlink_packet_route::{

--- a/netlink-packet-route/examples/dump_rules.rs
+++ b/netlink-packet-route/examples/dump_rules.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_route::{
     constants::*,
     NetlinkHeader,

--- a/netlink-packet-route/examples/new_rule.rs
+++ b/netlink-packet-route/examples/new_rule.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NetlinkPayload};
 use netlink_packet_route::{constants::*, rule, RtnlMessage, RuleHeader, RuleMessage};
 use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};

--- a/netlink-packet-route/fuzz/fuzz_targets/netlink.rs
+++ b/netlink-packet-route/fuzz/fuzz_targets/netlink.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use netlink_packet_route::{NetlinkMessage, RtnlMessage};

--- a/netlink-packet-route/src/lib.rs
+++ b/netlink-packet-route/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/netlink-packet-route/src/rtnl/address/buffer.rs
+++ b/netlink-packet-route/src/rtnl/address/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/address/message.rs
+++ b/netlink-packet-route/src/rtnl/address/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/address/mod.rs
+++ b/netlink-packet-route/src/rtnl/address/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 pub use self::buffer::*;
 

--- a/netlink-packet-route/src/rtnl/address/nlas/cache_info.rs
+++ b/netlink-packet-route/src/rtnl/address/nlas/cache_info.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/address/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/address/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod cache_info;
 pub use self::cache_info::*;
 

--- a/netlink-packet-route/src/rtnl/buffer.rs
+++ b/netlink-packet-route/src/rtnl/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     traits::{Parseable, ParseableParametrized},

--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub use netlink_packet_core::constants::*;
 
 pub const RTM_BASE: u16 = 16;

--- a/netlink-packet-route/src/rtnl/link/buffer.rs
+++ b/netlink-packet-route/src/rtnl/link/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/header.rs
+++ b/netlink-packet-route/src/rtnl/link/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/message.rs
+++ b/netlink-packet-route/src/rtnl/link/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/link/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 mod header;
 mod message;

--- a/netlink-packet-route/src/rtnl/link/nlas/af_spec_inet.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/af_spec_inet.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use super::{inet, inet6};

--- a/netlink-packet-route/src/rtnl/link/nlas/inet/dev_conf.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet/dev_conf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/inet/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/link/nlas/inet6/cache.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet6/cache.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/inet6/dev_conf.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet6/dev_conf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/inet6/icmp6_stats.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet6/icmp6_stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/inet6/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet6/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 

--- a/netlink-packet-route/src/rtnl/link/nlas/inet6/stats.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/inet6/stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     nlas::{DefaultNla, Nla, NlaBuffer, NlasIterator},

--- a/netlink-packet-route/src/rtnl/link/nlas/link_state.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::constants::*;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/netlink-packet-route/src/rtnl/link/nlas/map.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/map.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod inet;
 pub use self::inet::*;
 

--- a/netlink-packet-route/src/rtnl/link/nlas/prop_list.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/prop_list.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     nlas::{DefaultNla, Nla, NlaBuffer},

--- a/netlink-packet-route/src/rtnl/link/nlas/stats.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/stats64.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/stats64.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/link/nlas/tests.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{utils::nla::Nla, DecodeError};
 
 use super::*;

--- a/netlink-packet-route/src/rtnl/message.rs
+++ b/netlink-packet-route/src/rtnl/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     traits::{Emitable, ParseableParametrized},

--- a/netlink-packet-route/src/rtnl/mod.rs
+++ b/netlink-packet-route/src/rtnl/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub mod address;
 pub use address::{AddressHeader, AddressMessage, AddressMessageBuffer, ADDRESS_HEADER_LEN};
 

--- a/netlink-packet-route/src/rtnl/neighbour/buffer.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/neighbour/header.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/neighbour/message.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/neighbour/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 mod header;
 mod message;

--- a/netlink-packet-route/src/rtnl/neighbour/nlas/cache_info.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/nlas/cache_info.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/neighbour/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod cache_info;
 pub use self::cache_info::*;
 

--- a/netlink-packet-route/src/rtnl/neighbour_table/buffer.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/neighbour_table/header.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/neighbour_table/message.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::neighbour_table::Nla,
     traits::{Emitable, Parseable},

--- a/netlink-packet-route/src/rtnl/neighbour_table/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 mod header;
 mod message;

--- a/netlink-packet-route/src/rtnl/neighbour_table/nlas/config.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/nlas/config.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/neighbour_table/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod config;
 pub use config::*;
 

--- a/netlink-packet-route/src/rtnl/neighbour_table/nlas/stats.rs
+++ b/netlink-packet-route/src/rtnl/neighbour_table/nlas/stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/nsid/buffer.rs
+++ b/netlink-packet-route/src/rtnl/nsid/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/nsid/header.rs
+++ b/netlink-packet-route/src/rtnl/nsid/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use super::{NsidMessageBuffer, NSID_HEADER_LEN};
 use crate::{
     traits::{Emitable, Parseable},

--- a/netlink-packet-route/src/rtnl/nsid/message.rs
+++ b/netlink-packet-route/src/rtnl/nsid/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/nsid/mod.rs
+++ b/netlink-packet-route/src/rtnl/nsid/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 mod header;
 mod message;

--- a/netlink-packet-route/src/rtnl/nsid/nlas.rs
+++ b/netlink-packet-route/src/rtnl/nsid/nlas.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 

--- a/netlink-packet-route/src/rtnl/route/buffer.rs
+++ b/netlink-packet-route/src/rtnl/route/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/route/header.rs
+++ b/netlink-packet-route/src/rtnl/route/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     traits::{Emitable, Parseable},

--- a/netlink-packet-route/src/rtnl/route/message.rs
+++ b/netlink-packet-route/src/rtnl/route/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::route::Nla,
     traits::{Emitable, Parseable},

--- a/netlink-packet-route/src/rtnl/route/mod.rs
+++ b/netlink-packet-route/src/rtnl/route/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 mod header;
 mod message;

--- a/netlink-packet-route/src/rtnl/route/nlas/cache_info.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/cache_info.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/route/nlas/metrics.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/metrics.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 use std::mem::size_of;

--- a/netlink-packet-route/src/rtnl/route/nlas/mfc_stats.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/mfc_stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/route/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod cache_info;
 pub use self::cache_info::*;
 

--- a/netlink-packet-route/src/rtnl/rule/buffer.rs
+++ b/netlink-packet-route/src/rtnl/rule/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/rule/header.rs
+++ b/netlink-packet-route/src/rtnl/rule/header.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use super::{buffer::RuleMessageBuffer, RULE_HEADER_LEN};
 use crate::{
     constants::*,

--- a/netlink-packet-route/src/rtnl/rule/message.rs
+++ b/netlink-packet-route/src/rtnl/rule/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use super::{buffer::RuleMessageBuffer, header::RuleHeader, nlas::Nla};
 use crate::{
     utils::{Emitable, Parseable},

--- a/netlink-packet-route/src/rtnl/rule/mod.rs
+++ b/netlink-packet-route/src/rtnl/rule/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub mod buffer;
 pub mod header;
 pub mod message;

--- a/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas,
     nlas::DefaultNla,

--- a/netlink-packet-route/src/rtnl/tc/buffer.rs
+++ b/netlink-packet-route/src/rtnl/tc/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     nlas::{NlaBuffer, NlasIterator},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/tc/message.rs
+++ b/netlink-packet-route/src/rtnl/tc/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/tc/mod.rs
+++ b/netlink-packet-route/src/rtnl/tc/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod buffer;
 mod message;
 pub mod nlas;

--- a/netlink-packet-route/src/rtnl/tc/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/tc/nlas/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod stats;
 pub use self::stats::*;
 

--- a/netlink-packet-route/src/rtnl/tc/nlas/stats.rs
+++ b/netlink-packet-route/src/rtnl/tc/nlas/stats.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/tc/nlas/stats_basic.rs
+++ b/netlink-packet-route/src/rtnl/tc/nlas/stats_basic.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/tc/nlas/stats_queue.rs
+++ b/netlink-packet-route/src/rtnl/tc/nlas/stats_queue.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     traits::{Emitable, Parseable},
     DecodeError,

--- a/netlink-packet-route/src/rtnl/test.rs
+++ b/netlink-packet-route/src/rtnl/test.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #![cfg(test)]
 
 use crate::{

--- a/netlink-packet-sock-diag/examples/dump_ipv4.rs
+++ b/netlink-packet-sock-diag/examples/dump_ipv4.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use netlink_packet_sock_diag::{
     constants::*,
     inet::{ExtensionFlags, InetRequest, SocketId, StateFlags},

--- a/netlink-packet-sock-diag/src/buffer.rs
+++ b/netlink-packet-sock-diag/src/buffer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     inet,

--- a/netlink-packet-sock-diag/src/constants.rs
+++ b/netlink-packet-sock-diag/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub use netlink_packet_core::constants::*;
 
 pub const SOCK_DIAG_BY_FAMILY: u16 = 20;

--- a/netlink-packet-sock-diag/src/inet/mod.rs
+++ b/netlink-packet-sock-diag/src/inet/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod socket_id;
 pub use self::socket_id::*;
 

--- a/netlink-packet-sock-diag/src/inet/nlas.rs
+++ b/netlink-packet-sock-diag/src/inet/nlas.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 

--- a/netlink-packet-sock-diag/src/inet/request.rs
+++ b/netlink-packet-sock-diag/src/inet/request.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-sock-diag/src/inet/response.rs
+++ b/netlink-packet-sock-diag/src/inet/response.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use smallvec::SmallVec;
 use std::time::Duration;

--- a/netlink-packet-sock-diag/src/inet/socket_id.rs
+++ b/netlink-packet-sock-diag/src/inet/socket_id.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use byteorder::{BigEndian, ByteOrder};
 use std::{
     convert::{TryFrom, TryInto},

--- a/netlink-packet-sock-diag/src/inet/tests.rs
+++ b/netlink-packet-sock-diag/src/inet/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     net::{IpAddr, Ipv4Addr},
     time::Duration,

--- a/netlink-packet-sock-diag/src/lib.rs
+++ b/netlink-packet-sock-diag/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_use]
 extern crate bitflags;
 

--- a/netlink-packet-sock-diag/src/message.rs
+++ b/netlink-packet-sock-diag/src/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     inet,
     traits::{Emitable, ParseableParametrized},

--- a/netlink-packet-sock-diag/src/unix/mod.rs
+++ b/netlink-packet-sock-diag/src/unix/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod request;
 pub use self::request::*;
 

--- a/netlink-packet-sock-diag/src/unix/nlas.rs
+++ b/netlink-packet-sock-diag/src/unix/nlas.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 

--- a/netlink-packet-sock-diag/src/unix/request.rs
+++ b/netlink-packet-sock-diag/src/unix/request.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::convert::TryFrom;
 
 use crate::{

--- a/netlink-packet-sock-diag/src/unix/response.rs
+++ b/netlink-packet-sock-diag/src/unix/response.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::Context;
 use smallvec::SmallVec;
 use std::convert::TryFrom;

--- a/netlink-packet-sock-diag/src/unix/tests.rs
+++ b/netlink-packet-sock-diag/src/unix/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     constants::*,
     traits::{Emitable, Parseable},

--- a/netlink-packet-utils/src/errors.rs
+++ b/netlink-packet-utils/src/errors.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use anyhow::anyhow;
 use thiserror::Error;
 

--- a/netlink-packet-utils/src/lib.rs
+++ b/netlink-packet-utils/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub extern crate byteorder;
 pub extern crate paste;
 

--- a/netlink-packet-utils/src/macros.rs
+++ b/netlink-packet-utils/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_export]
 macro_rules! getter {
     ($buffer: ident, $name:ident, slice, $offset:expr) => {

--- a/netlink-packet-utils/src/nla.rs
+++ b/netlink-packet-utils/src/nla.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use core::ops::Range;
 
 use anyhow::Context;

--- a/netlink-packet-utils/src/parsers.rs
+++ b/netlink-packet-utils/src/parsers.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::mem::size_of;
 
 use anyhow::Context;

--- a/netlink-packet-utils/src/traits.rs
+++ b/netlink-packet-utils/src/traits.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::DecodeError;
 
 /// A type that implements `Emitable` can be serialized.

--- a/netlink-proto/examples/audit_events.rs
+++ b/netlink-proto/examples/audit_events.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // This example shows how to use `netlink-proto` with the tokio runtime to print audit events.
 //
 // This example shows how the netlink socket can be accessed

--- a/netlink-proto/examples/dump_links.rs
+++ b/netlink-proto/examples/dump_links.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::StreamExt;
 use netlink_packet_route::{
     LinkMessage,

--- a/netlink-proto/examples/dump_links_async.rs
+++ b/netlink-proto/examples/dump_links_async.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::StreamExt;
 use netlink_packet_route::{
     LinkMessage,

--- a/netlink-proto/src/codecs.rs
+++ b/netlink-proto/src/codecs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{fmt::Debug, io};
 
 use bytes::{BufMut, BytesMut};

--- a/netlink-proto/src/connection.rs
+++ b/netlink-proto/src/connection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     fmt::Debug,
     io,

--- a/netlink-proto/src/errors.rs
+++ b/netlink-proto/src/errors.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     error::Error as StdError,
     fmt::{self, Debug},

--- a/netlink-proto/src/framed.rs
+++ b/netlink-proto/src/framed.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use bytes::BytesMut;
 use std::{
     fmt::Debug,

--- a/netlink-proto/src/handle.rs
+++ b/netlink-proto/src/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{
     channel::mpsc::{unbounded, UnboundedSender},
     Stream,

--- a/netlink-proto/src/lib.rs
+++ b/netlink-proto/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! `netlink-proto` is an asynchronous implementation of the Netlink
 //! protocol.
 //!

--- a/netlink-proto/src/protocol/mod.rs
+++ b/netlink-proto/src/protocol/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[allow(clippy::module_inception)]
 mod protocol;
 mod request;

--- a/netlink-proto/src/protocol/protocol.rs
+++ b/netlink-proto/src/protocol/protocol.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     collections::{hash_map, HashMap, VecDeque},
     fmt::Debug,

--- a/netlink-proto/src/protocol/request.rs
+++ b/netlink-proto/src/protocol/request.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::fmt::Debug;
 
 use netlink_packet_core::NetlinkMessage;

--- a/netlink-sys/examples/audit_events.rs
+++ b/netlink-sys/examples/audit_events.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Build:
 //
 // ```

--- a/netlink-sys/examples/audit_events_async_std.rs
+++ b/netlink-sys/examples/audit_events_async_std.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Build:
 //
 // ```

--- a/netlink-sys/examples/audit_events_tokio.rs
+++ b/netlink-sys/examples/audit_events_tokio.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Build:
 //
 // ```

--- a/netlink-sys/examples/audit_events_tokio_manual_thread_builder.rs
+++ b/netlink-sys/examples/audit_events_tokio_manual_thread_builder.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 /*
  * This example shows the mimimal manual tokio initialization required to be able
  * to use netlink.

--- a/netlink-sys/src/addr.rs
+++ b/netlink-sys/src/addr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     fmt,
     hash::{Hash, Hasher},

--- a/netlink-sys/src/async_socket.rs
+++ b/netlink-sys/src/async_socket.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     io,
     task::{Context, Poll},

--- a/netlink-sys/src/async_socket_ext.rs
+++ b/netlink-sys/src/async_socket_ext.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     future::Future,
     io,

--- a/netlink-sys/src/constants.rs
+++ b/netlink-sys/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! This module provides a lot of netlink constants for various protocol. As we add support for the
 //! various protocols, these constants will be moved to their own crate.
 

--- a/netlink-sys/src/lib.rs
+++ b/netlink-sys/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub mod constants;
 pub mod protocols {
     pub use super::constants::{

--- a/netlink-sys/src/mio.rs
+++ b/netlink-sys/src/mio.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::Socket;
 use std::os::unix::io::AsRawFd;
 

--- a/netlink-sys/src/smol.rs
+++ b/netlink-sys/src/smol.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     io,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},

--- a/netlink-sys/src/socket.rs
+++ b/netlink-sys/src/socket.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     io::{Error, Result},
     mem,

--- a/netlink-sys/src/tokio.rs
+++ b/netlink-sys/src/tokio.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     io,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},

--- a/rtnetlink/examples/add_address.rs
+++ b/rtnetlink/examples/add_address.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use std::env;
 

--- a/rtnetlink/examples/add_neighbour.rs
+++ b/rtnetlink/examples/add_neighbour.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::{env, net::IpAddr};

--- a/rtnetlink/examples/add_netns.rs
+++ b/rtnetlink/examples/add_netns.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use rtnetlink::NetworkNamespace;
 use std::env;
 

--- a/rtnetlink/examples/add_netns_async.rs
+++ b/rtnetlink/examples/add_netns_async.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use rtnetlink::NetworkNamespace;
 use std::env;
 

--- a/rtnetlink/examples/add_route.rs
+++ b/rtnetlink/examples/add_route.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::env;
 
 use ipnetwork::Ipv4Network;

--- a/rtnetlink/examples/add_route_pref_src.rs
+++ b/rtnetlink/examples/add_route_pref_src.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::TryStreamExt;
 use std::{env, net::Ipv4Addr};
 

--- a/rtnetlink/examples/add_rule.rs
+++ b/rtnetlink/examples/add_rule.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::env;
 
 use ipnetwork::Ipv4Network;

--- a/rtnetlink/examples/create_bridge.rs
+++ b/rtnetlink/examples/create_bridge.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use rtnetlink::new_connection;
 
 #[tokio::main]

--- a/rtnetlink/examples/create_macvlan.rs
+++ b/rtnetlink/examples/create_macvlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::env;

--- a/rtnetlink/examples/create_veth.rs
+++ b/rtnetlink/examples/create_veth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use rtnetlink::new_connection;
 
 #[tokio::main]

--- a/rtnetlink/examples/create_vxlan.rs
+++ b/rtnetlink/examples/create_vxlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::env;

--- a/rtnetlink/examples/del_link.rs
+++ b/rtnetlink/examples/del_link.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::env;

--- a/rtnetlink/examples/del_netns.rs
+++ b/rtnetlink/examples/del_netns.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use rtnetlink::NetworkNamespace;
 use std::env;
 

--- a/rtnetlink/examples/del_netns_async.rs
+++ b/rtnetlink/examples/del_netns_async.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use rtnetlink::NetworkNamespace;
 use std::env;
 

--- a/rtnetlink/examples/flush_addresses.rs
+++ b/rtnetlink/examples/flush_addresses.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::env;

--- a/rtnetlink/examples/get_address.rs
+++ b/rtnetlink/examples/get_address.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 

--- a/rtnetlink/examples/get_links.rs
+++ b/rtnetlink/examples/get_links.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{
     new_connection,

--- a/rtnetlink/examples/get_links_async.rs
+++ b/rtnetlink/examples/get_links_async.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{
     new_connection,

--- a/rtnetlink/examples/get_links_thread_builder.rs
+++ b/rtnetlink/examples/get_links_thread_builder.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 
 use rtnetlink::{

--- a/rtnetlink/examples/get_neighbours.rs
+++ b/rtnetlink/examples/get_neighbours.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, IpVersion};
 

--- a/rtnetlink/examples/get_route.rs
+++ b/rtnetlink/examples/get_route.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, IpVersion};
 

--- a/rtnetlink/examples/get_rule.rs
+++ b/rtnetlink/examples/get_rule.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, IpVersion};
 

--- a/rtnetlink/examples/ip_monitor.rs
+++ b/rtnetlink/examples/ip_monitor.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use netlink_packet_route::constants::*;

--- a/rtnetlink/examples/listen.rs
+++ b/rtnetlink/examples/listen.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! This example opens a netlink socket, registers for IPv4 and IPv6 routing changes, listens for
 //! said changes and prints the received messages.
 

--- a/rtnetlink/examples/property_altname.rs
+++ b/rtnetlink/examples/property_altname.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{
     new_connection,

--- a/rtnetlink/examples/set_link_down.rs
+++ b/rtnetlink/examples/set_link_down.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 use std::env;

--- a/rtnetlink/src/addr/add.rs
+++ b/rtnetlink/src/addr/add.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 use std::net::{IpAddr, Ipv4Addr};
 

--- a/rtnetlink/src/addr/del.rs
+++ b/rtnetlink/src/addr/del.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use crate::{

--- a/rtnetlink/src/addr/get.rs
+++ b/rtnetlink/src/addr/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{
     future::{self, Either},
     stream::{StreamExt, TryStream, TryStreamExt},

--- a/rtnetlink/src/addr/handle.rs
+++ b/rtnetlink/src/addr/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::net::IpAddr;
 
 use super::{AddressAddRequest, AddressDelRequest, AddressGetRequest};

--- a/rtnetlink/src/addr/mod.rs
+++ b/rtnetlink/src/addr/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use self::handle::*;
 

--- a/rtnetlink/src/connection.rs
+++ b/rtnetlink/src/connection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::io;
 
 use futures::channel::mpsc::UnboundedReceiver;

--- a/rtnetlink/src/constants.rs
+++ b/rtnetlink/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pub const RTMGRP_LINK: u32 = 1;
 pub const RTMGRP_NOTIFY: u32 = 2;
 pub const RTMGRP_NEIGH: u32 = 4;

--- a/rtnetlink/src/errors.rs
+++ b/rtnetlink/src/errors.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use thiserror::Error;
 
 use crate::packet::{ErrorMessage, NetlinkMessage, RtnlMessage};

--- a/rtnetlink/src/handle.rs
+++ b/rtnetlink/src/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::Stream;
 
 use crate::{

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! This crate provides methods to manipulate networking resources (links, addresses, arp tables,
 //! route tables) via the netlink protocol.
 

--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use crate::{

--- a/rtnetlink/src/link/del.rs
+++ b/rtnetlink/src/link/del.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use crate::{

--- a/rtnetlink/src/link/get.rs
+++ b/rtnetlink/src/link/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{
     future::{self, Either},
     stream::{StreamExt, TryStream, TryStreamExt},

--- a/rtnetlink/src/link/handle.rs
+++ b/rtnetlink/src/link/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use super::{
     LinkAddRequest,
     LinkDelPropRequest,

--- a/rtnetlink/src/link/mod.rs
+++ b/rtnetlink/src/link/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use self::handle::*;
 

--- a/rtnetlink/src/link/property_add.rs
+++ b/rtnetlink/src/link/property_add.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     packet::{
         nlas::link::{Nla, Prop},

--- a/rtnetlink/src/link/property_del.rs
+++ b/rtnetlink/src/link/property_del.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     packet::{
         nlas::link::{Nla, Prop},

--- a/rtnetlink/src/link/set.rs
+++ b/rtnetlink/src/link/set.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     packet::{
         nlas::link::Nla,

--- a/rtnetlink/src/link/test.rs
+++ b/rtnetlink/src/link/test.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::TryStreamExt;
 use tokio::runtime::Runtime;
 

--- a/rtnetlink/src/macros.rs
+++ b/rtnetlink/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[macro_export]
 macro_rules! try_rtnl {
     ($msg: expr, $message_type:path) => {{

--- a/rtnetlink/src/neighbour/add.rs
+++ b/rtnetlink/src/neighbour/add.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use netlink_packet_route::{

--- a/rtnetlink/src/neighbour/del.rs
+++ b/rtnetlink/src/neighbour/del.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use netlink_packet_route::{

--- a/rtnetlink/src/neighbour/get.rs
+++ b/rtnetlink/src/neighbour/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{
     future::{self, Either},
     stream::{StreamExt, TryStream},

--- a/rtnetlink/src/neighbour/handle.rs
+++ b/rtnetlink/src/neighbour/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{Handle, NeighbourAddRequest, NeighbourDelRequest, NeighbourGetRequest};
 use netlink_packet_route::NeighbourMessage;
 use std::net::IpAddr;

--- a/rtnetlink/src/neighbour/mod.rs
+++ b/rtnetlink/src/neighbour/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use self::handle::*;
 

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::Error;
 use nix::{
     fcntl::OFlag,

--- a/rtnetlink/src/route/add.rs
+++ b/rtnetlink/src/route/add.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 use std::{
     marker::PhantomData,

--- a/rtnetlink/src/route/del.rs
+++ b/rtnetlink/src/route/del.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use crate::{

--- a/rtnetlink/src/route/get.rs
+++ b/rtnetlink/src/route/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{
     future::{self, Either},
     stream::{StreamExt, TryStream},

--- a/rtnetlink/src/route/handle.rs
+++ b/rtnetlink/src/route/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{Handle, IpVersion, RouteAddRequest, RouteDelRequest, RouteGetRequest};
 use netlink_packet_route::RouteMessage;
 

--- a/rtnetlink/src/route/mod.rs
+++ b/rtnetlink/src/route/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use self::handle::*;
 

--- a/rtnetlink/src/rule/add.rs
+++ b/rtnetlink/src/rule/add.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 use std::{
     marker::PhantomData,

--- a/rtnetlink/src/rule/del.rs
+++ b/rtnetlink/src/rule/del.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::stream::StreamExt;
 
 use crate::{

--- a/rtnetlink/src/rule/get.rs
+++ b/rtnetlink/src/rule/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::IpVersion;
 use futures::{
     future::{self, Either},

--- a/rtnetlink/src/rule/handle.rs
+++ b/rtnetlink/src/rule/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{Handle, IpVersion, RuleAddRequest, RuleDelRequest, RuleGetRequest};
 use netlink_packet_route::RuleMessage;
 

--- a/rtnetlink/src/rule/mod.rs
+++ b/rtnetlink/src/rule/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use self::handle::*;
 

--- a/rtnetlink/src/traffic_control/get.rs
+++ b/rtnetlink/src/traffic_control/get.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use futures::{
     future::{self, Either},
     stream::{StreamExt, TryStream},

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use super::{
     QDiscGetRequest,
     TrafficChainGetRequest,

--- a/rtnetlink/src/traffic_control/mod.rs
+++ b/rtnetlink/src/traffic_control/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 mod handle;
 pub use self::handle::*;
 

--- a/rtnetlink/src/traffic_control/test.rs
+++ b/rtnetlink/src/traffic_control/test.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::process::Command;
 
 use futures::stream::TryStreamExt;


### PR DESCRIPTION
This command is used to generate the changes:

    find -type f -name \*.rs -exec sed -i \
        '1s/^/\/\/ SPDX-License-Identifier: MIT\n\n/' {} \;

Adding license header to each source file is suggested by Fedora where
the `licensecheck` command is used for license vetting.