### PR TITLE
bridge: Fix decode error on bridge with IFLA_BR_MCAST_QUERIER_STATE

### DIFF
--- a/netlink-packet-route/src/rtnl/constants.rs
+++ b/netlink-packet-route/src/rtnl/constants.rs
@@ -395,16 +395,16 @@ pub const IFLA_INFO_XSTATS: u16 = 3;
 pub const IFLA_INFO_SLAVE_KIND: u16 = 4;
 pub const IFLA_INFO_SLAVE_DATA: u16 = 5;
 // Bridge flags
-pub const IFLA_BRIDGE_FLAGS: u16 = 47;
-pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
-pub const BRIDGE_FLAGS_SELF: u16 = 2; /* Bridge command to/from lowerdev */
-
-pub const IFLA_BRIDGE_VLAN_INFO: u16 = 48;
-pub const BRIDGE_VLAN_INFO_MASTER: u16 = 1;
-pub const BRIDGE_VLAN_INFO_PVID: u16 = 4;
-pub const BRIDGE_VLAN_INFO_UNTAGGED: u16 = 8;
-pub const BRIDGE_VLAN_INFO_RANGE_BEGIN: u16 = 16;
-pub const BRIDGE_VLAN_INFO_RANGE_END: u16 = 32;
+// pub const IFLA_BRIDGE_FLAGS: u16 = 0;
+// pub const BRIDGE_FLAGS_MASTER: u16 = 1; /* Bridge command to/from master */
+// pub const BRIDGE_FLAGS_SELF: u16 = 2; /* Bridge command to/from lowerdev */
+//
+// pub const IFLA_BRIDGE_VLAN_INFO: u16 = 2;
+// pub const BRIDGE_VLAN_INFO_MASTER: u16 = 1;
+// pub const BRIDGE_VLAN_INFO_PVID: u16 = 4;
+// pub const BRIDGE_VLAN_INFO_UNTAGGED: u16 = 8;
+// pub const BRIDGE_VLAN_INFO_RANGE_BEGIN: u16 = 16;
+// pub const BRIDGE_VLAN_INFO_RANGE_END: u16 = 32;
 
 pub const IFLA_BR_UNSPEC: u16 = 0;
 pub const IFLA_BR_FORWARD_DELAY: u16 = 1;
@@ -453,6 +453,7 @@ pub const IFLA_BR_MCAST_IGMP_VERSION: u16 = 43;
 pub const IFLA_BR_MCAST_MLD_VERSION: u16 = 44;
 pub const IFLA_BR_VLAN_STATS_PER_PORT: u16 = 45;
 pub const IFLA_BR_MULTI_BOOLOPT: u16 = 46;
+// pub const IFLA_BR_MCAST_QUERIER_STATE: u16 = 47;
 pub const IFLA_MACVLAN_UNSPEC: u16 = 0;
 pub const IFLA_MACVLAN_MODE: u16 = 1;
 pub const IFLA_MACVLAN_FLAGS: u16 = 2;


### PR DESCRIPTION
With kernel supporting `IFLA_BR_MCAST_QUERIER_STATE`, we got error:

    Decode error occurred: Failed to parse message with type 16

After painfull debug, this is caused by IFLA_BRIDGE_FLAGS holding the
same value as `IFLA_BR_MCAST_QUERIER_STATE` and expecting the payload
been a u16.

This is incorrect:
 * `IFLA_BRIDGE_FLAGS` is 0, and for `IFLA_AF_SPEC`, not `IFLA_LINKINFO`.
 * `IFLA_BR_MCAST_QUERIER_STATE` is a nested netlink attribute, not u16
   which cause this failure.

I have no project needing the support `IFLA_BR_MCAST_QUERIER_STATE` of
it yet, so this patch just remove `IFLA_BRIDGE_FLAGS`,
`IFLA_BRIDGE_VLAN_INFO`, and their associates.

Also reordering the order of parsing `IFLA_LINKINFO` for bridge, to
match the numeric order. So the developer could easily compare it to
`/usr/include/linux/if_link.h`.