### PR TITLE
diag: add support for SOCK_DESTROY

### DIFF
--- a/netlink-packet-sock-diag/src/message.rs
+++ b/netlink-packet-sock-diag/src/message.rs
@@ -10,6 +10,7 @@ use crate::{
     NetlinkPayload,
     NetlinkSerializable,
     SockDiagBuffer,
+    SOCK_DESTROY,
     SOCK_DIAG_BY_FAMILY,
 };
 
@@ -90,6 +91,44 @@ impl NetlinkDeserializable for SockDiagMessage {
 
 impl From<SockDiagMessage> for NetlinkPayload<SockDiagMessage> {
     fn from(message: SockDiagMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SockDiagDestroy(SockDiagMessage);
+
+impl SockDiagDestroy {
+    pub fn new(message: SockDiagMessage) -> SockDiagDestroy {
+        SockDiagDestroy(message)
+    }
+}
+
+impl NetlinkSerializable for SockDiagDestroy {
+    fn message_type(&self) -> u16 {
+        SOCK_DESTROY
+    }
+
+    fn buffer_len(&self) -> usize {
+        NetlinkSerializable::buffer_len(&self.0)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.0.serialize(buffer)
+    }
+}
+
+impl NetlinkDeserializable for SockDiagDestroy {
+    type Error = DecodeError;
+    fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
+        Ok(SockDiagDestroy::new(SockDiagMessage::deserialize(
+            header, payload,
+        )?))
+    }
+}
+
+impl From<SockDiagDestroy> for NetlinkPayload<SockDiagDestroy> {
+    fn from(message: SockDiagDestroy) -> Self {
         NetlinkPayload::InnerMessage(message)
     }
 }


### PR DESCRIPTION
It is implemented on top of SockDiagMessage, and allows using Linux's
CONFIG_INET_DIAG_DESTROY feature to close an arbitrary socket.

Please consider this PR more like a request for comments, and a feature request for SOCK_DESTROY support. I'm not really a fan of how it's implemented, but I wanted to see if this was possible, and sent the first working version :-)