### PR TITLE
make a release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,32 @@
 ### New Features
 ### Bug fixes
 
+## [20220220] 2022-02-20
+
+### Versioning
+
+* netlink-packet-netfilter NULL -> 0.1.0
+* netlink-sys 0.8.1 -> 0.8.2
+* netlink-packet-core 0.4.1 -> 0.4.2
+* netlink-packet-utils 0.5.0 -> 0.5.1
+* netlink-packet-route 0.10.0 -> 0.11.0
+* netlink-packet-sock-diag 0.3.0 -> 0.3.1
+* netlink-packet-wireguard 0.2.0 -> 0.2.1
+* netlink-proto 0.9.1 -> 0.9.2
+* ethtool 0.2.1 -> 0.2.2
+* rtnetlink 0.9.0 -> 0.9.1
+
+### New Features
+
+* **new crate netlink-packet-netfilter!** Thank you @dzamlo :) (https://github.com/little-dude/netlink/pull/235)
+* netlink-packet-utils: speed up computation of netlink attributes paddins (https://github.com/little-dude/netlink/pull/229)
+* netlink-packet-route: support additional MPLS attributes (https://github.com/little-dude/netlink/pull/233)
+
+### Bug fixes
+
+* netlink-packet-sys, netlink-packet-sock-diag, netlink-packet-route, netlink-packet-wireguard, ethtool, netlink-packet-core: clippy fixes (https://github.com/little-dude/netlink/pull/238)
+* netlink-packet-route: fix encoding of link info attribute (https://github.com/little-dude/netlink/pull/239)
+
 ## [20220212] 2022-02-12
 
 ### Versioning

--- a/ethtool/Cargo.toml
+++ b/ethtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethtool"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-core"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -18,4 +18,4 @@ libc = "0.2.66"
 netlink-packet-utils = "0.5"
 
 [dev-dependencies]
-netlink-packet-route = "0.10"
+netlink-packet-route = "0.11"

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-route/fuzz/Cargo.toml
+++ b/netlink-packet-route/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-route = "0.9"
+netlink-packet-route = { path = "../" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Flier Lu <flier.lu@gmail.com>", "Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-sock-diag"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-utils/Cargo.toml
+++ b/netlink-packet-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-utils"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-wireguard/Cargo.toml
+++ b/netlink-packet-wireguard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-wireguard"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Leo <leo881003@gmail.com>", "Jake McGinty <me@jake.su>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -27,7 +27,7 @@ smol_socket = ["netlink-sys/smol_socket"]
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = "0.10"
+netlink-packet-route = "0.11"
 netlink-packet-audit = "0.4"
 async-std = {version = "1.9.0", features = ["attributes"]}
 

--- a/netlink-sys/Cargo.toml
+++ b/netlink-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-sys"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -21,8 +21,8 @@ smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
-netlink-packet-route = "0.10.0"
-netlink-proto = { default-features = false, version = "0.9.0" }
+netlink-packet-route = "0.11"
+netlink-proto = { default-features = false, version = "0.9" }
 nix = "0.22.0"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }


### PR DESCRIPTION
## [20220220] 2022-02-20

### Versioning

- [x] netlink-packet-netfilter NULL -> 0.1.0
- [x] netlink-sys 0.8.1 -> 0.8.2
- [x] netlink-packet-core 0.4.1 -> 0.4.2
- [x] netlink-packet-utils 0.5.0 -> 0.5.1
- [x] netlink-packet-route 0.10.0 -> 0.11.0
- [x] netlink-packet-sock-diag 0.3.0 -> 0.3.1
- [x] netlink-packet-wireguard 0.2.0 -> 0.2.1
- [x] netlink-proto 0.9.1 -> 0.9.2
- [x] ethtool 0.2.1 -> 0.2.2
- [x] rtnetlink 0.9.0 -> 0.9.1

### New Features

* **new crate netlink-packet-netfilter!** Thank you @dzamlo :) (https://github.com/little-dude/netlink/pull/235)
* netlink-packet-utils: speed up computation of netlink attributes paddins (https://github.com/little-dude/netlink/pull/229)
* netlink-packet-route: support additional MPLS attributes (https://github.com/little-dude/netlink/pull/233)

### Bug fixes

* netlink-packet-sys, netlink-packet-sock-diag, netlink-packet-route, netlink-packet-wireguard, ethtool, netlink-packet-core: clippy fixes (https://github.com/little-dude/netlink/pull/238)
* netlink-packet-route: fix encoding of link info attribute (https://github.com/little-dude/netlink/pull/239)
