### PR TITLE
Don't depend on async-std

### DIFF
--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -15,7 +15,7 @@ description = "manipulate linux networking resources via netlink"
 test_as_root = []
 default = ["tokio_socket"]
 tokio_socket = ["netlink-proto/tokio_socket", "tokio"]
-smol_socket = ["netlink-proto/smol_socket", "async-std"]
+smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 
 [dependencies]
 futures = "0.3.11"
@@ -25,7 +25,7 @@ netlink-packet-route = "0.9"
 netlink-proto = { default-features = false, version = "0.8" }
 nix = "0.22.0"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
-async-std = { version = "1.9.0", features = ["unstable"], optional = true}
+async-global-executor = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
 env_logger = "0.8.2"

--- a/rtnetlink/src/ns.rs
+++ b/rtnetlink/src/ns.rs
@@ -20,7 +20,7 @@ where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
 {
-    async_std::task::spawn_blocking(fut).await
+    async_global_executor::spawn_blocking(fut).await
 }
 
 // only tokio enabled, so use tokio


### PR DESCRIPTION
before:
```
cargo tree --no-default-features --features smol_socket --edges no-dev | wc -l
169
```
after:
```
cargo tree --no-default-features --features smol_socket --edges no-dev | wc -l
135
```