### PR TITLE
rtnetlink: add replace option to Add*Request

### DIFF
--- a/rtnetlink/src/addr/add.rs
+++ b/rtnetlink/src/addr/add.rs
@@ -13,6 +13,7 @@ use netlink_packet_route::{
     NLM_F_ACK,
     NLM_F_CREATE,
     NLM_F_EXCL,
+    NLM_F_REPLACE,
     NLM_F_REQUEST,
 };
 
@@ -22,6 +23,7 @@ use crate::{try_nl, Error, Handle};
 pub struct AddressAddRequest {
     handle: Handle,
     message: AddressMessage,
+    replace: bool,
 }
 
 impl AddressAddRequest {
@@ -68,7 +70,19 @@ impl AddressAddRequest {
                 message.nlas.push(Nla::Broadcast(brd.octets().to_vec()));
             };
         }
-        AddressAddRequest { handle, message }
+        AddressAddRequest {
+            handle,
+            message,
+            replace: false,
+        }
+    }
+
+    /// Replace existing matching address.
+    pub fn replace(self) -> Self {
+        Self {
+            replace: true,
+            ..self
+        }
     }
 
     /// Execute the request.
@@ -76,9 +90,11 @@ impl AddressAddRequest {
         let AddressAddRequest {
             mut handle,
             message,
+            replace,
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::NewAddress(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+        let replace = if replace { NLM_F_REPLACE } else { NLM_F_EXCL };
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | replace | NLM_F_CREATE;
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {

--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -12,6 +12,7 @@ use crate::{
         NLM_F_ACK,
         NLM_F_CREATE,
         NLM_F_EXCL,
+        NLM_F_REPLACE,
         NLM_F_REQUEST,
     },
     try_nl,
@@ -246,6 +247,7 @@ impl VxlanAddRequest {
 pub struct LinkAddRequest {
     handle: Handle,
     message: LinkMessage,
+    replace: bool,
 }
 
 impl LinkAddRequest {
@@ -253,6 +255,7 @@ impl LinkAddRequest {
         LinkAddRequest {
             handle,
             message: LinkMessage::default(),
+            replace: false,
         }
     }
 
@@ -261,9 +264,11 @@ impl LinkAddRequest {
         let LinkAddRequest {
             mut handle,
             message,
+            replace,
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::NewLink(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+        let replace = if replace { NLM_F_REPLACE } else { NLM_F_EXCL };
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | replace | NLM_F_CREATE;
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
@@ -367,6 +372,14 @@ impl LinkAddRequest {
         self.name(name.clone())
             .link_info(InfoKind::Bridge, None)
             .append_nla(Nla::IfName(name))
+    }
+
+    /// Replace existing matching link.
+    pub fn replace(self) -> Self {
+        Self {
+            replace: true,
+            ..self
+        }
     }
 
     fn up(mut self) -> Self {

--- a/rtnetlink/src/route/add.rs
+++ b/rtnetlink/src/route/add.rs
@@ -20,6 +20,7 @@ use crate::{try_nl, Error, Handle};
 pub struct RouteAddRequest<T = ()> {
     handle: Handle,
     message: RouteMessage,
+    replace: bool,
     _phantom: PhantomData<T>,
 }
 
@@ -35,6 +36,7 @@ impl<T> RouteAddRequest<T> {
         RouteAddRequest {
             handle,
             message,
+            replace: false,
             _phantom: Default::default(),
         }
     }
@@ -89,6 +91,7 @@ impl<T> RouteAddRequest<T> {
         RouteAddRequest {
             handle: self.handle,
             message: self.message,
+            replace: false,
             _phantom: Default::default(),
         }
     }
@@ -99,7 +102,16 @@ impl<T> RouteAddRequest<T> {
         RouteAddRequest {
             handle: self.handle,
             message: self.message,
+            replace: false,
             _phantom: Default::default(),
+        }
+    }
+
+    /// Replace existing matching route.
+    pub fn replace(self) -> Self {
+        Self {
+            replace: true,
+            ..self
         }
     }
 
@@ -108,10 +120,12 @@ impl<T> RouteAddRequest<T> {
         let RouteAddRequest {
             mut handle,
             message,
+            replace,
             ..
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::NewRoute(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+        let replace = if replace { NLM_F_REPLACE } else { NLM_F_EXCL };
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | replace | NLM_F_CREATE;
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {

--- a/rtnetlink/src/rule/add.rs
+++ b/rtnetlink/src/rule/add.rs
@@ -20,6 +20,7 @@ use crate::{try_nl, Error, Handle};
 pub struct RuleAddRequest<T = ()> {
     handle: Handle,
     message: RuleMessage,
+    replace: bool,
     _phantom: PhantomData<T>,
 }
 
@@ -33,6 +34,7 @@ impl<T> RuleAddRequest<T> {
         RuleAddRequest {
             handle,
             message,
+            replace: false,
             _phantom: Default::default(),
         }
     }
@@ -75,6 +77,7 @@ impl<T> RuleAddRequest<T> {
         RuleAddRequest {
             handle: self.handle,
             message: self.message,
+            replace: false,
             _phantom: Default::default(),
         }
     }
@@ -85,7 +88,16 @@ impl<T> RuleAddRequest<T> {
         RuleAddRequest {
             handle: self.handle,
             message: self.message,
+            replace: false,
             _phantom: Default::default(),
+        }
+    }
+
+    /// Replace existing matching rule.
+    pub fn replace(self) -> Self {
+        Self {
+            replace: true,
+            ..self
         }
     }
 
@@ -94,10 +106,12 @@ impl<T> RuleAddRequest<T> {
         let RuleAddRequest {
             mut handle,
             message,
+            replace,
             ..
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::NewRule(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+        let replace = if replace { NLM_F_REPLACE } else { NLM_F_EXCL };
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | replace | NLM_F_CREATE;
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {


### PR DESCRIPTION
This option sets the `NLM_F_REPLACE` instead of the `NLM_F_EXCL` flag, allowing "create or update" patterns.

My current usecase is for managing neighbors, for which I have a control plane, but it can happen that the neighbor is learnt from the dataplane first, and controlplane second. In this case, I want to set the neighbor as `NOARP` to prevent it from expiring. The easiest is to allow the kernel to just replace the neighbor with the one provided rather than create-fail-delete-create.