### PR TITLE
Optimize codec implementations

### DIFF
--- a/netlink-packet-audit/src/codec.rs
+++ b/netlink-packet-audit/src/codec.rs
@@ -37,9 +37,8 @@ impl NetlinkMessageCodec for NetlinkAuditCodec {
 
         loop {
             // If there's nothing to read, return Ok(None)
-            if src.as_ref().is_empty() {
+            if src.is_empty() {
                 trace!("buffer is empty");
-                src.clear();
                 return Ok(None);
             }
 

--- a/netlink-proto/src/codecs.rs
+++ b/netlink-proto/src/codecs.rs
@@ -55,9 +55,8 @@ impl NetlinkMessageCodec for NetlinkCodec {
 
         loop {
             // If there's nothing to read, return Ok(None)
-            if src.as_ref().is_empty() {
+            if src.is_empty() {
                 trace!("buffer is empty");
-                src.clear();
                 return Ok(None);
             }
 


### PR DESCRIPTION
#141 mentions "have `NetlinkFramed` return a `Result` instead of an `Option`" as "todo item", and for that I had a look at the codec implementations again. It turns out `decode` actually never returns an error - and if it did, it probably should return a `DecodeError` instead of an `io::Error`.

Anyway, I tried to clean up the code a little bit so that adding proper error handling should be easier in the future.

As usual I recommend reviewing my commits individually - I split them for that purpose :)