### PR TITLE
bridge: add support for setting `IFLA_BRIDGE_VLAN_INFO`

### DIFF
--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -399,6 +399,7 @@ pub const IFLA_BRIDGE_FLAGS: u16 = 47;
 pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
 pub const BRIDGE_FLAGS_SELF: u16 = 2; /* Bridge command to/from lowerdev */
 
+pub const IFLA_BRIDGE_VLAN_INFO: u16 = 48;
 pub const IFLA_BR_UNSPEC: u16 = 0;
 pub const IFLA_BR_FORWARD_DELAY: u16 = 1;
 pub const IFLA_BR_HELLO_TIME: u16 = 2;

--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -400,6 +400,12 @@ pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
 pub const BRIDGE_FLAGS_SELF: u16 = 2; /* Bridge command to/from lowerdev */
 
 pub const IFLA_BRIDGE_VLAN_INFO: u16 = 48;
+pub const BRIDGE_VLAN_INFO_MASTER: u16 = 1;
+pub const BRIDGE_VLAN_INFO_PVID: u16 = 4;
+pub const BRIDGE_VLAN_INFO_UNTAGGED: u16 = 8;
+pub const BRIDGE_VLAN_INFO_RANGE_BEGIN: u16 = 16;
+pub const BRIDGE_VLAN_INFO_RANGE_END: u16 = 32;
+
 pub const IFLA_BR_UNSPEC: u16 = 0;
 pub const IFLA_BR_FORWARD_DELAY: u16 = 1;
 pub const IFLA_BR_HELLO_TIME: u16 = 2;

--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -835,6 +835,7 @@ pub enum InfoBridge {
     RootPort(u16),
     VlanDefaultPvid(u16),
     VlanFiltering(u8),
+    VlanInfo(u16),
     TopologyChange(u8),
     TopologyChangeDetected(u8),
     MulticastRouter(u8),
@@ -885,6 +886,7 @@ impl Nla for InfoBridge {
                 | RootPathCost(_)
                 => 4,
             Priority(_)
+                | VlanInfo(_)
                 | VlanProtocol(_)
                 | GroupFwdMask(_)
                 | RootPort(_)
@@ -925,6 +927,7 @@ impl Nla for InfoBridge {
         use self::InfoBridge::*;
         match self {
             Flags(value) => NativeEndian::write_u16(buffer, *value),
+            VlanInfo(value) => NativeEndian::write_u16(buffer, *value),
             Unspec(ref bytes)
                 | FdbFlush(ref bytes)
                 | Pad(ref bytes)
@@ -1031,6 +1034,7 @@ impl Nla for InfoBridge {
             RootPort(_) => IFLA_BR_ROOT_PORT,
             VlanDefaultPvid(_) => IFLA_BR_VLAN_DEFAULT_PVID,
             VlanFiltering(_) => IFLA_BR_VLAN_FILTERING,
+            VlanInfo(_) => IFLA_BRIDGE_VLAN_INFO,
             TopologyChange(_) => IFLA_BR_TOPOLOGY_CHANGE,
             TopologyChangeDetected(_) => IFLA_BR_TOPOLOGY_CHANGE_DETECTED,
             MulticastRouter(_) => IFLA_BR_MCAST_ROUTER,
@@ -1061,6 +1065,9 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
             IFLA_BR_PAD => Pad(payload.to_vec()),
             IFLA_BR_HELLO_TIMER => {
                 HelloTimer(parse_u64(payload).context("invalid IFLA_BR_HELLO_TIMER value")?)
+            }
+            IFLA_BRIDGE_VLAN_INFO => {
+                VlanInfo(parse_u16(payload).context("invalid IFLA_BRIDGE_VLAN_INFO value")?)
             }
             IFLA_BR_TCN_TIMER => {
                 TcnTimer(parse_u64(payload).context("invalid IFLA_BR_TCN_TIMER value")?)


### PR DESCRIPTION
Extends `InfoBridge` to support Flags
    
Add support for setting `IFLA_BRIDGE_VLAN_INFO` to bridge management nested attributes.
    
            BRIDGE_VLAN_INFO_MASTER = 1
            BRIDGE_VLAN_INFO_PVID = 4
            BRIDGE_VLAN_INFO_UNTAGGED = 8
            BRIDGE_VLAN_INFO_RANGE_BEGIN = 16
            BRIDGE_VLAN_INFO_RANGE_END = 32
