### PR TITLE
Improved TokioSocket::recv() and recv_from()

### DIFF
--- a/netlink-proto/src/framed.rs
+++ b/netlink-proto/src/framed.rs
@@ -61,8 +61,8 @@ where
             reader.clear();
             reader.reserve(INITIAL_READER_CAPACITY);
 
-            *in_addr = match ready!(socket.poll_recv_from(cx, reader)) {
-                Ok(addr) => addr,
+            *in_addr = match ready!(socket.poll_recv_from(cx, reader, 0)) {
+                Ok((_len, addr)) => addr,
                 Err(e) => {
                     error!("failed to read from netlink socket: {:?}", e);
                     return Poll::Ready(None);

--- a/netlink-sys/examples/audit_events_tokio.rs
+++ b/netlink-sys/examples/audit_events_tokio.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = bytes::BytesMut::with_capacity(1024 * 8);
     loop {
         buf.clear();
-        let _addr = socket.recv_from(&mut buf).await.unwrap();
+        let (_len, _addr) = socket.recv_from(&mut buf, 0).await.unwrap();
         // This dance with the NetlinkBuffer should not be
         // necessary. It is here to work around a netlink bug. See:
         // https://github.com/mozilla/libaudit-go/issues/24

--- a/netlink-sys/src/async_socket.rs
+++ b/netlink-sys/src/async_socket.rs
@@ -32,7 +32,7 @@ pub trait AsyncSocket: Sized + Unpin {
     /// Polling wrapper for [`Socket::recv`]
     ///
     /// Passes 0 for flags, and ignores the returned length (the buffer will have advanced by the amount read).
-    fn poll_recv<B>(&mut self, cx: &mut Context<'_>, buf: &mut B) -> Poll<io::Result<()>>
+    fn poll_recv<B>(&mut self, cx: &mut Context<'_>, buf: &mut B, flags: i32) -> Poll<io::Result<usize>>
     where
         B: bytes::BufMut;
 
@@ -43,7 +43,8 @@ pub trait AsyncSocket: Sized + Unpin {
         &mut self,
         cx: &mut Context<'_>,
         buf: &mut B,
-    ) -> Poll<io::Result<SocketAddr>>
+        flags: i32
+    ) -> Poll<io::Result<(usize, SocketAddr)>>
     where
         B: bytes::BufMut;
 

--- a/netlink-sys/src/smol.rs
+++ b/netlink-sys/src/smol.rs
@@ -92,25 +92,26 @@ impl AsyncSocket for SmolSocket {
         self.poll_write_with(cx, |this| this.0.get_mut().send_to(buf, addr, 0))
     }
 
-    fn poll_recv<B>(&mut self, cx: &mut Context<'_>, buf: &mut B) -> Poll<io::Result<()>>
+    fn poll_recv<B>(&mut self, cx: &mut Context<'_>, buf: &mut B, flags: i32) -> Poll<io::Result<usize>>
     where
         B: bytes::BufMut,
     {
-        self.poll_read_with(cx, |this| this.0.get_mut().recv(buf, 0).map(|_len| ()))
+        self.poll_read_with(cx, |this| this.0.get_mut().recv(buf, flags).map(|len| len))
     }
 
     fn poll_recv_from<B>(
         &mut self,
         cx: &mut Context<'_>,
         buf: &mut B,
-    ) -> Poll<io::Result<SocketAddr>>
+        flags: i32
+    ) -> Poll<io::Result<(usize, SocketAddr)>>
     where
         B: bytes::BufMut,
     {
         self.poll_read_with(cx, |this| {
-            let x = this.0.get_mut().recv_from(buf, 0);
+            let x = this.0.get_mut().recv_from(buf, flags);
             trace!("poll_recv_from: {:?}", x);
-            x.map(|(_len, addr)| addr)
+            x.map(|(len, addr)| (len, addr))
         })
     }
 


### PR DESCRIPTION
Pass flags to recv() and recv_from(), give back the received bytes as result.

Thats enables passing MSG_PEEK | MSG_TRUNC to determine the number of  bytes in the socket first, before allocating a buffer and receiving the data.