### PR TITLE
New bundle release 20220715

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,21 @@
 ### New Features
 ### Bug fixes
 
+## [20220715] 2022-07-15
+### Versioning
+ * rtnetlink 0.10.1 -> 0.11.0
+ * netlink-packet-route 0.12.0 -> 0.13.0
+
+### Breaking Changes
+ * netlink-packet-route: `rtnl::link::nlas::InfoData::Bond` changed from
+   `Vec<u8>` to `Vec<InfoBond>`. (99b5765)
+
+### New Features
+ * Add support bond. (99b5765)
+
+### Bug fixes
+ * Fix the flag of link deletion. (9dccf92)
+
 ## [20220624] 2022-06-24
 ### Versioning
  * audit 0.7.0 -> 0.7.1

--- a/netlink-packet-core/Cargo.toml
+++ b/netlink-packet-core/Cargo.toml
@@ -18,4 +18,4 @@ libc = "0.2.66"
 netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
 
 [dev-dependencies]
-netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }
+netlink-packet-route = { version = "0.13.0", path = "../netlink-packet-route" }

--- a/netlink-packet-route/Cargo.toml
+++ b/netlink-packet-route/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-route"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 
 homepage = "https://github.com/little-dude/netlink"

--- a/netlink-packet-route/fuzz/Cargo.toml
+++ b/netlink-packet-route/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-netlink-packet-route = { path = "../", version = "0.12.0" }
+netlink-packet-route = { path = "../", version = "0.13" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/netlink-proto/Cargo.toml
+++ b/netlink-proto/Cargo.toml
@@ -28,7 +28,7 @@ smol_socket = ["netlink-sys/smol_socket"]
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }
+netlink-packet-route = { version = "0.13.0", path = "../netlink-packet-route" }
 netlink-packet-audit = { version = "0.4.1", path = "../netlink-packet-audit" }
 async-std = {version = "1.9.0", features = ["attributes"]}
 

--- a/rtnetlink/Cargo.toml
+++ b/rtnetlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
-netlink-packet-route = { version = "0.12.0", path = "../netlink-packet-route" }
+netlink-packet-route = { version = "0.13.0", path = "../netlink-packet-route" }
 netlink-proto = { default-features = false, version = "0.10", path = "../netlink-proto" }
 nix = { version = "0.24.1" , default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}


### PR DESCRIPTION
## Versioning
 * rtnetlink 0.10.1 -> 0.11.0
 * netlink-packet-route 0.12.0 -> 0.13.0

## Breaking Changes
 * netlink-packet-route: `rtnl::link::nlas::InfoData::Bond` changed from
   `Vec<u8>` to `Vec<InfoBond>`. (99b5765)

## New Features
 * Add support bond. (99b5765)

## Bug fixes
 * Fix the flag of link deletion. (9dccf92)