### PR TITLE
Rename metadata to response_tx, remove Metadata generic

### DIFF
--- a/netlink-proto/src/connection.rs
+++ b/netlink-proto/src/connection.rs
@@ -45,7 +45,7 @@ where
 {
     socket: NetlinkFramed<T, S, C>,
 
-    protocol: Protocol<T, UnboundedSender<NetlinkMessage<T>>>,
+    protocol: Protocol<T>,
 
     /// Channel used by the user to pass requests to the connection.
     requests_rx: Option<UnboundedReceiver<Request<T>>>,
@@ -217,14 +217,14 @@ where
             let Response {
                 message,
                 done,
-                metadata: tx,
+                response_tx: tx,
             } = response;
             if done {
                 use NetlinkPayload::*;
                 match &message.payload {
                     // Since `self.protocol` set the `done` flag here,
                     // we know it has already dropped the request and
-                    // its associated metadata, ie the UnboundedSender
+                    // its associated response_tx, the UnboundedSender
                     // used to forward messages back to the
                     // ConnectionHandle. By just continuing we're
                     // dropping the last instance of that sender,

--- a/netlink-proto/src/handle.rs
+++ b/netlink-proto/src/handle.rs
@@ -37,8 +37,12 @@ where
         message: NetlinkMessage<T>,
         destination: SocketAddr,
     ) -> Result<impl Stream<Item = NetlinkMessage<T>>, Error<T>> {
-        let (tx, rx) = unbounded::<NetlinkMessage<T>>();
-        let request = Request::from((message, destination, tx));
+        let (response_tx, rx) = unbounded::<NetlinkMessage<T>>();
+        let request = Request {
+            response_tx,
+            message,
+            destination,
+        };
         debug!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request).map_err(|e| {
             // the channel is unbounded, so it can't be full. If this
@@ -59,8 +63,12 @@ where
         message: NetlinkMessage<T>,
         destination: SocketAddr,
     ) -> Result<(), Error<T>> {
-        let (tx, _rx) = unbounded::<NetlinkMessage<T>>();
-        let request = Request::from((message, destination, tx));
+        let (response_tx, _rx) = unbounded::<NetlinkMessage<T>>();
+        let request = Request {
+            response_tx,
+            message,
+            destination,
+        };
         debug!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request)
             .map_err(|_| Error::ConnectionClosed)

--- a/netlink-proto/src/lib.rs
+++ b/netlink-proto/src/lib.rs
@@ -175,9 +175,7 @@ mod framed;
 pub use crate::framed::*;
 
 mod protocol;
-pub(crate) use self::protocol::{Protocol, Response};
-pub(crate) type Request<T> =
-    self::protocol::Request<T, UnboundedSender<crate::packet::NetlinkMessage<T>>>;
+pub(crate) use self::protocol::{Protocol, Request, Response};
 
 mod connection;
 pub use crate::connection::*;
@@ -188,7 +186,7 @@ pub use crate::errors::*;
 mod handle;
 pub use crate::handle::*;
 
-use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use std::{fmt::Debug, io};
 
 pub use netlink_packet_core as packet;

--- a/netlink-proto/src/protocol/request.rs
+++ b/netlink-proto/src/protocol/request.rs
@@ -2,37 +2,36 @@
 
 use std::fmt::Debug;
 
+use futures::channel::mpsc::UnboundedSender;
 use netlink_packet_core::NetlinkMessage;
 
 use crate::sys::SocketAddr;
 
 #[derive(Debug)]
-pub(crate) struct Request<T, M> {
-    pub metadata: M,
+pub(crate) struct Request<T> {
+    pub response_tx: UnboundedSender<NetlinkMessage<T>>,
     pub message: NetlinkMessage<T>,
     pub destination: SocketAddr,
 }
 
-impl<T, M> From<(NetlinkMessage<T>, SocketAddr, M)> for Request<T, M>
+impl<T> From<(NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>)> for Request<T>
 where
     T: Debug,
-    M: Debug,
 {
-    fn from(parts: (NetlinkMessage<T>, SocketAddr, M)) -> Self {
+    fn from(parts: (NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>)) -> Self {
         Request {
             message: parts.0,
             destination: parts.1,
-            metadata: parts.2,
+            response_tx: parts.2,
         }
     }
 }
 
-impl<T, M> From<Request<T, M>> for (NetlinkMessage<T>, SocketAddr, M)
+impl<T> From<Request<T>> for (NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>)
 where
     T: Debug,
-    M: Debug,
 {
-    fn from(req: Request<T, M>) -> (NetlinkMessage<T>, SocketAddr, M) {
-        (req.message, req.destination, req.metadata)
+    fn from(req: Request<T>) -> (NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>) {
+        (req.message, req.destination, req.response_tx)
     }
 }

--- a/netlink-proto/src/protocol/request.rs
+++ b/netlink-proto/src/protocol/request.rs
@@ -13,25 +13,3 @@ pub(crate) struct Request<T> {
     pub message: NetlinkMessage<T>,
     pub destination: SocketAddr,
 }
-
-impl<T> From<(NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>)> for Request<T>
-where
-    T: Debug,
-{
-    fn from(parts: (NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>)) -> Self {
-        Request {
-            message: parts.0,
-            destination: parts.1,
-            response_tx: parts.2,
-        }
-    }
-}
-
-impl<T> From<Request<T>> for (NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>)
-where
-    T: Debug,
-{
-    fn from(req: Request<T>) -> (NetlinkMessage<T>, SocketAddr, UnboundedSender<NetlinkMessage<T>>) {
-        (req.message, req.destination, req.response_tx)
-    }
-}


### PR DESCRIPTION
Motivation for this: I'd like to give #138 a shot (before moving #170 forward).

The `metadata` field makes changes in that area rather unreadable, so I'd like to clean this up in a separate step.