### PR TITLE
New bundle release 20220623

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,44 @@
 ### New Features
 ### Bug fixes
 
+## [20220623] 2022-06-23
+### Versioning
+ * audit 0.6.0 -> 0.7.0
+ * genetlink 0.2.1 -> 0.2.2
+ * mptcp-pm NULL -> 0.1.0
+ * netlink-packet-generic 0.2.0 -> 0.3.1
+ * netlink-packet-audit 0.4.0 -> 0.4.1
+ * netlink-packet-route 0.11.0 -> 0.12.0
+ * netlink-proto 0.9.2 -> 0.9.3
+ * netlink-sys 0.8.2 -> 0.8.3
+ * rtnetlink 0.9.1 -> 0.10.0
+
+### Breaking Changes
+ * audit: removed `audit::proto::ErrorKind`. (3d799df)
+ * netlink-packet-route: changed from `AfSpecBridge::VlanInfo(Vec<u8>)` to
+   `AfSpecBridge::VlanInfo(BridgeVlanInfo)`. (f21ddb2)
+ * netlink-packet-route: changed from `Nla::AfSpecBridge(Vec<u8>)` to
+   `Nla::AfSpecBridge(Vec<AfSpecBridge>)`. (f21ddb2)
+ * netlink-packet-route: removed `InfoBridge::Flags` and `InfoBridge::VlanInfo`
+   as they should in `Nla::AfSpecBridge`. (b688737)
+ * netlink-packet-route: changed `NextHop.gateway` to
+   `NextHop.nlas`. (f6b3b9a)
+ * rtnetlink: Removed `rtnetlink::proto::ErrorKind`. (3d799df)
+
+### New Features
+ * New crate mptcp-pm for MPTCP path manager. (1903b39)
+ * netlink-packet-route: Add tc filter support. (2c41fb0)
+ * netlink-packet-route: Add tc qdisc support. (921a936)
+ * rtnetlink: Add tc filter support. (2c41fb0)
+ * rtnetlink: Add tc qdisc support. (921a936)
+
+### Bug fixes
+ * netlink-packet-audit: Simplfied codec error handling.
+   (33cc558, 0027b82, 9cdc870)
+ * netlink-packet-route: Fixed tc buffer error. (d2a5109)
+ * netlink-proto: fix netlink_proto::Error recursive problem. (3d799df)
+ * netlink-proto: Simplfied codec error handling. (0027b82, 9cdc870)
+
 ## [20220220] 2022-02-20
 
 ### Versioning

--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -14,8 +14,8 @@ description = "linux audit via netlink"
 [dependencies]
 futures = "0.3.11"
 thiserror = "1"
-netlink-packet-audit = { version = "0.4.0", path = "../netlink-packet-audit" }
-netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
+netlink-packet-audit = { version = "0.4.1", path = "../netlink-packet-audit" }
+netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
 
 [features]
 default = ["tokio_socket"]

--- a/ethtool/Cargo.toml
+++ b/ethtool/Cargo.toml
@@ -27,10 +27,10 @@ futures = "0.3.17"
 log = "0.4.14"
 genetlink = { default-features = false, version = "0.2.1", path = "../genetlink" }
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
-netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
-netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
-netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
+netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-sys = { version = "0.8.3", path = "../netlink-sys" }
 thiserror = "1.0.29"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 

--- a/genetlink/Cargo.toml
+++ b/genetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genetlink"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Leo <leo881003@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"
@@ -17,8 +17,8 @@ smol_socket = ["netlink-proto/smol_socket","async-std"]
 
 [dependencies]
 futures = "0.3.16"
-netlink-proto = { default-features = false, version = "0.9.0" , path = "../netlink-proto" }
-netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-proto = { default-features = false, version = "0.9.3" , path = "../netlink-proto" }
+netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 tokio = { version = "1.9.0", features = ["rt"], optional = true }

--- a/mptcp-pm/Cargo.toml
+++ b/mptcp-pm/Cargo.toml
@@ -29,10 +29,10 @@ thiserror = "1.0.29"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 genetlink = { default-features = false, version = "0.2.1", path = "../genetlink" }
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
-netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
-netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
-netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
+netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-sys = { version = "0.8.3", path = "../netlink-sys" }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/netlink-packet-audit/Cargo.toml
+++ b/netlink-packet-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-audit"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -18,7 +18,7 @@ byteorder = "1.3.2"
 log = "0.4.8"
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
-netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/netlink-packet-audit/fuzz/Cargo.toml
+++ b/netlink-packet-audit/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-audit = { version = "0.4", path = "../../netlink-packet-audit" }
+netlink-packet-audit = { version = "0.4.1", path = "../../netlink-packet-audit" }
 netlink-packet-core = { version = "0.4.2", path = "../../netlink-packet-core" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -18,4 +18,4 @@ libc = "0.2.66"
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
-netlink-packet-route = { version = "0.11.0", path = "../netlink-packet-route" }
+netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }

--- a/netlink-packet-generic/Cargo.toml
+++ b/netlink-packet-generic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-generic"
-version = "0.2.0"
+version = "0.3.1"
 authors = ["Leo <leo881003@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"
@@ -18,4 +18,4 @@ netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
-netlink-sys = { path = "../netlink-sys", version = "0.8.2" }
+netlink-sys = { path = "../netlink-sys", version = "0.8.3" }

--- a/netlink-packet-netfilter/Cargo.toml
+++ b/netlink-packet-netfilter/Cargo.toml
@@ -21,4 +21,4 @@ libc = "0.2.77"
 derive_more = "0.99.16"
 
 [dev-dependencies]
-netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
+netlink-sys = { version = "0.8.3", path = "../netlink-sys" }

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -29,7 +29,7 @@ name = "dump_packet_links"
 criterion = "0.3.0"
 pcap-file = "1.1.1"
 lazy_static = "1.4.0"
-netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
+netlink-sys = { version = "0.8.3", path = "../netlink-sys" }
 pretty_assertions = "0.7.2"
 
 [[bench]]

--- a/netlink-packet-route/fuzz/Cargo.toml
+++ b/netlink-packet-route/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-route = { path = "../", version = "0.11.0" }
+netlink-packet-route = { path = "../", version = "0.12.0" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/netlink-packet-sock-diag/Cargo.toml
+++ b/netlink-packet-sock-diag/Cargo.toml
@@ -25,4 +25,4 @@ smallvec = "1.4.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-netlink-sys = { version = "0.8.2", path = "../netlink-sys" }
+netlink-sys = { version = "0.8.3", path = "../netlink-sys" }

--- a/netlink-packet-wireguard/Cargo.toml
+++ b/netlink-packet-wireguard/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.42"
 byteorder = "1.4.3"
 libc = "0.2.98"
 log = "0.4.14"
-netlink-packet-generic = { version = "0.2.0", path = "../netlink-packet-generic" }
+netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
@@ -23,6 +23,6 @@ base64 = "0.13.0"
 env_logger = "0.9.0"
 futures = "0.3.16"
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
-netlink-proto = { version = "0.9.2", path = "../netlink-proto" }
+netlink-proto = { version = "0.9.3", path = "../netlink-proto" }
 genetlink = { version = "0.2.1", path = "../genetlink" }
 tokio = { version = "1.9.0", features = ["macros", "rt-multi-thread"] }

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -17,7 +17,7 @@ log = "0.4.8"
 futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util"] }
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
-netlink-sys = { default-features = false, version = "0.8.2", path = "../netlink-sys" }
+netlink-sys = { default-features = false, version = "0.8.3", path = "../netlink-sys" }
 thiserror = "1.0.30"
 
 [features]
@@ -28,8 +28,8 @@ smol_socket = ["netlink-sys/smol_socket"]
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = { version = "0.11.0", path = "../netlink-packet-route" }
-netlink-packet-audit = { version = "0.4.0", path = "../netlink-packet-audit" }
+netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }
+netlink-packet-audit = { version = "0.4.1", path = "../netlink-packet-audit" }
 async-std = {version = "1.9.0", features = ["attributes"]}
 
 [[example]]

--- a/netlink-sys/Cargo.toml
+++ b/netlink-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-sys"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -43,7 +43,7 @@ tokio_socket = ["tokio", "futures"]
 smol_socket = ["async-io","futures"]
 
 [dev-dependencies]
-netlink-packet-audit = { version = "0.4.0", path = "../netlink-packet-audit" }
+netlink-packet-audit = { version = "0.4.1", path = "../netlink-packet-audit" }
 
 [dev-dependencies.tokio]
 version = "1.0.1"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -21,8 +21,8 @@ smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
-netlink-packet-route = { version = "0.11.0", path = "../netlink-packet-route" }
-netlink-proto = { default-features = false, version = "0.9.2", path = "../netlink-proto" }
+netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }
+netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
 nix = { version = "0.24.1" , default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }


### PR DESCRIPTION
== Versioning
 * audit 0.6.0 -> 0.7.0
 * genetlink 0.2.1 -> 0.2.2
 * mptcp-pm NULL -> 0.1.0
 * netlink-packet-generic 0.2.0 -> 0.3.1
 * netlink-packet-audit 0.4.0 -> 0.4.1
 * netlink-packet-route 0.11.0 -> 0.12.0
 * netlink-proto 0.9.2 -> 0.9.3
 * netlink-sys 0.8.2 -> 0.8.3
 * rtnetlink 0.9.1 -> 0.10.0

== Breaking Changes
 * audit: removed `audit::proto::ErrorKind`. (3d799df)
 * netlink-packet-route: changed from `AfSpecBridge::VlanInfo(Vec<u8>)` to
   `AfSpecBridge::VlanInfo(BridgeVlanInfo)`. (f21ddb2)
 * netlink-packet-route: changed from `Nla::AfSpecBridge(Vec<u8>)` to
   `Nla::AfSpecBridge(Vec<AfSpecBridge>)`. (f21ddb2)
 * netlink-packet-route: removed `InfoBridge::Flags` and `InfoBridge::VlanInfo`
   as they should in `Nla::AfSpecBridge`. (b688737)
 * netlink-packet-route: changed `NextHop.gateway` to
   `NextHop.nlas`. (f6b3b9a)
 * rtnetlink: Removed `rtnetlink::proto::ErrorKind`. (3d799df)

== New Features
 * New crate mptcp-pm for MPTCP path manager. (1903b39)
 * netlink-packet-route: Add tc filter support. (2c41fb0)
 * netlink-packet-route: Add tc qdisc support. (921a936)
 * rtnetlink: Add tc filter support. (2c41fb0)
 * rtnetlink: Add tc qdisc support. (921a936)

== Bug fixes
 * netlink-packet-audit: Simplfied codec error handling.
   (33cc558, 0027b82, 9cdc870)
 * netlink-packet-route: Fixed tc buffer error. (d2a5109)
 * netlink-proto: fix netlink_proto::Error recursive problem. (3d799df)
 * netlink-proto: Simplfied codec error handling. (0027b82, 9cdc870)