### PR TITLE
netlink-packet-route: re-introduce rich NLAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           cd netlink-packet-route
           cargo test
+          cargo test --features rich_nlas
 
       - name: test (netlink-packet-sock-diag)
         run: |

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -11,6 +11,9 @@ readme = "../README.md"
 repository = "https://github.com/little-dude/netlink"
 description = "netlink packet types"
 
+[features]
+rich_nlas = []
+
 [dependencies]
 anyhow = "1.0.31"
 byteorder = "1.3.2"

--- a/netlink-packet-route/src/rtnl/route/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/route/nlas/mod.rs
@@ -18,19 +18,33 @@ use crate::{
     DecodeError,
 };
 
+#[cfg(feature = "rich_nlas")]
+use crate::traits::Emitable;
+
+/// Netlink attributes for `RTM_NEWROUTE`, `RTM_DELROUTE`,
+/// `RTM_GETROUTE` messages.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Nla {
+    #[cfg(not(feature = "rich_nlas"))]
+    Metrics(Vec<u8>),
+    #[cfg(feature = "rich_nlas")]
+    Metrics(Metrics),
+    #[cfg(not(feature = "rich_nlas"))]
+    MfcStats(Vec<u8>),
+    #[cfg(feature = "rich_nlas")]
+    MfcStats(MfcStats),
+    #[cfg(not(feature = "rich_nlas"))]
+    CacheInfo(Vec<u8>),
+    #[cfg(feature = "rich_nlas")]
+    CacheInfo(CacheInfo),
     Unspec(Vec<u8>),
     Destination(Vec<u8>),
     Source(Vec<u8>),
     Gateway(Vec<u8>),
     PrefSource(Vec<u8>),
-    Metrics(Vec<u8>),
     MultiPath(Vec<u8>),
-    CacheInfo(Vec<u8>),
     Session(Vec<u8>),
     MpAlgo(Vec<u8>),
-    MfcStats(Vec<u8>),
     Via(Vec<u8>),
     NewDestination(Vec<u8>),
     Pref(Vec<u8>),
@@ -71,10 +85,19 @@ impl nlas::Nla for Nla {
                 | Pad(ref bytes)
                 | Uid(ref bytes)
                 | TtlPropagate(ref bytes)
-                | CacheInfo(ref bytes)
+                => bytes.len(),
+
+            #[cfg(not(feature = "rich_nlas"))]
+            CacheInfo(ref bytes)
                 | MfcStats(ref bytes)
                 | Metrics(ref bytes)
                 => bytes.len(),
+            #[cfg(feature = "rich_nlas")]
+            CacheInfo(ref cache_info) => cache_info.buffer_len(),
+            #[cfg(feature = "rich_nlas")]
+            MfcStats(ref stats) => stats.buffer_len(),
+            #[cfg(feature = "rich_nlas")]
+            Metrics(ref metrics) => metrics.buffer_len(),
 
             EncapType(_) => 2,
             Iif(_)
@@ -110,10 +133,20 @@ impl nlas::Nla for Nla {
                 | Pad(ref bytes)
                 | Uid(ref bytes)
                 | TtlPropagate(ref bytes)
+                => buffer.copy_from_slice(bytes.as_slice()),
+
+            #[cfg(not(feature = "rich_nlas"))]
                 | CacheInfo(ref bytes)
                 | MfcStats(ref bytes)
                 | Metrics(ref bytes)
                 => buffer.copy_from_slice(bytes.as_slice()),
+
+            #[cfg(feature = "rich_nlas")]
+            CacheInfo(ref cache_info) => cache_info.emit(buffer),
+            #[cfg(feature = "rich_nlas")]
+            MfcStats(ref stats) => stats.emit(buffer),
+            #[cfg(feature = "rich_nlas")]
+            Metrics(ref metrics) => metrics.emit(buffer),
             EncapType(value) => NativeEndian::write_u16(buffer, value),
             Iif(value)
                 | Oif(value)
@@ -196,9 +229,35 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
             RTA_FLOW => Flow(parse_u32(payload).context("invalid RTA_FLOW value")?),
             RTA_TABLE => Table(parse_u32(payload).context("invalid RTA_TABLE value")?),
             RTA_MARK => Mark(parse_u32(payload).context("invalid RTA_MARK value")?),
+
+            #[cfg(not(feature = "rich_nlas"))]
             RTA_CACHEINFO => CacheInfo(payload.to_vec()),
+            #[cfg(feature = "rich_nlas")]
+            RTA_CACHEINFO => CacheInfo(
+                cache_info::CacheInfo::parse(
+                    &CacheInfoBuffer::new_checked(payload)
+                        .context("invalid RTA_CACHEINFO value")?,
+                )
+                .context("invalid RTA_CACHEINFO value")?,
+            ),
+            #[cfg(not(feature = "rich_nlas"))]
             RTA_MFC_STATS => MfcStats(payload.to_vec()),
+            #[cfg(feature = "rich_nlas")]
+            RTA_MFC_STATS => MfcStats(
+                mfc_stats::MfcStats::parse(
+                    &MfcStatsBuffer::new_checked(payload).context("invalid RTA_MFC_STATS value")?,
+                )
+                .context("invalid RTA_MFC_STATS value")?,
+            ),
+            #[cfg(not(feature = "rich_nlas"))]
             RTA_METRICS => Metrics(payload.to_vec()),
+            #[cfg(feature = "rich_nlas")]
+            RTA_METRICS => Metrics(
+                metrics::Metrics::parse(
+                    &NlaBuffer::new_checked(payload).context("invalid RTA_METRICS value")?,
+                )
+                .context("invalid RTA_METRICS value")?,
+            ),
             _ => Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
         })
     }


### PR DESCRIPTION
The Netlink API is not stable, and the packet format may change from
one kernel version to another or even from a CPU architecture to
another. In an ideal world, we'd have conditional compilation based on
the kernel version and/or system architecture. But at the moment, we
just follow whatever is the current format at the time of
implementation.

This led to several issues, which prompted a PR that simply removes
the problematic NLAs:
https://github.com/little-dude/netlink/pull/51

However, not parsing these NLAs means allocating a buffer and do the parsing a
posteriori which is wasteful and inconvenient. Therefore, this commit
re-introduces these problematic NLAs but behind a feature flag.