### PR TITLE
use latest netlink-packet-generic as dependency in other subcrates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,11 @@ jobs:
           cd netlink-packet-utils
           cargo test
 
+      - name: test (netlink-packet-wireguard)
+        run: |
+          cd netlink-packet-wireguard
+          cargo test
+
       - name: test (netlink-proto)
         run: |
           cd netlink-proto

--- a/ethtool/Cargo.toml
+++ b/ethtool/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3.17"
 genetlink = { default-features = false, version = "0.2.0"}
 log = "0.4.14"
 netlink-packet-core = "0.4.0"
-netlink-packet-generic = "0.2.0"
+netlink-packet-generic = "0.3.0"
 netlink-packet-utils = "0.5"
 netlink-proto = { default-features = false, version = "0.9.0" }
 netlink-sys = "0.8.0"

--- a/genetlink/Cargo.toml
+++ b/genetlink/Cargo.toml
@@ -17,7 +17,7 @@ smol_socket = ["netlink-proto/smol_socket","async-std"]
 
 [dependencies]
 futures = "0.3.16"
-netlink-packet-generic = "0.2.0"
+netlink-packet-generic = "0.3.0"
 netlink-proto = { default-features = false, version = "0.9.0" }
 tokio = { version = "1.9.0", features = ["rt"], optional = true }
 async-std = { version = "1.9.0", optional = true }

--- a/netlink-packet-wireguard/Cargo.toml
+++ b/netlink-packet-wireguard/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.42"
 byteorder = "1.4.3"
 libc = "0.2.98"
 log = "0.4.14"
-netlink-packet-generic = "0.2.0"
+netlink-packet-generic = "0.3.0"
 netlink-packet-utils = "0.5.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Otherwise a crate already depending on `netlink-packet-generic 0.3` will get errors like this when compiling:

```
 the trait `netlink_packet_generic::traits::GenlFamily` is not implemented for `Wireguard`
```
