### PR TITLE
Bump netlink-proto version to 0.10.0

### DIFF
--- a/audit/Cargo.toml
+++ b/audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audit"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ description = "linux audit via netlink"
 futures = "0.3.11"
 thiserror = "1"
 netlink-packet-audit = { version = "0.4.1", path = "../netlink-packet-audit" }
-netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.10.0", path = "../netlink-proto" }
 
 [features]
 default = ["tokio_socket"]

--- a/ethtool/Cargo.toml
+++ b/ethtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethtool"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"
@@ -29,7 +29,7 @@ genetlink = { default-features = false, version = "0.2.1", path = "../genetlink"
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
-netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.10", path = "../netlink-proto" }
 netlink-sys = { version = "0.8.3", path = "../netlink-sys" }
 thiserror = "1.0.29"
 tokio = { version = "1.0.1", features = ["rt"], optional = true}

--- a/genetlink/Cargo.toml
+++ b/genetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genetlink"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Leo <leo881003@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"
@@ -17,7 +17,7 @@ smol_socket = ["netlink-proto/smol_socket","async-std"]
 
 [dependencies]
 futures = "0.3.16"
-netlink-proto = { default-features = false, version = "0.9.3" , path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.10" , path = "../netlink-proto" }
 netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }

--- a/mptcp-pm/Cargo.toml
+++ b/mptcp-pm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mptcp-pm"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"
@@ -31,7 +31,7 @@ genetlink = { default-features = false, version = "0.2.1", path = "../genetlink"
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
-netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.10", path = "../netlink-proto" }
 netlink-sys = { version = "0.8.3", path = "../netlink-sys" }
 
 [dev-dependencies]

--- a/netlink-packet-audit/Cargo.toml
+++ b/netlink-packet-audit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-audit"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"
@@ -18,7 +18,7 @@ byteorder = "1.3.2"
 log = "0.4.8"
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
-netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.10", path = "../netlink-proto" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/netlink-packet-wireguard/Cargo.toml
+++ b/netlink-packet-wireguard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlink-packet-wireguard"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Leo <leo881003@gmail.com>", "Jake McGinty <me@jake.su>"]
 edition = "2018"
 homepage = "https://github.com/little-dude/netlink"
@@ -23,6 +23,6 @@ base64 = "0.13.0"
 env_logger = "0.9.0"
 futures = "0.3.16"
 netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
-netlink-proto = { version = "0.9.3", path = "../netlink-proto" }
+netlink-proto = { version = "0.10", path = "../netlink-proto" }
 genetlink = { version = "0.2.1", path = "../genetlink" }
 tokio = { version = "1.9.0", features = ["macros", "rt-multi-thread"] }

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.9.3"
+version = "0.10.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -22,7 +22,7 @@ futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }
-netlink-proto = { default-features = false, version = "0.9.3", path = "../netlink-proto" }
+netlink-proto = { default-features = false, version = "0.10", path = "../netlink-proto" }
 nix = { version = "0.24.1" , default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }


### PR DESCRIPTION
The `netlink-proto` removed `ErrorKind` from root. So it should not be
0.9.3 release but 0.10.0