### PR TITLE
the example "ip link" command had a typo

### DIFF
--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -342,8 +342,8 @@ impl LinkAddRequest {
     }
 
     /// Create macvlan on a link.
-    /// This is equivalent to `ip link add NAME name link LINK type macvlan mode MACVLAN_MODE`,
-    /// but instead of specifying a link name (`LINK`), we specify a link index.
+    /// This is equivalent to `ip link add name NAME link LINK type macvlan mode MACVLAN_MODE`,
+    ///   but instead of specifying a link name (`LINK`), we specify a link index.
     /// The MACVLAN_MODE is an integer consisting of flags from MACVLAN_MODE (netlink-packet-route/src/rtnl/constants.rs)
     ///   being: _PRIVATE, _VEPA, _BRIDGE, _PASSTHRU, _SOURCE, which can be *combined*.
     pub fn macvlan(self, name: String, index: u32, mode: u32) -> Self {


### PR DESCRIPTION
if NAME is considered the variable, then the order should be "name NAME" rather than "NAME name"
