### PR TITLE
rtnetlink/neigh: add new_bridge helper to add AF_BRIDGE neighs

### DIFF
--- a/rtnetlink/src/neighbour/add.rs
+++ b/rtnetlink/src/neighbour/add.rs
@@ -40,6 +40,19 @@ impl NeighbourAddRequest {
         NeighbourAddRequest { handle, message }
     }
 
+    pub(crate) fn new_bridge(handle: Handle, index: u32, lla: &[u8]) -> Self {
+        let mut message = NeighbourMessage::default();
+
+        message.header.family = AF_BRIDGE as u8;
+        message.header.ifindex = index;
+        message.header.state = NUD_PERMANENT;
+        message.header.ntype = NDA_UNSPEC as u8;
+
+        message.nlas.push(Nla::LinkLocalAddress(lla.to_vec()));
+
+        NeighbourAddRequest { handle, message }
+    }
+
     /// Set a bitmask of states for the neighbor cache entry.
     /// It should be a combination of `NUD_*` constants.
     pub fn state(mut self, state: u16) -> Self {
@@ -63,7 +76,38 @@ impl NeighbourAddRequest {
 
     /// Set a neighbor cache link layer address (see `NDA_LLADDR` for details).
     pub fn link_local_address(mut self, addr: &[u8]) -> Self {
-        self.message.nlas.push(Nla::LinkLocalAddress(addr.to_vec()));
+        let lla = self.message.nlas.iter_mut().find_map(|nla| match nla {
+            Nla::LinkLocalAddress(lla) => Some(lla),
+            _ => None,
+        });
+
+        if let Some(lla) = lla {
+            *lla = addr.to_vec();
+        } else {
+            self.message.nlas.push(Nla::LinkLocalAddress(addr.to_vec()));
+        }
+
+        self
+    }
+
+    /// Set the destination address for the neighbour (see `NDA_DST` for details).
+    pub fn destination(mut self, addr: IpAddr) -> Self {
+        let dst = self.message.nlas.iter_mut().find_map(|nla| match nla {
+            Nla::Destination(dst) => Some(dst),
+            _ => None,
+        });
+
+        let addr = match addr {
+            IpAddr::V4(v4) => v4.octets().to_vec(),
+            IpAddr::V6(v6) => v6.octets().to_vec(),
+        };
+
+        if let Some(dst) = dst {
+            *dst = addr;
+        } else {
+            self.message.nlas.push(Nla::Destination(addr));
+        }
+
         self
     }
 

--- a/rtnetlink/src/neighbour/handle.rs
+++ b/rtnetlink/src/neighbour/handle.rs
@@ -21,6 +21,11 @@ impl NeighbourHandle {
         NeighbourAddRequest::new(self.0.clone(), index, destination)
     }
 
+    /// Add a new fdb entry (equivalent to `bridge fdb add`)
+    pub fn add_bridge(&self, index: u32, lla: &[u8]) -> NeighbourAddRequest {
+        NeighbourAddRequest::new_bridge(self.0.clone(), index, lla)
+    }
+
     /// Delete a neighbour entry (equivalent to `ip neighbour delete`)
     pub fn del(&self, message: NeighbourMessage) -> NeighbourDelRequest {
         NeighbourDelRequest::new(self.0.clone(), message)


### PR DESCRIPTION
This allows to manipulate the FDB in addition to the ARP table.

While the same could be accomplished with `.message_mut()`, this is less cumbersome:

Before:
```rust
// 0.0.0.0 as a dummy IP, we don't need it for generic FDB entries
let mut req = handle.neighbours()
    .add(index, [0, 0, 0, 0].into())
    .state(NUD_PERMANENT)
    .link_local_address(&[0x8c, 0x8c, 0xde, 0xad, 0xbe, 0xef]);
let mut msg = req.message_mut();
msg.header.family = AF_BRIDGE as u8;
req.execute().await?;
```

After:
```rust
handle.neighbours().add_bridge(index, &[0x8c, 0x8c, 0xde, 0xad, 0xbe, 0xef]).execute().await?;
```