### PR TITLE
Improve internal sub-crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,3 @@ default-members = [
     "audit",
     "mptcp-pm",
 ]
-
-[patch.crates-io]
-netlink-sys = { path = "netlink-sys" }
-netlink-packet-core = { path = "netlink-packet-core" }
-netlink-packet-utils = { path = "netlink-packet-utils" }
-netlink-packet-generic = { path = "netlink-packet-generic" }
-netlink-packet-route = { path = "netlink-packet-route" }
-netlink-packet-audit = { path = "netlink-packet-audit" }
-netlink-packet-sock-diag = { path = "netlink-packet-sock-diag" }
-netlink-proto = { path = "netlink-proto" }
-genetlink = { path = "genetlink" }
-rtnetlink = { path = "rtnetlink" }
-audit = { path = "audit" }
-ethtool = { path = "ethtool" }
-mptcp-pm = { path = "mptcp-pm" }

--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -14,8 +14,8 @@ description = "linux audit via netlink"
 [dependencies]
 futures = "0.3.11"
 thiserror = "1"
-netlink-packet-audit = "0.4"
-netlink-proto = { default-features = false, version = "0.9" }
+netlink-packet-audit = { version = "0.4.0", path = "../netlink-packet-audit" }
+netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
 
 [features]
 default = ["tokio_socket"]

--- a/ethtool/Cargo.toml
+++ b/ethtool/Cargo.toml
@@ -24,13 +24,13 @@ anyhow = "1.0.44"
 async-std = { version = "1.9.0", optional = true}
 byteorder = "1.4.3"
 futures = "0.3.17"
-genetlink = { default-features = false, version = "0.2.1"}
 log = "0.4.14"
-netlink-packet-core = "0.4.0"
-netlink-packet-generic = "0.3.0"
-netlink-packet-utils = "0.5"
-netlink-proto = { default-features = false, version = "0.9.0" }
-netlink-sys = "0.8.0"
+genetlink = { default-features = false, version = "0.2.1", path = "../genetlink" }
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
+netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
+netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
 thiserror = "1.0.29"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 

--- a/genetlink/Cargo.toml
+++ b/genetlink/Cargo.toml
@@ -17,12 +17,12 @@ smol_socket = ["netlink-proto/smol_socket","async-std"]
 
 [dependencies]
 futures = "0.3.16"
-netlink-packet-generic = "0.3.0"
-netlink-proto = { default-features = false, version = "0.9.0" }
+netlink-proto = { default-features = false, version = "0.9.0" , path = "../netlink-proto" }
+netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 tokio = { version = "1.9.0", features = ["rt"], optional = true }
 async-std = { version = "1.9.0", optional = true }
-netlink-packet-utils = "0.5.0"
-netlink-packet-core = "0.4.0"
 thiserror = "1.0.26"
 
 [dev-dependencies]

--- a/mptcp-pm/Cargo.toml
+++ b/mptcp-pm/Cargo.toml
@@ -24,15 +24,15 @@ anyhow = "1.0.44"
 async-std = { version = "1.9.0", optional = true}
 byteorder = "1.4.3"
 futures = "0.3.17"
-genetlink = { default-features = false, version = "0.2.1"}
 log = "0.4.14"
-netlink-packet-core = "0.4.0"
-netlink-packet-generic = "0.3.0"
-netlink-packet-utils = "0.5"
-netlink-proto = { default-features = false, version = "0.9.0" }
-netlink-sys = "0.8.0"
 thiserror = "1.0.29"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
+genetlink = { default-features = false, version = "0.2.1", path = "../genetlink" }
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
+netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
+netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/netlink-packet-audit/Cargo.toml
+++ b/netlink-packet-audit/Cargo.toml
@@ -16,9 +16,9 @@ anyhow = "1.0.31"
 bytes = "1.0"
 byteorder = "1.3.2"
 log = "0.4.8"
-netlink-packet-core = "0.4"
-netlink-packet-utils = "0.5"
-netlink-proto = { default-features = false, version = "0.9" }
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
+netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/netlink-packet-audit/fuzz/Cargo.toml
+++ b/netlink-packet-audit/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-audit = "0.3"
-netlink-packet-core = "0.3"
+netlink-packet-audit = { version = "0.4", path = "../../netlink-packet-audit" }
+netlink-packet-core = { version = "0.4.2", path = "../../netlink-packet-core" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -15,7 +15,7 @@ description = "netlink packet types"
 anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
-netlink-packet-utils = "0.5"
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
-netlink-packet-route = "0.11"
+netlink-packet-route = { version = "0.11.0", path = "../netlink-packet-route" }

--- a/netlink-packet-generic/Cargo.toml
+++ b/netlink-packet-generic/Cargo.toml
@@ -14,8 +14,8 @@ description = "generic netlink packet types"
 anyhow = "1.0.39"
 libc = "0.2.86"
 byteorder = "1.4.2"
-netlink-packet-core = "0.4"
-netlink-packet-utils = "0.5"
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
-netlink-sys = { path = "../netlink-sys", version = "0.8" }
+netlink-sys = { path = "../netlink-sys", version = "0.8.2" }

--- a/netlink-packet-netfilter/Cargo.toml
+++ b/netlink-packet-netfilter/Cargo.toml
@@ -14,11 +14,11 @@ description = "netlink packet types for the netfilter subprotocol"
 [dependencies]
 anyhow = "1.0.32"
 byteorder = "1.3.4"
-netlink-packet-core = "0.4"
-netlink-packet-utils = "0.5"
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 bitflags = "1.2.1"
 libc = "0.2.77"
 derive_more = "0.99.16"
 
 [dev-dependencies]
-netlink-sys = "0.8"
+netlink-sys = { version = "0.8.2", path = "../netlink-sys" }

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -18,8 +18,8 @@ rich_nlas = []
 anyhow = "1.0.31"
 byteorder = "1.3.2"
 libc = "0.2.66"
-netlink-packet-core = "0.4"
-netlink-packet-utils = "0.5"
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 bitflags = "1.2.1"
 
 [[example]]
@@ -29,7 +29,7 @@ name = "dump_packet_links"
 criterion = "0.3.0"
 pcap-file = "1.1.1"
 lazy_static = "1.4.0"
-netlink-sys = "0.8"
+netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
 pretty_assertions = "0.7.2"
 
 [[bench]]

--- a/netlink-packet-route/fuzz/Cargo.toml
+++ b/netlink-packet-route/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-route = { path = "../" }
+netlink-packet-route = { path = "../", version = "0.11.0" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -17,12 +17,12 @@ rich_nlas = []
 [dependencies]
 anyhow = "1.0.32"
 byteorder = "1.3.4"
-netlink-packet-core = "0.4"
-netlink-packet-utils = "0.5"
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 bitflags = "1.2.1"
 libc = "0.2.77"
 smallvec = "1.4.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-netlink-sys = "0.8"
+netlink-sys = { version = "0.8.2", path = "../netlink-sys" }

--- a/netlink-packet-wireguard/Cargo.toml
+++ b/netlink-packet-wireguard/Cargo.toml
@@ -15,14 +15,14 @@ anyhow = "1.0.42"
 byteorder = "1.4.3"
 libc = "0.2.98"
 log = "0.4.14"
-netlink-packet-generic = "0.3.0"
-netlink-packet-utils = "0.5.0"
+netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
 base64 = "0.13.0"
 env_logger = "0.9.0"
 futures = "0.3.16"
-netlink-packet-core = "0.4.0"
-netlink-proto = "0.9.0"
-genetlink = "0.2.1"
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-proto = { version = "0.9.2", path = "../netlink-proto" }
+genetlink = { version = "0.2.1", path = "../genetlink" }
 tokio = { version = "1.9.0", features = ["macros", "rt-multi-thread"] }

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -16,8 +16,8 @@ bytes = "1.0"
 log = "0.4.8"
 futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util"] }
-netlink-packet-core = "0.4"
-netlink-sys = { default-features = false, version = "0.8" }
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-sys = { default-features = false, version = "0.8.2", path = "../netlink-sys" }
 thiserror = "1.0.30"
 
 [features]
@@ -28,8 +28,8 @@ smol_socket = ["netlink-sys/smol_socket"]
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = "0.11"
-netlink-packet-audit = "0.4"
+netlink-packet-route = { version = "0.11.0", path = "../netlink-packet-route" }
+netlink-packet-audit = { version = "0.4.0", path = "../netlink-packet-audit" }
 async-std = {version = "1.9.0", features = ["attributes"]}
 
 [[example]]

--- a/netlink-sys/Cargo.toml
+++ b/netlink-sys/Cargo.toml
@@ -43,7 +43,7 @@ tokio_socket = ["tokio", "futures"]
 smol_socket = ["async-io","futures"]
 
 [dev-dependencies]
-netlink-packet-audit = "0.4"
+netlink-packet-audit = { version = "0.4.0", path = "../netlink-packet-audit" }
 
 [dev-dependencies.tokio]
 version = "1.0.1"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -21,8 +21,8 @@ smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
-netlink-packet-route = "0.11"
-netlink-proto = { default-features = false, version = "0.9" }
+netlink-packet-route = { version = "0.11.0", path = "../netlink-packet-route" }
+netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
 nix = { version = "0.24.1" , default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }


### PR DESCRIPTION
Instead of `patch.crates-io` globally, the internal sub-crate dependency
should use `foo = { version = "0.1.0", path = "../foo" }`.

For more detail, please read
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies