### PR TITLE
nlas: Add type for `AfSpecBridge` which allows `links` to configure various bridge flags with `SETLINK` calls

### DIFF
--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -395,11 +395,11 @@ pub const IFLA_INFO_XSTATS: u16 = 3;
 pub const IFLA_INFO_SLAVE_KIND: u16 = 4;
 pub const IFLA_INFO_SLAVE_DATA: u16 = 5;
 // Bridge flags
-pub const IFLA_BRIDGE_FLAGS: u16 = 47;
+pub const IFLA_BRIDGE_FLAGS: u16 = 0;
 pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
 pub const BRIDGE_FLAGS_SELF: u16 = 2; /* Bridge command to/from lowerdev */
 
-pub const IFLA_BRIDGE_VLAN_INFO: u16 = 48;
+pub const IFLA_BRIDGE_VLAN_INFO: u16 = 2;
 pub const BRIDGE_VLAN_INFO_MASTER: u16 = 1;
 pub const BRIDGE_VLAN_INFO_PVID: u16 = 4;
 pub const BRIDGE_VLAN_INFO_UNTAGGED: u16 = 8;

--- a/netlink-packet-route/src/rtnl/link/nlas/af_spec_bridge.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/af_spec_bridge.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 use anyhow::Context;
 
 use crate::{

--- a/netlink-packet-route/src/rtnl/link/nlas/af_spec_bridge.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/af_spec_bridge.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+
+use crate::{
+    constants::*,
+    nlas::{self, DefaultNla, NlaBuffer},
+    parsers::parse_u16,
+    traits::Parseable,
+    DecodeError,
+};
+
+use byteorder::{ByteOrder, NativeEndian};
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum AfSpecBridge {
+    Flags(u16),
+    VlanInfo(Vec<u8>),
+    Other(DefaultNla),
+}
+
+impl nlas::Nla for AfSpecBridge {
+    fn value_len(&self) -> usize {
+        use self::AfSpecBridge::*;
+        match *self {
+            VlanInfo(ref bytes) => bytes.len(),
+            Flags(_) => 2,
+            Other(ref nla) => nla.value_len(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        use self::AfSpecBridge::*;
+        match *self {
+            Flags(value) => NativeEndian::write_u16(buffer, value),
+            VlanInfo(ref bytes) => {
+                (&mut buffer[..bytes.len()]).copy_from_slice(bytes.as_slice());
+            }
+            Other(ref nla) => nla.emit_value(buffer),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        use self::AfSpecBridge::*;
+        match *self {
+            Flags(_) => IFLA_BRIDGE_FLAGS,
+            VlanInfo(_) => IFLA_BRIDGE_VLAN_INFO,
+            Other(ref nla) => nla.kind(),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for AfSpecBridge {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        use self::AfSpecBridge::*;
+
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            IFLA_BRIDGE_VLAN_INFO => VlanInfo(payload.to_vec()),
+            IFLA_BRIDGE_FLAGS => {
+                Flags(parse_u16(payload).context("invalid IFLA_BRIDGE_FLAGS value")?)
+            }
+            kind => Other(DefaultNla::parse(buf).context(format!("Unknown NLA type {}", kind))?),
+        })
+    }
+}

--- a/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
+++ b/netlink-packet-route/src/rtnl/link/nlas/link_infos.rs
@@ -805,7 +805,6 @@ pub enum InfoBridge {
     // FIXME: what type is this? putting Vec<u8> for now but it might
     // be a boolean actually
     FdbFlush(Vec<u8>),
-    Flags(u16),
     Pad(Vec<u8>),
     HelloTimer(u64),
     TcnTimer(u64),
@@ -835,7 +834,6 @@ pub enum InfoBridge {
     RootPort(u16),
     VlanDefaultPvid(u16),
     VlanFiltering(u8),
-    VlanInfo(u16),
     TopologyChange(u8),
     TopologyChangeDetected(u8),
     MulticastRouter(u8),
@@ -886,12 +884,10 @@ impl Nla for InfoBridge {
                 | RootPathCost(_)
                 => 4,
             Priority(_)
-                | VlanInfo(_)
                 | VlanProtocol(_)
                 | GroupFwdMask(_)
                 | RootPort(_)
                 | VlanDefaultPvid(_)
-                | Flags(_)
                 => 2,
 
             RootId(_)
@@ -926,8 +922,6 @@ impl Nla for InfoBridge {
     fn emit_value(&self, buffer: &mut [u8]) {
         use self::InfoBridge::*;
         match self {
-            Flags(value) => NativeEndian::write_u16(buffer, *value),
-            VlanInfo(value) => NativeEndian::write_u16(buffer, *value),
             Unspec(ref bytes)
                 | FdbFlush(ref bytes)
                 | Pad(ref bytes)
@@ -1004,7 +998,6 @@ impl Nla for InfoBridge {
             Unspec(_) => IFLA_BR_UNSPEC,
             GroupAddr(_) => IFLA_BR_GROUP_ADDR,
             FdbFlush(_) => IFLA_BR_FDB_FLUSH,
-            Flags(_) => IFLA_BRIDGE_FLAGS,
             Pad(_) => IFLA_BR_PAD,
             HelloTimer(_) => IFLA_BR_HELLO_TIMER,
             TcnTimer(_) => IFLA_BR_TCN_TIMER,
@@ -1034,7 +1027,6 @@ impl Nla for InfoBridge {
             RootPort(_) => IFLA_BR_ROOT_PORT,
             VlanDefaultPvid(_) => IFLA_BR_VLAN_DEFAULT_PVID,
             VlanFiltering(_) => IFLA_BR_VLAN_FILTERING,
-            VlanInfo(_) => IFLA_BRIDGE_VLAN_INFO,
             TopologyChange(_) => IFLA_BR_TOPOLOGY_CHANGE,
             TopologyChangeDetected(_) => IFLA_BR_TOPOLOGY_CHANGE_DETECTED,
             MulticastRouter(_) => IFLA_BR_MCAST_ROUTER,
@@ -1066,14 +1058,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for InfoBridge {
             IFLA_BR_HELLO_TIMER => {
                 HelloTimer(parse_u64(payload).context("invalid IFLA_BR_HELLO_TIMER value")?)
             }
-            IFLA_BRIDGE_VLAN_INFO => {
-                VlanInfo(parse_u16(payload).context("invalid IFLA_BRIDGE_VLAN_INFO value")?)
-            }
             IFLA_BR_TCN_TIMER => {
                 TcnTimer(parse_u64(payload).context("invalid IFLA_BR_TCN_TIMER value")?)
-            }
-            IFLA_BRIDGE_FLAGS => {
-                Flags(parse_u16(payload).context("invalid IFLA_BRIDGE_FLAGS value")?)
             }
             IFLA_BR_TOPOLOGY_CHANGE_TIMER => TopologyChangeTimer(
                 parse_u64(payload).context("invalid IFLA_BR_TOPOLOGY_CHANGE_TIMER value")?,


### PR DESCRIPTION
Following PR allows `handle.link().set(` or `RTM_SETLINK` calls to configure various `bridge` attributes like.

* `IFLA_BRIDGE_FLAGS`
* `IFLA_BRIDGE_VLAN_INFO`

With this PR its easy to implement functionality like
```console
bridge vlan add ...
```

This PR also corrects some changes made in 
https://github.com/little-dude/netlink/pull/212 and https://github.com/little-dude/netlink/pull/213