### PR TITLE
rtnetlink: add a way to set netlink flags in requests

### DIFF
--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -26,6 +26,7 @@ netlink-proto = { default-features = false, version = "0.9" }
 nix = "0.22.0"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }
+bitflags = "1.3.2"
 
 [dev-dependencies]
 env_logger = "0.8.2"

--- a/rtnetlink/src/flags.rs
+++ b/rtnetlink/src/flags.rs
@@ -1,0 +1,132 @@
+bitflags::bitflags! {
+    pub struct GetFlags: u16 {
+        /// Must be set on all request messages (typically from user
+        /// space to kernel space)
+        ///
+        /// **This flag is set by default**
+        const REQUEST = 1;
+        ///  Indicates the message is part of a multipart message
+        ///  terminated by NLMSG_DONE
+        const MULTIPART = 2;
+        /// Request for an acknowledgment on success. Typical
+        /// direction of request is from user space (CPC) to kernel
+        /// space (FEC).
+        const ACK = 4;
+        /// Echo this request. Typical direction of request is from
+        /// user space (CPC) to kernel space (FEC).
+        const ECHO = 8;
+        /// Return the complete table instead of a single entry.
+        const ROOT = 256;
+        /// Return all entries matching criteria passed in message
+        /// content.
+        const MATCH = 512;
+        /// Return an atomic snapshot of the table. Requires
+        /// `CAP_NET_ADMIN` capability or a effective UID of 0.
+        const ATOMIC = 1024;
+        /// Equivalent to `ROOT|MATCH`.
+        const DUMP = 768;
+    }
+}
+
+impl GetFlags {
+    /// Create new `GetFlags` with only `GetFlags::REQUEST`.
+    pub fn new() -> Self {
+        GetFlags::REQUEST
+    }
+}
+
+impl Default for GetFlags {
+    /// Create new `GetFlags` with only `GetFlags::REQUEST`.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+bitflags::bitflags! {
+    pub struct NewFlags: u16 {
+        /// Must be set on all request messages (typically from user
+        /// space to kernel space).
+        ///
+        /// **This flag is set by default**
+        const REQUEST = 1;
+        ///  Indicates the message is part of a multipart message
+        ///  terminated by NLMSG_DONE
+        const MULTIPART = 2;
+        /// Request for an acknowledgment on success. Typical
+        /// direction of request is from user space (CPC) to kernel
+        /// space (FEC).
+        ///
+        /// **This flag is set by default**
+        const ACK = 4;
+        /// Echo this request. Typical direction of request is from
+        /// user space (CPC) to kernel space (FEC).
+        const ECHO = 8;
+        /// Replace existing matching object.
+        const REPLACE = 256;
+        /// Don't replace if the object already exists.
+        ///
+        /// This flag is not set by default but can is pretty commonly
+        /// used.
+        const EXCL = 512;
+        /// Create object if it doesn't already exist.
+        ///
+        /// **This flag is set by default**
+        const CREATE = 1024;
+        /// Add to the end of the object list.
+        const APPEND = 2048;
+        /// Do not delete recursively
+        const NONREC = 256;
+    }
+}
+
+impl NewFlags {
+    /// Create new `NewFlags` with `REQUEST | ACK | CREATE` set.
+    pub fn new() -> Self {
+        Self::REQUEST | Self::ACK | Self::CREATE
+    }
+}
+
+impl Default for NewFlags {
+    /// Create new `NewFlags` with `REQUEST | ACK | CREATE` set.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+bitflags::bitflags! {
+    pub struct DelFlags: u16 {
+        /// Must be set on all request messages (typically from user
+        /// space to kernel space)
+        ///
+        /// **This flag is set by default**
+        const REQUEST = 1;
+        ///  Indicates the message is part of a multipart message
+        ///  terminated by NLMSG_DONE
+        const MULTIPART = 2;
+        /// Request for an acknowledgment on success. Typical
+        /// direction of request is from user space (CPC) to kernel
+        /// space (FEC).
+        ///
+        /// **This flag is set by default**
+        const ACK = 4;
+        /// Echo this request. Typical direction of request is from
+        /// user space (CPC) to kernel space (FEC).
+        const ECHO = 8;
+        /// Do not delete recursively
+        const NONREC = 256;
+    }
+}
+
+impl DelFlags {
+    /// Create a new `DelFlags` with `REQUEST | ACK` set
+    pub fn new() -> Self {
+        Self::REQUEST | Self::ACK
+    }
+}
+
+impl Default for DelFlags {
+    /// Create a new `DelFlags` with `REQUEST | ACK` set
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rtnetlink/src/lib.rs
+++ b/rtnetlink/src/lib.rs
@@ -48,4 +48,5 @@ pub mod proto {
 }
 pub use netlink_proto::sys;
 
+pub mod flags;
 mod macros;

--- a/rtnetlink/src/link/add.rs
+++ b/rtnetlink/src/link/add.rs
@@ -3,17 +3,13 @@
 use futures::stream::StreamExt;
 
 use crate::{
+    flags::NewFlags,
     packet::{
         nlas::link::{Info, InfoData, InfoKind, InfoMacVlan, InfoVlan, InfoVxlan, Nla, VethInfo},
         LinkMessage,
         NetlinkMessage,
         RtnlMessage,
         IFF_UP,
-        NLM_F_ACK,
-        NLM_F_CREATE,
-        NLM_F_EXCL,
-        NLM_F_REPLACE,
-        NLM_F_REQUEST,
     },
     try_nl,
     Error,
@@ -247,7 +243,7 @@ impl VxlanAddRequest {
 pub struct LinkAddRequest {
     handle: Handle,
     message: LinkMessage,
-    replace: bool,
+    flags: NewFlags,
 }
 
 impl LinkAddRequest {
@@ -255,7 +251,7 @@ impl LinkAddRequest {
         LinkAddRequest {
             handle,
             message: LinkMessage::default(),
-            replace: false,
+            flags: NewFlags::new(),
         }
     }
 
@@ -264,11 +260,10 @@ impl LinkAddRequest {
         let LinkAddRequest {
             mut handle,
             message,
-            replace,
+            flags,
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::NewLink(message));
-        let replace = if replace { NLM_F_REPLACE } else { NLM_F_EXCL };
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | replace | NLM_F_CREATE;
+        req.header.flags = flags.bits();
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
@@ -302,6 +297,17 @@ impl LinkAddRequest {
     /// }
     pub fn message_mut(&mut self) -> &mut LinkMessage {
         &mut self.message
+    }
+
+    /// Set the netlink header flags.
+    ///
+    /// # Warning
+    ///
+    /// Altering the request's flags may render the request
+    /// ineffective. Only set the flags if you know what you're doing.
+    pub fn set_flags(mut self, flags: NewFlags) -> Self {
+        self.flags = flags;
+        self
     }
 
     /// Create a dummy link.
@@ -374,14 +380,6 @@ impl LinkAddRequest {
         self.name(name.clone())
             .link_info(InfoKind::Bridge, None)
             .append_nla(Nla::IfName(name))
-    }
-
-    /// Replace existing matching link.
-    pub fn replace(self) -> Self {
-        Self {
-            replace: true,
-            ..self
-        }
     }
 
     fn up(mut self) -> Self {

--- a/rtnetlink/src/link/del.rs
+++ b/rtnetlink/src/link/del.rs
@@ -3,15 +3,8 @@
 use futures::stream::StreamExt;
 
 use crate::{
-    packet::{
-        LinkMessage,
-        NetlinkMessage,
-        RtnlMessage,
-        NLM_F_ACK,
-        NLM_F_CREATE,
-        NLM_F_EXCL,
-        NLM_F_REQUEST,
-    },
+    flags::DelFlags,
+    packet::{LinkMessage, NetlinkMessage, RtnlMessage},
     try_nl,
     Error,
     Handle,
@@ -20,13 +13,18 @@ use crate::{
 pub struct LinkDelRequest {
     handle: Handle,
     message: LinkMessage,
+    flags: DelFlags,
 }
 
 impl LinkDelRequest {
     pub(crate) fn new(handle: Handle, index: u32) -> Self {
         let mut message = LinkMessage::default();
         message.header.index = index;
-        LinkDelRequest { handle, message }
+        LinkDelRequest {
+            handle,
+            message,
+            flags: DelFlags::new(),
+        }
     }
 
     /// Execute the request
@@ -34,9 +32,10 @@ impl LinkDelRequest {
         let LinkDelRequest {
             mut handle,
             message,
+            flags,
         } = self;
         let mut req = NetlinkMessage::from(RtnlMessage::DelLink(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+        req.header.flags = flags.bits();
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
@@ -48,5 +47,16 @@ impl LinkDelRequest {
     /// Return a mutable reference to the request
     pub fn message_mut(&mut self) -> &mut LinkMessage {
         &mut self.message
+    }
+
+    /// Set the netlink header flags.
+    ///
+    /// # Warning
+    ///
+    /// Altering the request's flags may render the request
+    /// ineffective. Only set the flags if you know what you're doing.
+    pub fn set_flags(mut self, flags: DelFlags) -> Self {
+        self.flags = flags;
+        self
     }
 }

--- a/rtnetlink/src/rule/del.rs
+++ b/rtnetlink/src/rule/del.rs
@@ -3,7 +3,8 @@
 use futures::stream::StreamExt;
 
 use crate::{
-    packet::{NetlinkMessage, RtnlMessage, RuleMessage, NLM_F_ACK, NLM_F_REQUEST},
+    flags::DelFlags,
+    packet::{NetlinkMessage, RtnlMessage, RuleMessage},
     try_nl,
     Error,
     Handle,
@@ -12,11 +13,16 @@ use crate::{
 pub struct RuleDelRequest {
     handle: Handle,
     message: RuleMessage,
+    flags: DelFlags,
 }
 
 impl RuleDelRequest {
     pub(crate) fn new(handle: Handle, message: RuleMessage) -> Self {
-        RuleDelRequest { handle, message }
+        RuleDelRequest {
+            handle,
+            message,
+            flags: DelFlags::new(),
+        }
     }
 
     /// Execute the request
@@ -24,10 +30,11 @@ impl RuleDelRequest {
         let RuleDelRequest {
             mut handle,
             message,
+            flags,
         } = self;
 
         let mut req = NetlinkMessage::from(RtnlMessage::DelRule(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        req.header.flags = flags.bits();
         let mut response = handle.request(req)?;
         while let Some(msg) = response.next().await {
             try_nl!(msg);
@@ -37,5 +44,16 @@ impl RuleDelRequest {
 
     pub fn message_mut(&mut self) -> &mut RuleMessage {
         &mut self.message
+    }
+
+    /// Set the netlink header flags.
+    ///
+    /// # Warning
+    ///
+    /// Altering the request's flags may render the request
+    /// ineffective. Only set the flags if you know what you're doing.
+    pub fn set_flags(mut self, flags: DelFlags) -> Self {
+        self.flags = flags;
+        self
     }
 }

--- a/rtnetlink/src/rule/get.rs
+++ b/rtnetlink/src/rule/get.rs
@@ -1,19 +1,24 @@
 // SPDX-License-Identifier: MIT
 
-use crate::IpVersion;
 use futures::{
     future::{self, Either},
     stream::{StreamExt, TryStream},
     FutureExt,
 };
 
-use netlink_packet_route::{constants::*, NetlinkMessage, RtnlMessage, RuleMessage};
-
-use crate::{try_rtnl, Error, Handle};
+use crate::{
+    flags::GetFlags,
+    packet::{constants::*, NetlinkMessage, RtnlMessage, RuleMessage},
+    try_rtnl,
+    Error,
+    Handle,
+    IpVersion,
+};
 
 pub struct RuleGetRequest {
     handle: Handle,
     message: RuleMessage,
+    flags: GetFlags,
 }
 
 impl RuleGetRequest {
@@ -27,21 +32,37 @@ impl RuleGetRequest {
         message.header.action = FR_ACT_UNSPEC;
         message.header.table = RT_TABLE_UNSPEC;
 
-        RuleGetRequest { handle, message }
+        RuleGetRequest {
+            handle,
+            message,
+            flags: GetFlags::new() | GetFlags::DUMP,
+        }
     }
 
     pub fn message_mut(&mut self) -> &mut RuleMessage {
         &mut self.message
     }
 
+    /// Set the netlink header flags.
+    ///
+    /// # Warning
+    ///
+    /// Altering the request's flags may render the request
+    /// ineffective. Only set the flags if you know what you're doing.
+    pub fn set_flags(mut self, flags: GetFlags) -> Self {
+        self.flags = flags;
+        self
+    }
+
     pub fn execute(self) -> impl TryStream<Ok = RuleMessage, Error = Error> {
         let RuleGetRequest {
             mut handle,
             message,
+            flags,
         } = self;
 
         let mut req = NetlinkMessage::from(RtnlMessage::GetRule(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+        req.header.flags = flags.bits();
 
         match handle.request(req) {
             Ok(response) => {


### PR DESCRIPTION
There has been several PRs to add helper methods to set the flags in
the netlink header, so it seems that this is something we should
provide systematically.

This PR introduces three new types to manipulate netlink flags:

- `NewFlags`: flags used for "set" and "add" requests
- `DelFlags`: flags used to "del" requests
- `GetFlags:` flags used for "get" requests

Each request now has a `set_flags` method to force a certain set of
flags. This may interfere with other builder methods for certain
requests, or may simply render the request ineffective, so the
documentation always warns users.