### PR TITLE
Add support of mptcp path manager interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,3 +95,9 @@ jobs:
         run: |
           cd ethtool
           cargo test
+
+      - name: test (mptcp-pm)
+        env:
+          # Needed root permission to modify MPTCP
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "sudo -E"
+        run: cargo test -p mptcp-pm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "genetlink",
     "rtnetlink",
     "audit",
+    "mptcp-pm",
 ]
 
 # omit fuzz projects
@@ -35,6 +36,7 @@ default-members = [
     "genetlink",
     "rtnetlink",
     "audit",
+    "mptcp-pm",
 ]
 
 [patch.crates-io]
@@ -50,3 +52,4 @@ genetlink = { path = "genetlink" }
 rtnetlink = { path = "rtnetlink" }
 audit = { path = "audit" }
 ethtool = { path = "ethtool" }
+mptcp-pm = { path = "mptcp-pm" }

--- a/mptcp-pm/Cargo.toml
+++ b/mptcp-pm/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "mptcp-pm"
+version = "0.1.0"
+authors = ["Gris Ge <fge@redhat.com>"]
+license = "MIT"
+edition = "2018"
+description = "Linux kernel MPTCP path manager netlink Library"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+readme = "../README.md"
+
+[lib]
+name = "mptcp_pm"
+path = "src/lib.rs"
+crate-type = ["lib"]
+
+[features]
+default = ["tokio_socket"]
+tokio_socket = ["netlink-proto/tokio_socket", "tokio"]
+smol_socket = ["netlink-proto/smol_socket", "async-std"]
+
+[dependencies]
+anyhow = "1.0.44"
+async-std = { version = "1.9.0", optional = true}
+byteorder = "1.4.3"
+futures = "0.3.17"
+genetlink = { default-features = false, version = "0.2.1"}
+log = "0.4.14"
+netlink-packet-core = "0.4.0"
+netlink-packet-generic = "0.3.0"
+netlink-packet-utils = "0.5"
+netlink-proto = { default-features = false, version = "0.9.0" }
+netlink-sys = "0.8.0"
+thiserror = "1.0.29"
+tokio = { version = "1.0.1", features = ["rt"], optional = true}
+
+[dev-dependencies]
+tokio = { version = "1.11.0", features = ["macros", "rt", "rt-multi-thread"] }
+env_logger = "0.9.0"

--- a/mptcp-pm/LICENSE-MIT
+++ b/mptcp-pm/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/mptcp-pm/README.md
+++ b/mptcp-pm/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mptcp-pm/examples/dump_mptcp.rs
+++ b/mptcp-pm/examples/dump_mptcp.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(get_addresses());
+}
+
+async fn get_addresses() {
+    let (connection, handle, _) = mptcp_pm::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut address_handle = handle.address().get().execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = address_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(!msgs.is_empty());
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+
+    let mut limits_handle = handle.limits().get().execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = limits_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(!msgs.is_empty());
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/mptcp-pm/src/address/attr.rs
+++ b/mptcp-pm/src/address/attr.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    parsers::{parse_i32, parse_ip, parse_u16, parse_u32, parse_u8},
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+const MPTCP_PM_ADDR_ATTR_FAMILY: u16 = 1;
+const MPTCP_PM_ADDR_ATTR_ID: u16 = 2;
+const MPTCP_PM_ADDR_ATTR_ADDR4: u16 = 3;
+const MPTCP_PM_ADDR_ATTR_ADDR6: u16 = 4;
+const MPTCP_PM_ADDR_ATTR_PORT: u16 = 5;
+const MPTCP_PM_ADDR_ATTR_FLAGS: u16 = 6;
+const MPTCP_PM_ADDR_ATTR_IF_IDX: u16 = 7;
+
+const MPTCP_PM_ADDR_FLAG_SIGNAL: u32 = 1 << 0;
+const MPTCP_PM_ADDR_FLAG_SUBFLOW: u32 = 1 << 1;
+const MPTCP_PM_ADDR_FLAG_BACKUP: u32 = 1 << 2;
+const MPTCP_PM_ADDR_FLAG_FULLMESH: u32 = 1 << 3;
+const MPTCP_PM_ADDR_FLAG_IMPLICIT: u32 = 1 << 4;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum MptcpPathManagerAddressAttrFlag {
+    Signal,
+    Subflow,
+    Backup,
+    Fullmesh,
+    Implicit,
+    Other(u32),
+}
+
+fn u32_to_vec_flags(value: u32) -> Vec<MptcpPathManagerAddressAttrFlag> {
+    let mut ret = Vec::new();
+    let mut found = 0u32;
+    if (value & MPTCP_PM_ADDR_FLAG_SIGNAL) > 0 {
+        found += MPTCP_PM_ADDR_FLAG_SIGNAL;
+        ret.push(MptcpPathManagerAddressAttrFlag::Signal);
+    }
+    if (value & MPTCP_PM_ADDR_FLAG_SUBFLOW) > 0 {
+        found += MPTCP_PM_ADDR_FLAG_SUBFLOW;
+        ret.push(MptcpPathManagerAddressAttrFlag::Subflow);
+    }
+    if (value & MPTCP_PM_ADDR_FLAG_BACKUP) > 0 {
+        found += MPTCP_PM_ADDR_FLAG_BACKUP;
+        ret.push(MptcpPathManagerAddressAttrFlag::Backup);
+    }
+    if (value & MPTCP_PM_ADDR_FLAG_FULLMESH) > 0 {
+        found += MPTCP_PM_ADDR_FLAG_FULLMESH;
+        ret.push(MptcpPathManagerAddressAttrFlag::Fullmesh);
+    }
+    if (value & MPTCP_PM_ADDR_FLAG_IMPLICIT) > 0 {
+        found += MPTCP_PM_ADDR_FLAG_IMPLICIT;
+        ret.push(MptcpPathManagerAddressAttrFlag::Implicit);
+    }
+    if (value - found) > 0 {
+        ret.push(MptcpPathManagerAddressAttrFlag::Other(value - found));
+    }
+    ret
+}
+
+impl From<&MptcpPathManagerAddressAttrFlag> for u32 {
+    fn from(v: &MptcpPathManagerAddressAttrFlag) -> u32 {
+        match v {
+            MptcpPathManagerAddressAttrFlag::Signal => MPTCP_PM_ADDR_FLAG_SIGNAL,
+            MptcpPathManagerAddressAttrFlag::Subflow => MPTCP_PM_ADDR_FLAG_SUBFLOW,
+            MptcpPathManagerAddressAttrFlag::Backup => MPTCP_PM_ADDR_FLAG_BACKUP,
+            MptcpPathManagerAddressAttrFlag::Fullmesh => MPTCP_PM_ADDR_FLAG_FULLMESH,
+            MptcpPathManagerAddressAttrFlag::Implicit => MPTCP_PM_ADDR_FLAG_IMPLICIT,
+            MptcpPathManagerAddressAttrFlag::Other(d) => *d,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum MptcpPathManagerAddressAttr {
+    Family(u16),
+    Id(u8),
+    Addr4(Ipv4Addr),
+    Addr6(Ipv6Addr),
+    Port(u16),
+    Flags(Vec<MptcpPathManagerAddressAttrFlag>),
+    IfIndex(i32),
+    Other(DefaultNla),
+}
+
+impl Nla for MptcpPathManagerAddressAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Family(_) | Self::Port(_) => 2,
+            Self::Addr4(_) | Self::Flags(_) | Self::IfIndex(_) => 4,
+            Self::Id(_) => 1,
+            Self::Addr6(_) => 16,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Family(_) => MPTCP_PM_ADDR_ATTR_FAMILY,
+            Self::Id(_) => MPTCP_PM_ADDR_ATTR_ID,
+            Self::Addr4(_) => MPTCP_PM_ADDR_ATTR_ADDR4,
+            Self::Addr6(_) => MPTCP_PM_ADDR_ATTR_ADDR6,
+            Self::Port(_) => MPTCP_PM_ADDR_ATTR_PORT,
+            Self::Flags(_) => MPTCP_PM_ADDR_ATTR_FLAGS,
+            Self::IfIndex(_) => MPTCP_PM_ADDR_ATTR_IF_IDX,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Family(d) | Self::Port(d) => NativeEndian::write_u16(buffer, *d),
+            Self::Addr4(i) => buffer.copy_from_slice(&i.octets()),
+            Self::Addr6(i) => buffer.copy_from_slice(&i.octets()),
+            Self::Id(d) => buffer[0] = *d,
+            Self::Flags(flags) => {
+                let mut value = 0u32;
+                for flag in flags {
+                    value += u32::from(flag);
+                }
+                NativeEndian::write_u32(buffer, value)
+            }
+            Self::IfIndex(d) => NativeEndian::write_i32(buffer, *d),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for MptcpPathManagerAddressAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            MPTCP_PM_ADDR_ATTR_FAMILY => {
+                let err_msg = format!("Invalid MPTCP_PM_ADDR_ATTR_FAMILY value {:?}", payload);
+                Self::Family(parse_u16(payload).context(err_msg)?)
+            }
+            MPTCP_PM_ADDR_ATTR_ID => {
+                Self::Id(parse_u8(payload).context("Invalid MPTCP_PM_ADDR_ATTR_ID value")?)
+            }
+            MPTCP_PM_ADDR_ATTR_ADDR4 | MPTCP_PM_ADDR_ATTR_ADDR6 => {
+                match parse_ip(payload)
+                    .context("Invalid MPTCP_PM_ADDR_ATTR_ADDR4/MPTCP_PM_ADDR_ATTR_ADDR6 value")?
+                {
+                    IpAddr::V4(i) => Self::Addr4(i),
+                    IpAddr::V6(i) => Self::Addr6(i),
+                }
+            }
+            MPTCP_PM_ADDR_ATTR_PORT => {
+                Self::Port(parse_u16(payload).context("Invalid MPTCP_PM_ADDR_ATTR_PORT value")?)
+            }
+            MPTCP_PM_ADDR_ATTR_FLAGS => Self::Flags(u32_to_vec_flags(
+                parse_u32(payload).context("Invalid MPTCP_PM_ADDR_ATTR_FLAGS value")?,
+            )),
+            MPTCP_PM_ADDR_ATTR_IF_IDX => Self::IfIndex(
+                parse_i32(payload).context("Invalid MPTCP_PM_ADDR_ATTR_IF_IDX value")?,
+            ),
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}

--- a/mptcp-pm/src/address/get.rs
+++ b/mptcp-pm/src/address/get.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    mptcp_execute,
+    MptcpPathManagerError,
+    MptcpPathManagerHandle,
+    MptcpPathManagerMessage,
+};
+
+pub struct MptcpPathManagerAddressGetRequest {
+    handle: MptcpPathManagerHandle,
+}
+
+impl MptcpPathManagerAddressGetRequest {
+    pub(crate) fn new(handle: MptcpPathManagerHandle) -> Self {
+        MptcpPathManagerAddressGetRequest { handle }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<MptcpPathManagerMessage>, Error = MptcpPathManagerError>
+    {
+        let MptcpPathManagerAddressGetRequest { mut handle } = self;
+
+        let mptcp_msg = MptcpPathManagerMessage::new_address_get();
+        mptcp_execute(&mut handle, mptcp_msg).await
+    }
+}

--- a/mptcp-pm/src/address/handle.rs
+++ b/mptcp-pm/src/address/handle.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{MptcpPathManagerAddressGetRequest, MptcpPathManagerHandle};
+
+pub struct MptcpPathManagerAddressHandle(MptcpPathManagerHandle);
+
+impl MptcpPathManagerAddressHandle {
+    pub fn new(handle: MptcpPathManagerHandle) -> Self {
+        MptcpPathManagerAddressHandle(handle)
+    }
+
+    /// Retrieve the multipath-TCP  addresses
+    /// (equivalent to `ip mptcp endpoint show`)
+    pub fn get(&mut self) -> MptcpPathManagerAddressGetRequest {
+        MptcpPathManagerAddressGetRequest::new(self.0.clone())
+    }
+}

--- a/mptcp-pm/src/address/mod.rs
+++ b/mptcp-pm/src/address/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::{MptcpPathManagerAddressAttr, MptcpPathManagerAddressAttrFlag};
+pub use get::MptcpPathManagerAddressGetRequest;
+pub use handle::MptcpPathManagerAddressHandle;

--- a/mptcp-pm/src/connection.rs
+++ b/mptcp-pm/src/connection.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+use std::io;
+
+use futures::channel::mpsc::UnboundedReceiver;
+use genetlink::message::RawGenlMessage;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::Connection;
+use netlink_sys::{AsyncSocket, SocketAddr};
+
+use crate::MptcpPathManagerHandle;
+
+#[cfg(feature = "tokio_socket")]
+#[allow(clippy::type_complexity)]
+pub fn new_connection() -> io::Result<(
+    Connection<RawGenlMessage>,
+    MptcpPathManagerHandle,
+    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+)> {
+    new_connection_with_socket()
+}
+
+#[allow(clippy::type_complexity)]
+pub fn new_connection_with_socket<S>() -> io::Result<(
+    Connection<RawGenlMessage, S>,
+    MptcpPathManagerHandle,
+    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+)>
+where
+    S: AsyncSocket,
+{
+    let (conn, handle, messages) = genetlink::new_connection_with_socket()?;
+    Ok((conn, MptcpPathManagerHandle::new(handle), messages))
+}

--- a/mptcp-pm/src/error.rs
+++ b/mptcp-pm/src/error.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+use thiserror::Error;
+
+use netlink_packet_core::{ErrorMessage, NetlinkMessage};
+use netlink_packet_generic::GenlMessage;
+
+use crate::MptcpPathManagerMessage;
+
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum MptcpPathManagerError {
+    #[error("Received an unexpected message {0:?}")]
+    UnexpectedMessage(NetlinkMessage<GenlMessage<MptcpPathManagerMessage>>),
+
+    #[error("Received a netlink error message {0}")]
+    NetlinkError(ErrorMessage),
+
+    #[error("A netlink request failed")]
+    RequestFailed(String),
+
+    #[error("A bug in this crate")]
+    Bug(String),
+}

--- a/mptcp-pm/src/handle.rs
+++ b/mptcp-pm/src/handle.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+use futures::{future::Either, FutureExt, Stream, StreamExt, TryStream};
+use genetlink::GenetlinkHandle;
+use netlink_packet_core::{NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+use netlink_packet_utils::DecodeError;
+
+use crate::{
+    try_mptcp,
+    MptcpPathManagerAddressHandle,
+    MptcpPathManagerCmd,
+    MptcpPathManagerError,
+    MptcpPathManagerLimitsHandle,
+    MptcpPathManagerMessage,
+};
+
+#[derive(Clone, Debug)]
+pub struct MptcpPathManagerHandle {
+    pub handle: GenetlinkHandle,
+}
+
+impl MptcpPathManagerHandle {
+    pub(crate) fn new(handle: GenetlinkHandle) -> Self {
+        MptcpPathManagerHandle { handle }
+    }
+
+    // equivalent to `ip mptcp endpoint` command
+    // Instead of using `endpoint`, we are aligning with kernel netlink name
+    // `address` here.
+    pub fn address(&self) -> MptcpPathManagerAddressHandle {
+        MptcpPathManagerAddressHandle::new(self.clone())
+    }
+
+    // equivalent to `ip mptcp limits` command
+    pub fn limits(&self) -> MptcpPathManagerLimitsHandle {
+        MptcpPathManagerLimitsHandle::new(self.clone())
+    }
+
+    pub async fn request(
+        &mut self,
+        message: NetlinkMessage<GenlMessage<MptcpPathManagerMessage>>,
+    ) -> Result<
+        impl Stream<Item = Result<NetlinkMessage<GenlMessage<MptcpPathManagerMessage>>, DecodeError>>,
+        MptcpPathManagerError,
+    > {
+        self.handle.request(message).await.map_err(|e| {
+            MptcpPathManagerError::RequestFailed(format!("BUG: Request failed with {}", e))
+        })
+    }
+}
+
+pub(crate) async fn mptcp_execute(
+    handle: &mut MptcpPathManagerHandle,
+    mptcp_msg: MptcpPathManagerMessage,
+) -> impl TryStream<Ok = GenlMessage<MptcpPathManagerMessage>, Error = MptcpPathManagerError> {
+    let nl_header_flags = match mptcp_msg.cmd {
+        MptcpPathManagerCmd::AddressGet => NLM_F_REQUEST | NLM_F_DUMP,
+        MptcpPathManagerCmd::LimitsGet => NLM_F_REQUEST,
+    };
+
+    let mut nl_msg = NetlinkMessage::from(GenlMessage::from_payload(mptcp_msg));
+
+    nl_msg.header.flags = nl_header_flags;
+
+    match handle.request(nl_msg).await {
+        Ok(response) => Either::Left(response.map(move |msg| Ok(try_mptcp!(msg)))),
+        Err(e) => Either::Right(
+            futures::future::err::<GenlMessage<MptcpPathManagerMessage>, MptcpPathManagerError>(e)
+                .into_stream(),
+        ),
+    }
+}

--- a/mptcp-pm/src/lib.rs
+++ b/mptcp-pm/src/lib.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+mod address;
+mod connection;
+mod error;
+mod handle;
+mod limits;
+mod macros;
+mod message;
+
+pub use address::{
+    MptcpPathManagerAddressAttr,
+    MptcpPathManagerAddressAttrFlag,
+    MptcpPathManagerAddressGetRequest,
+    MptcpPathManagerAddressHandle,
+};
+#[cfg(feature = "tokio_socket")]
+pub use connection::new_connection;
+pub use connection::new_connection_with_socket;
+pub use error::MptcpPathManagerError;
+pub use handle::MptcpPathManagerHandle;
+pub use limits::{
+    MptcpPathManagerLimitsAttr,
+    MptcpPathManagerLimitsGetRequest,
+    MptcpPathManagerLimitsHandle,
+};
+pub use message::{MptcpPathManagerAttr, MptcpPathManagerCmd, MptcpPathManagerMessage};
+
+pub(crate) use handle::mptcp_execute;

--- a/mptcp-pm/src/limits/attr.rs
+++ b/mptcp-pm/src/limits/attr.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    parsers::parse_u32,
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+const MPTCP_PM_ATTR_RCV_ADD_ADDRS: u16 = 2;
+const MPTCP_PM_ATTR_SUBFLOWS: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum MptcpPathManagerLimitsAttr {
+    RcvAddAddrs(u32),
+    Subflows(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for MptcpPathManagerLimitsAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Other(attr) => attr.value_len(),
+            _ => 4,
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::RcvAddAddrs(_) => MPTCP_PM_ATTR_RCV_ADD_ADDRS,
+            Self::Subflows(_) => MPTCP_PM_ATTR_SUBFLOWS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::RcvAddAddrs(d) | Self::Subflows(d) => NativeEndian::write_u32(buffer, *d),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for MptcpPathManagerLimitsAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            MPTCP_PM_ATTR_RCV_ADD_ADDRS => Self::RcvAddAddrs(
+                parse_u32(payload).context("Invalid MPTCP_PM_ATTR_RCV_ADD_ADDRS value")?,
+            ),
+            MPTCP_PM_ATTR_SUBFLOWS => {
+                Self::Subflows(parse_u32(payload).context("Invalid MPTCP_PM_ATTR_SUBFLOWS value")?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}

--- a/mptcp-pm/src/limits/get.rs
+++ b/mptcp-pm/src/limits/get.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    mptcp_execute,
+    MptcpPathManagerError,
+    MptcpPathManagerHandle,
+    MptcpPathManagerMessage,
+};
+
+pub struct MptcpPathManagerLimitsGetRequest {
+    handle: MptcpPathManagerHandle,
+}
+
+impl MptcpPathManagerLimitsGetRequest {
+    pub(crate) fn new(handle: MptcpPathManagerHandle) -> Self {
+        MptcpPathManagerLimitsGetRequest { handle }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<MptcpPathManagerMessage>, Error = MptcpPathManagerError>
+    {
+        let MptcpPathManagerLimitsGetRequest { mut handle } = self;
+
+        let mptcp_msg = MptcpPathManagerMessage::new_limits_get();
+        mptcp_execute(&mut handle, mptcp_msg).await
+    }
+}

--- a/mptcp-pm/src/limits/handle.rs
+++ b/mptcp-pm/src/limits/handle.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{MptcpPathManagerHandle, MptcpPathManagerLimitsGetRequest};
+
+pub struct MptcpPathManagerLimitsHandle(MptcpPathManagerHandle);
+
+impl MptcpPathManagerLimitsHandle {
+    pub fn new(handle: MptcpPathManagerHandle) -> Self {
+        MptcpPathManagerLimitsHandle(handle)
+    }
+
+    /// Retrieve the multipath-TCP  addresses
+    /// (equivalent to `ip mptcp endpoint show`)
+    pub fn get(&mut self) -> MptcpPathManagerLimitsGetRequest {
+        MptcpPathManagerLimitsGetRequest::new(self.0.clone())
+    }
+}

--- a/mptcp-pm/src/limits/mod.rs
+++ b/mptcp-pm/src/limits/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::MptcpPathManagerLimitsAttr;
+pub use get::MptcpPathManagerLimitsGetRequest;
+pub use handle::MptcpPathManagerLimitsHandle;

--- a/mptcp-pm/src/macros.rs
+++ b/mptcp-pm/src/macros.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+#[macro_export]
+macro_rules! try_mptcp {
+    ($msg: expr) => {{
+        use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+        use $crate::MptcpPathManagerError;
+
+        match $msg {
+            Ok(msg) => {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    NetlinkPayload::InnerMessage(msg) => msg,
+                    NetlinkPayload::Error(err) => {
+                        return Err(MptcpPathManagerError::NetlinkError(err))
+                    }
+                    _ => {
+                        return Err(MptcpPathManagerError::UnexpectedMessage(
+                            NetlinkMessage::new(header, payload),
+                        ))
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(MptcpPathManagerError::Bug(format!(
+                    "BUG: decode error {:?}",
+                    e
+                )))
+            }
+        }
+    }};
+}

--- a/mptcp-pm/src/message.rs
+++ b/mptcp-pm/src/message.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use netlink_packet_core::DecodeError;
+use netlink_packet_generic::{GenlFamily, GenlHeader};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlasIterator},
+    Emitable,
+    Parseable,
+    ParseableParametrized,
+};
+
+use crate::{address::MptcpPathManagerAddressAttr, limits::MptcpPathManagerLimitsAttr};
+
+const MPTCP_PM_CMD_GET_ADDR: u8 = 3;
+const MPTCP_PM_CMD_GET_LIMITS: u8 = 6;
+
+const MPTCP_PM_ATTR_ADDR: u16 = 1;
+const MPTCP_PM_ATTR_RCV_ADD_ADDRS: u16 = 2;
+const MPTCP_PM_ATTR_SUBFLOWS: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum MptcpPathManagerCmd {
+    AddressGet,
+    LimitsGet,
+}
+
+impl From<MptcpPathManagerCmd> for u8 {
+    fn from(cmd: MptcpPathManagerCmd) -> Self {
+        match cmd {
+            MptcpPathManagerCmd::AddressGet => MPTCP_PM_CMD_GET_ADDR,
+            MptcpPathManagerCmd::LimitsGet => MPTCP_PM_CMD_GET_LIMITS,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum MptcpPathManagerAttr {
+    Address(MptcpPathManagerAddressAttr),
+    Limits(MptcpPathManagerLimitsAttr),
+    Other(DefaultNla),
+}
+
+impl Nla for MptcpPathManagerAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Address(attr) => attr.value_len(),
+            Self::Limits(attr) => attr.value_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Address(attr) => attr.kind(),
+            Self::Limits(attr) => attr.kind(),
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Address(attr) => attr.emit_value(buffer),
+            Self::Limits(attr) => attr.emit_value(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MptcpPathManagerMessage {
+    pub cmd: MptcpPathManagerCmd,
+    pub nlas: Vec<MptcpPathManagerAttr>,
+}
+
+impl GenlFamily for MptcpPathManagerMessage {
+    fn family_name() -> &'static str {
+        "mptcp_pm"
+    }
+
+    fn version(&self) -> u8 {
+        1
+    }
+
+    fn command(&self) -> u8 {
+        self.cmd.into()
+    }
+}
+
+impl MptcpPathManagerMessage {
+    pub fn new_address_get() -> Self {
+        MptcpPathManagerMessage {
+            cmd: MptcpPathManagerCmd::AddressGet,
+            nlas: vec![],
+        }
+    }
+
+    pub fn new_limits_get() -> Self {
+        MptcpPathManagerMessage {
+            cmd: MptcpPathManagerCmd::LimitsGet,
+            nlas: vec![],
+        }
+    }
+}
+
+impl Emitable for MptcpPathManagerMessage {
+    fn buffer_len(&self) -> usize {
+        self.nlas.as_slice().buffer_len()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.nlas.as_slice().emit(buffer)
+    }
+}
+
+fn parse_nlas(buffer: &[u8]) -> Result<Vec<MptcpPathManagerAttr>, DecodeError> {
+    let mut nlas = Vec::new();
+    for nla in NlasIterator::new(buffer) {
+        let error_msg = format!("Failed to parse mptcp address message attribute {:?}", nla);
+        let nla = &nla.context(error_msg)?;
+        match nla.kind() {
+            MPTCP_PM_ATTR_ADDR => {
+                for addr_nla in NlasIterator::new(nla.value()) {
+                    let error_msg = format!("Failed to parse MPTCP_PM_ATTR_ADDR {:?}", addr_nla);
+                    let addr_nla = &addr_nla.context(error_msg)?;
+
+                    nlas.push(MptcpPathManagerAttr::Address(
+                        MptcpPathManagerAddressAttr::parse(addr_nla)
+                            .context("Failed to parse MPTCP_PM_ATTR_ADDR")?,
+                    ))
+                }
+            }
+            MPTCP_PM_ATTR_RCV_ADD_ADDRS => nlas.push(MptcpPathManagerAttr::Limits(
+                MptcpPathManagerLimitsAttr::parse(nla)
+                    .context("Failed to parse MPTCP_PM_ATTR_RCV_ADD_ADDRS")?,
+            )),
+            MPTCP_PM_ATTR_SUBFLOWS => nlas.push(MptcpPathManagerAttr::Limits(
+                MptcpPathManagerLimitsAttr::parse(nla)
+                    .context("Failed to parse MPTCP_PM_ATTR_RCV_ADD_ADDRS")?,
+            )),
+            _ => nlas.push(MptcpPathManagerAttr::Other(
+                DefaultNla::parse(nla).context("invalid NLA (unknown kind)")?,
+            )),
+        }
+    }
+    Ok(nlas)
+}
+
+impl ParseableParametrized<[u8], GenlHeader> for MptcpPathManagerMessage {
+    fn parse_with_param(buffer: &[u8], header: GenlHeader) -> Result<Self, DecodeError> {
+        Ok(match header.cmd {
+            MPTCP_PM_CMD_GET_ADDR => Self {
+                cmd: MptcpPathManagerCmd::AddressGet,
+                nlas: parse_nlas(buffer)?,
+            },
+            MPTCP_PM_CMD_GET_LIMITS => Self {
+                cmd: MptcpPathManagerCmd::LimitsGet,
+                nlas: parse_nlas(buffer)?,
+            },
+            cmd => {
+                return Err(DecodeError::from(format!(
+                    "Unsupported mptcp reply command: {}",
+                    cmd
+                )))
+            }
+        })
+    }
+}

--- a/mptcp-pm/tests/dump_mptcp.rs
+++ b/mptcp-pm/tests/dump_mptcp.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use std::process::Command;
+
+use mptcp_pm::{MptcpPathManagerAttr, MptcpPathManagerLimitsAttr};
+
+#[test]
+fn test_mptcp_empty_addresses_and_limits() {
+    Command::new("sysctl")
+        .arg("-w")
+        .arg("net.mptcp.enabled=1")
+        .spawn()
+        .unwrap();
+    // OK to fail as Github CI has no ip-mptcp
+    Command::new("ip")
+        .arg("mptcp")
+        .arg("endpoint")
+        .arg("flush")
+        .spawn()
+        .ok();
+    // OK to fail as Github CI has no ip-mptcp
+    Command::new("ip")
+        .arg("mptcp")
+        .arg("limits")
+        .arg("set")
+        .arg("subflows")
+        .arg("0")
+        .arg("add_addr_accepted")
+        .arg("0")
+        .spawn()
+        .ok();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(assert_empty_addresses_and_limits());
+}
+
+async fn assert_empty_addresses_and_limits() {
+    let (connection, handle, _) = mptcp_pm::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut address_handle = handle.address().get().execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = address_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.is_empty());
+    let mut limits_handle = handle.limits().get().execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = limits_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert_eq!(msgs.len(), 1);
+    let mptcp_nlas = &msgs[0].payload.nlas;
+    assert_eq!(
+        mptcp_nlas[0],
+        MptcpPathManagerAttr::Limits(MptcpPathManagerLimitsAttr::RcvAddAddrs(0))
+    );
+    assert_eq!(
+        mptcp_nlas[1],
+        MptcpPathManagerAttr::Limits(MptcpPathManagerLimitsAttr::Subflows(0))
+    );
+}


### PR DESCRIPTION
Provide functions mimicing:
 * `ip mptcp endpoint show`
 * `ip mptcp limits show`

Example been manually tested on CentOS stream 9 after command:

```bash
sudo ip mptcp  limits set subflow 1 add_addr_accepted 1
sudo ip netns exec mptcp ip mptcp endpoint add 198.51.100.1 \
    dev eth1 signal
```