### PR TITLE
Updated mio to 0.8

### DIFF
--- a/netlink-sys/Cargo.toml
+++ b/netlink-sys/Cargo.toml
@@ -29,7 +29,7 @@ features = ["net"]
 
 [dependencies.mio]
 optional = true
-version = "0.7"
+version = "0.8"
 features = ["os-poll", "os-ext"]
 
 [dependencies.async-io]


### PR DESCRIPTION
`mio` version mismatched can result in #242. Bumping the version number allows projects that use this library to use `mio` 0.8 without issue.