### PR TITLE
Fix panics when using iif or oif with ip rule

### DIFF
--- a/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
@@ -116,7 +116,7 @@ impl nlas::Nla for Nla {
         }
     }
 
-    fn emit_value(&self, buffer: &mut [u8]) {
+    fn emit_value(&self, mut buffer: &mut [u8]) {
         use self::Nla::*;
         match self {
             Unspec(ref bytes)
@@ -126,7 +126,7 @@ impl nlas::Nla for Nla {
             | UidRange(ref bytes)
             | SourcePortRange(ref bytes)
             | DestinationPortRange(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
-            Iifname(ref s) | OifName(ref s) => buffer.copy_from_slice(s.as_bytes()),
+            Iifname(ref s) | OifName(ref s) => buffer[..4].copy_from_slice(s.as_bytes()),
 
             Priority(value)
             | FwMark(value)

--- a/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
@@ -126,7 +126,7 @@ impl nlas::Nla for Nla {
             | UidRange(ref bytes)
             | SourcePortRange(ref bytes)
             | DestinationPortRange(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
-            Iifname(ref s) | OifName(ref s) => buffer[..4].copy_from_slice(s.as_bytes()),
+            Iifname(ref s) | OifName(ref s) => buffer[..s.len()].copy_from_slice(s.as_bytes()),
 
             Priority(value)
             | FwMark(value)

--- a/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
+++ b/netlink-packet-route/src/rtnl/rule/nlas/mod.rs
@@ -116,7 +116,7 @@ impl nlas::Nla for Nla {
         }
     }
 
-    fn emit_value(&self, mut buffer: &mut [u8]) {
+    fn emit_value(&self, buffer: &mut [u8]) {
         use self::Nla::*;
         match self {
             Unspec(ref bytes)


### PR DESCRIPTION
Copying string s (which size is `n`) in buffer of size `n+1` always panics because rust expect two slices of same length.

Since buffer has been initialized with 0, no need to add a second instruction like : `buffer[s.len()+1] = 0;`.