### PR TITLE
fix netlink_proto::Error type

### DIFF
--- a/audit/src/lib.rs
+++ b/audit/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::errors::*;
 
 pub use netlink_packet_audit as packet;
 pub mod proto {
-    pub use netlink_proto::{Connection, ConnectionHandle, Error, ErrorKind};
+    pub use netlink_proto::{Connection, ConnectionHandle, Error};
 }
 pub use netlink_proto::sys;
 

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util"] }
 netlink-packet-core = "0.4"
 netlink-sys = { default-features = false, version = "0.8" }
+thiserror = "1.0.30"
 
 [features]
 default = ["tokio_socket"]

--- a/netlink-proto/src/errors.rs
+++ b/netlink-proto/src/errors.rs
@@ -1,90 +1,20 @@
 // SPDX-License-Identifier: MIT
 
-use std::{
-    error::Error as StdError,
-    fmt::{self, Debug},
-    io,
-};
+use std::io;
 
 use netlink_packet_core::NetlinkMessage;
 
-#[derive(Debug)]
-pub struct Error<T>
-where
-    T: Debug,
-{
-    kind: ErrorKind<T>,
-}
-
-impl<T> Error<T>
-where
-    T: Debug,
-{
-    pub fn kind(&self) -> &ErrorKind<T> {
-        &self.kind
-    }
-
-    pub fn into_inner(self) -> ErrorKind<T> {
-        self.kind
-    }
-}
-
-#[derive(Debug)]
-pub enum ErrorKind<T>
-where
-    T: Debug,
-{
+#[derive(thiserror::Error, Debug)]
+pub enum Error<T> {
     /// The netlink connection is closed
+    #[error("the netlink connection is closed")]
     ConnectionClosed,
 
     /// Received an error message as a response
+    #[error("received an error message as a response: {0:?}")]
     NetlinkError(NetlinkMessage<T>),
 
     /// Error while reading from or writing to the netlink socket
-    SocketIo(io::Error),
-}
-
-impl<T> From<ErrorKind<T>> for Error<T>
-where
-    T: Debug,
-{
-    fn from(kind: ErrorKind<T>) -> Error<T> {
-        Error { kind }
-    }
-}
-
-impl<T> fmt::Display for Error<T>
-where
-    T: Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use crate::ErrorKind::*;
-        match self.kind() {
-            SocketIo(ref e) => write!(f, "{}: {}", self, e),
-            ConnectionClosed => write!(f, "{}", self),
-            NetlinkError(ref message) => write!(f, "{}: {:?}", self, message),
-        }
-    }
-}
-
-impl<T> StdError for Error<T>
-where
-    T: Debug,
-{
-    fn description(&self) -> &str {
-        use crate::ErrorKind::*;
-        match self.kind() {
-            SocketIo(_) => "Error while reading from or writing to the netlink socket",
-            ConnectionClosed => "The netlink connection is closed",
-            NetlinkError(_) => "Received an error message as a response",
-        }
-    }
-
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        if let ErrorKind::SocketIo(ref e) = self.kind() {
-            Some(e)
-        } else {
-            None
-        }
-    }
+    #[error("error while reading from or writing to the netlink socket: {0}")]
+    SocketIo(#[from] io::Error),
 }

--- a/netlink-proto/src/handle.rs
+++ b/netlink-proto/src/handle.rs
@@ -7,11 +7,7 @@ use futures::{
 use netlink_packet_core::NetlinkMessage;
 use std::fmt::Debug;
 
-use crate::{
-    errors::{Error, ErrorKind},
-    sys::SocketAddr,
-    Request,
-};
+use crate::{errors::Error, sys::SocketAddr, Request};
 
 /// A handle to pass requests to a [`Connection`](struct.Connection.html).
 #[derive(Clone, Debug)]
@@ -50,7 +46,7 @@ where
             if e.is_full() {
                 panic!("internal error: unbounded channel full?!");
             } else if e.is_disconnected() {
-                Error::from(ErrorKind::ConnectionClosed)
+                Error::ConnectionClosed
             } else {
                 panic!("unknown error: {:?}", e);
             }
@@ -67,6 +63,6 @@ where
         let request = Request::from((message, destination, tx));
         debug!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request)
-            .map_err(|_| ErrorKind::ConnectionClosed.into())
+            .map_err(|_| Error::ConnectionClosed)
     }
 }

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -44,7 +44,6 @@ pub mod proto {
         Connection,
         ConnectionHandle,
         Error,
-        ErrorKind,
     };
 }
 pub use netlink_proto::sys;

--- a/rtnetlink/src/traffic_control/handle.rs
+++ b/rtnetlink/src/traffic_control/handle.rs
@@ -46,7 +46,7 @@ impl QDiscHandle {
     /// ( equivalent to `tc qdisc replace dev STRING`)
     pub fn replace(&mut self, index: i32) -> QDiscNewRequest {
         let msg = TcMessage::with_index(index);
-        QDiscNewRequest::new(self.0.clone(), msg.into(), NLM_F_CREATE | NLM_F_REPLACE)
+        QDiscNewRequest::new(self.0.clone(), msg, NLM_F_CREATE | NLM_F_REPLACE)
     }
 
     /// Performs a replace where the node must exist already.


### PR DESCRIPTION
clippy found out that our implementation is recursive:

```
error: using `self` as `Display` in `impl Display` will cause infinite recursion
  --> netlink-proto/src/errors.rs:63:32
   |
63 |             SocketIo(ref e) => write!(f, "{}: {}", self, e),
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[deny(clippy::recursive_format_impl)]` on by default
   = help: for further information visit rust-lang.github.io/rust-clippy/master/index.html#recursive_format_impl
   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
```

It turns out that this Error implementation is clumsy and that we
don't need the inner `ErrorKind` type. This commit removes the
`ErrorKind` (which is also exposed in `audit` and `rtnetlink`) and
uses `thiserror` to derive most of the boilerplate we need for
`Error`.