### PR TITLE
New crate `wl-nl80211` for wireless network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "rtnetlink",
     "audit",
     "mptcp-pm",
+    "wl-nl80211",
 ]
 
 # omit fuzz projects
@@ -37,4 +38,5 @@ default-members = [
     "rtnetlink",
     "audit",
     "mptcp-pm",
+    "wl-nl80211",
 ]

--- a/wl-nl80211/Cargo.toml
+++ b/wl-nl80211/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+# The crate name `nl80211` is occupied
+name = "wl-nl80211"
+version = "0.1.0"
+authors = ["Gris Ge <fge@redhat.com>"]
+license = "MIT"
+edition = "2018"
+description = "Linux kernel wireless(802.11) netlink Library"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+readme = "../README.md"
+
+[lib]
+name = "wl_nl80211"
+path = "src/lib.rs"
+crate-type = ["lib"]
+
+[features]
+default = ["tokio_socket"]
+tokio_socket = ["netlink-proto/tokio_socket", "tokio"]
+smol_socket = ["netlink-proto/smol_socket", "async-std"]
+
+[dependencies]
+anyhow = "1.0.44"
+async-std = { version = "1.9.0", optional = true}
+byteorder = "1.4.3"
+futures = "0.3.17"
+log = "0.4.14"
+thiserror = "1.0.29"
+tokio = { version = "1.0.1", features = ["rt"], optional = true}
+genetlink = { default-features = false, version = "0.2.1", path = "../genetlink" }
+netlink-packet-core = { version = "0.4.2", path = "../netlink-packet-core" }
+netlink-packet-generic = { version = "0.3.1", path = "../netlink-packet-generic" }
+netlink-packet-utils = { version = "0.5.1", path = "../netlink-packet-utils" }
+netlink-proto = { default-features = false, version = "0.10", path = "../netlink-proto" }
+netlink-sys = { version = "0.8.3", path = "../netlink-sys" }
+
+[dev-dependencies]
+tokio = { version = "1.11.0", features = ["macros", "rt", "rt-multi-thread"] }
+env_logger = "0.9.0"

--- a/wl-nl80211/LICENSE-MIT
+++ b/wl-nl80211/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/wl-nl80211/README.md
+++ b/wl-nl80211/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/wl-nl80211/examples/dump_nl80211_iface.rs
+++ b/wl-nl80211/examples/dump_nl80211_iface.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(get_interfaces());
+}
+
+async fn get_interfaces() {
+    let (connection, handle, _) = wl_nl80211::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut interface_handle = handle.interface().get().execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = interface_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(!msgs.is_empty());
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/wl-nl80211/src/attr.rs
+++ b/wl-nl80211/src/attr.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer, NlasIterator},
+    parsers::{parse_string, parse_u32, parse_u64, parse_u8},
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+use crate::{
+    channel::{Nl80211ChannelWidth, Nl80211WiPhyChannelType},
+    iface::Nl80211InterfaceType,
+    stats::Nl80211TransmitQueueStat,
+};
+
+const NL80211_ATTR_WIPHY: u16 = 1;
+const NL80211_ATTR_IFINDEX: u16 = 3;
+const NL80211_ATTR_IFNAME: u16 = 4;
+const NL80211_ATTR_IFTYPE: u16 = 5;
+const NL80211_ATTR_MAC: u16 = 6;
+const NL80211_ATTR_WIPHY_FREQ: u16 = 38;
+const NL80211_ATTR_WIPHY_CHANNEL_TYPE: u16 = 39;
+const NL80211_ATTR_GENERATION: u16 = 46;
+const NL80211_ATTR_SSID: u16 = 52;
+const NL80211_ATTR_4ADDR: u16 = 83;
+const NL80211_ATTR_WIPHY_TX_POWER_LEVEL: u16 = 98;
+const NL80211_ATTR_WDEV: u16 = 153;
+const NL80211_ATTR_CHANNEL_WIDTH: u16 = 159;
+const NL80211_ATTR_CENTER_FREQ1: u16 = 160;
+const NL80211_ATTR_CENTER_FREQ2: u16 = 161;
+const NL80211_ATTR_TXQ_STATS: u16 = 265;
+const NL80211_ATTR_WIPHY_FREQ_OFFSET: u16 = 290;
+const NL80211_ATTR_MLO_LINKS: u16 = 312;
+const NL80211_ATTR_MLO_LINK_ID: u16 = 313;
+
+const ETH_ALEN: usize = 6;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211Attr {
+    WiPhy(u32),
+    IfIndex(u32),
+    IfName(String),
+    IfType(Nl80211InterfaceType),
+    Mac([u8; ETH_ALEN]),
+    Wdev(u64),
+    Generation(u32),
+    Use4Addr(bool),
+    WiPhyFreq(u32),
+    WiPhyFreqOffset(u32),
+    WiPhyChannelType(Nl80211WiPhyChannelType),
+    ChannelWidth(Nl80211ChannelWidth),
+    CenterFreq1(u32),
+    CenterFreq2(u32),
+    WiPhyTxPowerLevel(u32),
+    Ssid(String),
+    TransmitQueueStats(Vec<Nl80211TransmitQueueStat>),
+    MloLinks(Vec<Nl80211MloLink>),
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211Attr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::IfIndex(_)
+            | Self::WiPhy(_)
+            | Self::IfType(_)
+            | Self::Generation(_)
+            | Self::WiPhyFreq(_)
+            | Self::WiPhyFreqOffset(_)
+            | Self::WiPhyChannelType(_)
+            | Self::CenterFreq1(_)
+            | Self::CenterFreq2(_)
+            | Self::WiPhyTxPowerLevel(_)
+            | Self::ChannelWidth(_) => 4,
+            Self::Wdev(_) => 8,
+            Self::IfName(ref s) | Self::Ssid(ref s) => s.len() + 1,
+            Self::Mac(_) => ETH_ALEN,
+            Self::Use4Addr(_) => 1,
+            Self::TransmitQueueStats(ref nlas) => nlas.as_slice().buffer_len(),
+            Self::MloLinks(ref links) => links.as_slice().buffer_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::WiPhy(_) => NL80211_ATTR_WIPHY,
+            Self::IfIndex(_) => NL80211_ATTR_IFINDEX,
+            Self::IfName(_) => NL80211_ATTR_IFNAME,
+            Self::IfType(_) => NL80211_ATTR_IFTYPE,
+            Self::Mac(_) => NL80211_ATTR_MAC,
+            Self::Wdev(_) => NL80211_ATTR_WDEV,
+            Self::Generation(_) => NL80211_ATTR_GENERATION,
+            Self::Use4Addr(_) => NL80211_ATTR_4ADDR,
+            Self::WiPhyFreq(_) => NL80211_ATTR_WIPHY_FREQ,
+            Self::WiPhyFreqOffset(_) => NL80211_ATTR_WIPHY_FREQ_OFFSET,
+            Self::WiPhyChannelType(_) => NL80211_ATTR_WIPHY_CHANNEL_TYPE,
+            Self::ChannelWidth(_) => NL80211_ATTR_CHANNEL_WIDTH,
+            Self::CenterFreq1(_) => NL80211_ATTR_CENTER_FREQ1,
+            Self::CenterFreq2(_) => NL80211_ATTR_CENTER_FREQ2,
+            Self::WiPhyTxPowerLevel(_) => NL80211_ATTR_WIPHY_TX_POWER_LEVEL,
+            Self::Ssid(_) => NL80211_ATTR_SSID,
+            Self::TransmitQueueStats(_) => NL80211_ATTR_TXQ_STATS,
+            Self::MloLinks(_) => NL80211_ATTR_MLO_LINKS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::IfIndex(d)
+            | Self::WiPhy(d)
+            | Self::Generation(d)
+            | Self::WiPhyFreq(d)
+            | Self::WiPhyFreqOffset(d)
+            | Self::CenterFreq1(d)
+            | Self::CenterFreq2(d)
+            | Self::WiPhyTxPowerLevel(d) => NativeEndian::write_u32(buffer, *d),
+            Self::Wdev(d) => NativeEndian::write_u64(buffer, *d),
+            Self::IfType(d) => NativeEndian::write_u32(buffer, (*d).into()),
+            Self::Mac(ref s) => buffer.copy_from_slice(s),
+            Self::IfName(ref s) | Self::Ssid(ref s) => {
+                buffer[..s.len()].copy_from_slice(s.as_bytes());
+                buffer[s.len()] = 0;
+            }
+            Self::Use4Addr(d) => buffer[0] = *d as u8,
+            Self::WiPhyChannelType(d) => NativeEndian::write_u32(buffer, (*d).into()),
+            Self::ChannelWidth(d) => NativeEndian::write_u32(buffer, (*d).into()),
+            Self::TransmitQueueStats(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::MloLinks(ref links) => links.as_slice().emit(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211Attr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_ATTR_IFINDEX => {
+                let err_msg = format!("Invalid NL80211_ATTR_IFINDEX value {:?}", payload);
+                Self::IfIndex(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_WIPHY => {
+                let err_msg = format!("Invalid NL80211_ATTR_WIPHY value {:?}", payload);
+                Self::WiPhy(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_IFNAME => {
+                let err_msg = format!("Invalid NL80211_ATTR_IFNAME value {:?}", payload);
+                Self::IfName(parse_string(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_IFTYPE => {
+                let err_msg = format!("Invalid NL80211_ATTR_IFTYPE value {:?}", payload);
+                Self::IfType(parse_u32(payload).context(err_msg)?.into())
+            }
+            NL80211_ATTR_WDEV => {
+                let err_msg = format!("Invalid NL80211_ATTR_WDEV value {:?}", payload);
+                Self::Wdev(parse_u64(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_MAC => Self::Mac(if payload.len() == ETH_ALEN {
+                let mut ret = [0u8; ETH_ALEN];
+                ret.copy_from_slice(&payload[..ETH_ALEN]);
+                ret
+            } else {
+                return Err(format!(
+                    "Invalid length of NL80211_ATTR_MAC, expected length {} got {:?}",
+                    ETH_ALEN, payload
+                )
+                .into());
+            }),
+            NL80211_ATTR_GENERATION => {
+                let err_msg = format!("Invalid NL80211_ATTR_GENERATION value {:?}", payload);
+                Self::Generation(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_4ADDR => {
+                let err_msg = format!("Invalid NL80211_ATTR_4ADDR value {:?}", payload);
+                Self::Use4Addr(parse_u8(payload).context(err_msg)? > 0)
+            }
+            NL80211_ATTR_WIPHY_FREQ => {
+                let err_msg = format!("Invalid NL80211_ATTR_WIPHY_FREQ value {:?}", payload);
+                Self::WiPhyFreq(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_WIPHY_FREQ_OFFSET => {
+                let err_msg = format!("Invalid NL80211_ATTR_WIPHY_FREQ_OFFSET value {:?}", payload);
+                Self::WiPhyFreqOffset(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_WIPHY_CHANNEL_TYPE => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_WIPHY_CHANNEL_TYPE value {:?}",
+                    payload
+                );
+                Self::WiPhyChannelType(parse_u32(payload).context(err_msg)?.into())
+            }
+            NL80211_ATTR_CHANNEL_WIDTH => {
+                let err_msg = format!("Invalid NL80211_ATTR_CHANNEL_WIDTH value {:?}", payload);
+                Self::ChannelWidth(parse_u32(payload).context(err_msg)?.into())
+            }
+            NL80211_ATTR_CENTER_FREQ1 => {
+                let err_msg = format!("Invalid NL80211_ATTR_CENTER_FREQ1 value {:?}", payload);
+                Self::CenterFreq1(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_CENTER_FREQ2 => {
+                let err_msg = format!("Invalid NL80211_ATTR_CENTER_FREQ2 value {:?}", payload);
+                Self::CenterFreq2(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_WIPHY_TX_POWER_LEVEL => {
+                let err_msg = format!(
+                    "Invalid NL80211_ATTR_WIPHY_TX_POWER_LEVEL value {:?}",
+                    payload
+                );
+                Self::WiPhyTxPowerLevel(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_SSID => {
+                let err_msg = format!("Invalid NL80211_ATTR_SSID value {:?}", payload);
+                Self::Ssid(parse_string(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_TXQ_STATS => {
+                let err_msg = format!("Invalid NL80211_ATTR_TXQ_STATS value {:?}", payload);
+                let mut nlas = Vec::new();
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    nlas.push(Nl80211TransmitQueueStat::parse(nla).context(err_msg.clone())?);
+                }
+                Self::TransmitQueueStats(nlas)
+            }
+            NL80211_ATTR_MLO_LINKS => {
+                let err_msg = format!("Invalid NL80211_ATTR_MLO_LINKS value {:?}", payload);
+                let mut links = Vec::new();
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(err_msg.clone())?;
+                    links.push(Nl80211MloLink::parse(nla).context(err_msg.clone())?);
+                }
+                Self::MloLinks(links)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211MloLinkNla {
+    Id(u8),
+    Mac([u8; ETH_ALEN]),
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211MloLinkNla {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Id(_) => 1,
+            Self::Mac(_) => ETH_ALEN,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Id(_) => NL80211_ATTR_MLO_LINK_ID,
+            Self::Mac(_) => NL80211_ATTR_MAC,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Id(d) => buffer[0] = *d,
+            Self::Mac(ref s) => buffer.copy_from_slice(s),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211MloLinkNla {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_ATTR_MLO_LINK_ID => {
+                let err_msg = format!("Invalid NL80211_ATTR_MLO_LINK_ID value {:?}", payload);
+                Self::Id(parse_u8(payload).context(err_msg)?)
+            }
+            NL80211_ATTR_MAC => Self::Mac(if payload.len() == ETH_ALEN {
+                let mut ret = [0u8; ETH_ALEN];
+                ret.copy_from_slice(&payload[..ETH_ALEN]);
+                ret
+            } else {
+                return Err(format!(
+                    "Invalid length of NL80211_ATTR_MAC, expected length {} got {:?}",
+                    ETH_ALEN, payload
+                )
+                .into());
+            }),
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct Nl80211MloLink {
+    pub id: u8,
+    pub mac: [u8; ETH_ALEN],
+}
+
+impl Nla for Nl80211MloLink {
+    fn value_len(&self) -> usize {
+        Vec::<Nl80211MloLinkNla>::from(self).as_slice().buffer_len()
+    }
+
+    fn kind(&self) -> u16 {
+        self.id as u16 + 1
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        Vec::<Nl80211MloLinkNla>::from(self).as_slice().emit(buffer)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211MloLink {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let mut ret = Self::default();
+        let payload = buf.value();
+        let err_msg = format!("Invalid NL80211_ATTR_MLO_LINKS value {:?}", payload);
+        for nla in NlasIterator::new(payload) {
+            let nla = &nla.context(err_msg.clone())?;
+            match Nl80211MloLinkNla::parse(nla).context(err_msg.clone())? {
+                Nl80211MloLinkNla::Id(d) => ret.id = d,
+                Nl80211MloLinkNla::Mac(s) => ret.mac = s,
+                Nl80211MloLinkNla::Other(attr) => {
+                    log::warn!("Got unsupported NL80211_ATTR_MLO_LINKS value {:?}", attr)
+                }
+            }
+        }
+        Ok(ret)
+    }
+}
+
+impl From<&Nl80211MloLink> for Vec<Nl80211MloLinkNla> {
+    fn from(link: &Nl80211MloLink) -> Self {
+        vec![
+            Nl80211MloLinkNla::Id(link.id),
+            Nl80211MloLinkNla::Mac(link.mac),
+        ]
+    }
+}

--- a/wl-nl80211/src/channel.rs
+++ b/wl-nl80211/src/channel.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+const NL80211_CHAN_NO_HT: u32 = 0;
+const NL80211_CHAN_HT20: u32 = 1;
+const NL80211_CHAN_HT40MINUS: u32 = 2;
+const NL80211_CHAN_HT40PLUS: u32 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211WiPhyChannelType {
+    NoHT,
+    HT20,
+    HT40Minus,
+    HT40Plus,
+    Other(u32),
+}
+
+impl From<u32> for Nl80211WiPhyChannelType {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_CHAN_NO_HT => Self::NoHT,
+            NL80211_CHAN_HT20 => Self::HT20,
+            NL80211_CHAN_HT40MINUS => Self::HT40Plus,
+            NL80211_CHAN_HT40PLUS => Self::HT40Plus,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211WiPhyChannelType> for u32 {
+    fn from(v: Nl80211WiPhyChannelType) -> u32 {
+        match v {
+            Nl80211WiPhyChannelType::NoHT => NL80211_CHAN_NO_HT,
+            Nl80211WiPhyChannelType::HT20 => NL80211_CHAN_HT20,
+            Nl80211WiPhyChannelType::HT40Minus => NL80211_CHAN_HT40MINUS,
+            Nl80211WiPhyChannelType::HT40Plus => NL80211_CHAN_HT40PLUS,
+            Nl80211WiPhyChannelType::Other(d) => d,
+        }
+    }
+}
+
+const NL80211_CHAN_WIDTH_20_NOHT: u32 = 0;
+const NL80211_CHAN_WIDTH_20: u32 = 1;
+const NL80211_CHAN_WIDTH_40: u32 = 2;
+const NL80211_CHAN_WIDTH_80: u32 = 3;
+const NL80211_CHAN_WIDTH_80P80: u32 = 4;
+const NL80211_CHAN_WIDTH_160: u32 = 5;
+const NL80211_CHAN_WIDTH_5: u32 = 6;
+const NL80211_CHAN_WIDTH_10: u32 = 7;
+const NL80211_CHAN_WIDTH_1: u32 = 8;
+const NL80211_CHAN_WIDTH_2: u32 = 9;
+const NL80211_CHAN_WIDTH_4: u32 = 10;
+const NL80211_CHAN_WIDTH_8: u32 = 11;
+const NL80211_CHAN_WIDTH_16: u32 = 12;
+const NL80211_CHAN_WIDTH_320: u32 = 13;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211ChannelWidth {
+    NoHt20,
+    Mhz80Plus80,
+    Mhz(u32),
+    Other(u32),
+}
+
+impl From<u32> for Nl80211ChannelWidth {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_CHAN_WIDTH_20_NOHT => Self::NoHt20,
+            NL80211_CHAN_WIDTH_20 => Self::Mhz(20),
+            NL80211_CHAN_WIDTH_40 => Self::Mhz(40),
+            NL80211_CHAN_WIDTH_80 => Self::Mhz(80),
+            NL80211_CHAN_WIDTH_80P80 => Self::Mhz80Plus80,
+            NL80211_CHAN_WIDTH_160 => Self::Mhz(160),
+            NL80211_CHAN_WIDTH_5 => Self::Mhz(5),
+            NL80211_CHAN_WIDTH_10 => Self::Mhz(10),
+            NL80211_CHAN_WIDTH_1 => Self::Mhz(1),
+            NL80211_CHAN_WIDTH_2 => Self::Mhz(2),
+            NL80211_CHAN_WIDTH_4 => Self::Mhz(4),
+            NL80211_CHAN_WIDTH_8 => Self::Mhz(8),
+            NL80211_CHAN_WIDTH_16 => Self::Mhz(16),
+            NL80211_CHAN_WIDTH_320 => Self::Mhz(320),
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211ChannelWidth> for u32 {
+    fn from(v: Nl80211ChannelWidth) -> u32 {
+        match v {
+            Nl80211ChannelWidth::NoHt20 => NL80211_CHAN_WIDTH_20_NOHT,
+            Nl80211ChannelWidth::Mhz(20) => NL80211_CHAN_WIDTH_20,
+            Nl80211ChannelWidth::Mhz(40) => NL80211_CHAN_WIDTH_40,
+            Nl80211ChannelWidth::Mhz(80) => NL80211_CHAN_WIDTH_80,
+            Nl80211ChannelWidth::Mhz80Plus80 => NL80211_CHAN_WIDTH_80P80,
+            Nl80211ChannelWidth::Mhz(160) => NL80211_CHAN_WIDTH_160,
+            Nl80211ChannelWidth::Mhz(5) => NL80211_CHAN_WIDTH_5,
+            Nl80211ChannelWidth::Mhz(10) => NL80211_CHAN_WIDTH_10,
+            Nl80211ChannelWidth::Mhz(1) => NL80211_CHAN_WIDTH_1,
+            Nl80211ChannelWidth::Mhz(2) => NL80211_CHAN_WIDTH_2,
+            Nl80211ChannelWidth::Mhz(4) => NL80211_CHAN_WIDTH_4,
+            Nl80211ChannelWidth::Mhz(8) => NL80211_CHAN_WIDTH_8,
+            Nl80211ChannelWidth::Mhz(16) => NL80211_CHAN_WIDTH_16,
+            Nl80211ChannelWidth::Mhz(320) => NL80211_CHAN_WIDTH_320,
+            Nl80211ChannelWidth::Mhz(_) => {
+                log::warn!("Invalid Nl80211ChannelWidth {:?}", v);
+                u32::MAX
+            }
+            Nl80211ChannelWidth::Other(d) => d,
+        }
+    }
+}

--- a/wl-nl80211/src/connection.rs
+++ b/wl-nl80211/src/connection.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+use std::io;
+
+use futures::channel::mpsc::UnboundedReceiver;
+use genetlink::message::RawGenlMessage;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::Connection;
+use netlink_sys::{AsyncSocket, SocketAddr};
+
+use crate::Nl80211Handle;
+
+#[cfg(feature = "tokio_socket")]
+#[allow(clippy::type_complexity)]
+pub fn new_connection() -> io::Result<(
+    Connection<RawGenlMessage>,
+    Nl80211Handle,
+    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+)> {
+    new_connection_with_socket()
+}
+
+#[allow(clippy::type_complexity)]
+pub fn new_connection_with_socket<S>() -> io::Result<(
+    Connection<RawGenlMessage, S>,
+    Nl80211Handle,
+    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+)>
+where
+    S: AsyncSocket,
+{
+    let (conn, handle, messages) = genetlink::new_connection_with_socket()?;
+    Ok((conn, Nl80211Handle::new(handle), messages))
+}

--- a/wl-nl80211/src/error.rs
+++ b/wl-nl80211/src/error.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+use thiserror::Error;
+
+use netlink_packet_core::{ErrorMessage, NetlinkMessage};
+use netlink_packet_generic::GenlMessage;
+
+use crate::Nl80211Message;
+
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum Nl80211Error {
+    #[error("Received an unexpected message {0:?}")]
+    UnexpectedMessage(NetlinkMessage<GenlMessage<Nl80211Message>>),
+
+    #[error("Received a netlink error message {0}")]
+    NetlinkError(ErrorMessage),
+
+    #[error("A netlink request failed")]
+    RequestFailed(String),
+
+    #[error("A bug in this crate")]
+    Bug(String),
+}

--- a/wl-nl80211/src/handle.rs
+++ b/wl-nl80211/src/handle.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+use futures::{future::Either, FutureExt, Stream, StreamExt, TryStream};
+use genetlink::GenetlinkHandle;
+use netlink_packet_core::{NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+use netlink_packet_utils::DecodeError;
+
+use crate::{try_nl80211, Nl80211Error, Nl80211InterfaceHandle, Nl80211Message};
+
+#[derive(Clone, Debug)]
+pub struct Nl80211Handle {
+    pub handle: GenetlinkHandle,
+}
+
+impl Nl80211Handle {
+    pub(crate) fn new(handle: GenetlinkHandle) -> Self {
+        Nl80211Handle { handle }
+    }
+
+    // equivalent to `iw dev` command
+    pub fn interface(&self) -> Nl80211InterfaceHandle {
+        Nl80211InterfaceHandle::new(self.clone())
+    }
+
+    pub async fn request(
+        &mut self,
+        message: NetlinkMessage<GenlMessage<Nl80211Message>>,
+    ) -> Result<
+        impl Stream<Item = Result<NetlinkMessage<GenlMessage<Nl80211Message>>, DecodeError>>,
+        Nl80211Error,
+    > {
+        self.handle
+            .request(message)
+            .await
+            .map_err(|e| Nl80211Error::RequestFailed(format!("BUG: Request failed with {}", e)))
+    }
+}
+
+pub(crate) async fn nl80211_execute(
+    handle: &mut Nl80211Handle,
+    nl80211_msg: Nl80211Message,
+) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error> {
+    let nl_header_flags = NLM_F_REQUEST | NLM_F_DUMP;
+
+    let mut nl_msg = NetlinkMessage::from(GenlMessage::from_payload(nl80211_msg));
+
+    nl_msg.header.flags = nl_header_flags;
+
+    match handle.request(nl_msg).await {
+        Ok(response) => Either::Left(response.map(move |msg| Ok(try_nl80211!(msg)))),
+        Err(e) => Either::Right(
+            futures::future::err::<GenlMessage<Nl80211Message>, Nl80211Error>(e).into_stream(),
+        ),
+    }
+}

--- a/wl-nl80211/src/iface/get.rs
+++ b/wl-nl80211/src/iface/get.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_generic::GenlMessage;
+
+use crate::{nl80211_execute, Nl80211Error, Nl80211Handle, Nl80211Message};
+
+pub struct Nl80211InterfaceGetRequest {
+    handle: Nl80211Handle,
+}
+
+impl Nl80211InterfaceGetRequest {
+    pub(crate) fn new(handle: Nl80211Handle) -> Self {
+        Nl80211InterfaceGetRequest { handle }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<Nl80211Message>, Error = Nl80211Error> {
+        let Nl80211InterfaceGetRequest { mut handle } = self;
+
+        let nl80211_msg = Nl80211Message::new_interface_get();
+        nl80211_execute(&mut handle, nl80211_msg).await
+    }
+}

--- a/wl-nl80211/src/iface/handle.rs
+++ b/wl-nl80211/src/iface/handle.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{Nl80211Handle, Nl80211InterfaceGetRequest};
+
+pub struct Nl80211InterfaceHandle(Nl80211Handle);
+
+impl Nl80211InterfaceHandle {
+    pub fn new(handle: Nl80211Handle) -> Self {
+        Nl80211InterfaceHandle(handle)
+    }
+
+    /// Retrieve the wireless interfaces
+    /// (equivalent to `iw dev`)
+    pub fn get(&mut self) -> Nl80211InterfaceGetRequest {
+        Nl80211InterfaceGetRequest::new(self.0.clone())
+    }
+}

--- a/wl-nl80211/src/iface/iface_type.rs
+++ b/wl-nl80211/src/iface/iface_type.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+const NL80211_IFTYPE_ADHOC: u32 = 1;
+const NL80211_IFTYPE_STATION: u32 = 2;
+const NL80211_IFTYPE_AP: u32 = 3;
+const NL80211_IFTYPE_AP_VLAN: u32 = 4;
+const NL80211_IFTYPE_WDS: u32 = 5;
+const NL80211_IFTYPE_MONITOR: u32 = 6;
+const NL80211_IFTYPE_MESH_POINT: u32 = 7;
+const NL80211_IFTYPE_P2P_CLIENT: u32 = 8;
+const NL80211_IFTYPE_P2P_GO: u32 = 9;
+const NL80211_IFTYPE_P2P_DEVICE: u32 = 10;
+const NL80211_IFTYPE_OCB: u32 = 11;
+const NL80211_IFTYPE_NAN: u32 = 12;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211InterfaceType {
+    /// Independent BSS member
+    Adhoc,
+    /// Managed BSS member
+    Station,
+    /// Access point
+    Ap,
+    /// VLAN interface for access points; VLAN interfaces are a bit special in
+    /// that they must always be tied to a pre-existing AP type interface.
+    ApVlan,
+    /// wireless distribution interface
+    Wds,
+    /// Monitor interface receiving all frames
+    Monitor,
+    /// Mesh point
+    MeshPoint,
+    /// P2P client
+    P2pClient,
+    /// P2P group owner
+    P2pGo,
+    /// P2P device interface type, this is not a netdev
+    P2pDevice,
+    /// Outside Context of a BSS, This mode corresponds to the MIB variable dot11OCBActivated=true
+    Ocb,
+    /// NAN device interface type (not a netdev)
+    Nan,
+    Other(u32),
+}
+
+impl From<u32> for Nl80211InterfaceType {
+    fn from(d: u32) -> Self {
+        match d {
+            NL80211_IFTYPE_ADHOC => Self::Adhoc,
+            NL80211_IFTYPE_STATION => Self::Station,
+            NL80211_IFTYPE_AP => Self::Ap,
+            NL80211_IFTYPE_AP_VLAN => Self::ApVlan,
+            NL80211_IFTYPE_WDS => Self::Wds,
+            NL80211_IFTYPE_MONITOR => Self::Monitor,
+            NL80211_IFTYPE_MESH_POINT => Self::MeshPoint,
+            NL80211_IFTYPE_P2P_CLIENT => Self::P2pClient,
+            NL80211_IFTYPE_P2P_GO => Self::P2pGo,
+            NL80211_IFTYPE_P2P_DEVICE => Self::P2pDevice,
+            NL80211_IFTYPE_OCB => Self::Ocb,
+            NL80211_IFTYPE_NAN => Self::Nan,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<Nl80211InterfaceType> for u32 {
+    fn from(v: Nl80211InterfaceType) -> u32 {
+        match v {
+            Nl80211InterfaceType::Adhoc => NL80211_IFTYPE_ADHOC,
+            Nl80211InterfaceType::Station => NL80211_IFTYPE_STATION,
+            Nl80211InterfaceType::Ap => NL80211_IFTYPE_AP,
+            Nl80211InterfaceType::ApVlan => NL80211_IFTYPE_AP_VLAN,
+            Nl80211InterfaceType::Wds => NL80211_IFTYPE_WDS,
+            Nl80211InterfaceType::Monitor => NL80211_IFTYPE_MONITOR,
+            Nl80211InterfaceType::MeshPoint => NL80211_IFTYPE_MESH_POINT,
+            Nl80211InterfaceType::P2pClient => NL80211_IFTYPE_P2P_CLIENT,
+            Nl80211InterfaceType::P2pGo => NL80211_IFTYPE_P2P_GO,
+            Nl80211InterfaceType::P2pDevice => NL80211_IFTYPE_P2P_DEVICE,
+            Nl80211InterfaceType::Ocb => NL80211_IFTYPE_OCB,
+            Nl80211InterfaceType::Nan => NL80211_IFTYPE_NAN,
+            Nl80211InterfaceType::Other(d) => d,
+        }
+    }
+}

--- a/wl-nl80211/src/iface/mod.rs
+++ b/wl-nl80211/src/iface/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+mod get;
+mod handle;
+mod iface_type;
+
+pub use get::Nl80211InterfaceGetRequest;
+pub use handle::Nl80211InterfaceHandle;
+pub use iface_type::Nl80211InterfaceType;

--- a/wl-nl80211/src/lib.rs
+++ b/wl-nl80211/src/lib.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+mod attr;
+mod channel;
+mod connection;
+mod error;
+mod handle;
+mod iface;
+mod macros;
+mod message;
+mod stats;
+
+pub use attr::Nl80211Attr;
+pub use channel::Nl80211WiPhyChannelType;
+#[cfg(feature = "tokio_socket")]
+pub use connection::new_connection;
+pub use connection::new_connection_with_socket;
+pub use error::Nl80211Error;
+pub use handle::Nl80211Handle;
+pub use iface::{Nl80211InterfaceGetRequest, Nl80211InterfaceHandle, Nl80211InterfaceType};
+pub use message::{Nl80211Cmd, Nl80211Message};
+pub use stats::Nl80211TransmitQueueStat;
+
+pub(crate) use handle::nl80211_execute;

--- a/wl-nl80211/src/macros.rs
+++ b/wl-nl80211/src/macros.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+#[macro_export]
+macro_rules! try_nl80211 {
+    ($msg: expr) => {{
+        use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+        use $crate::Nl80211Error;
+
+        match $msg {
+            Ok(msg) => {
+                let (header, payload) = msg.into_parts();
+                match payload {
+                    NetlinkPayload::InnerMessage(msg) => msg,
+                    NetlinkPayload::Error(err) => return Err(Nl80211Error::NetlinkError(err)),
+                    _ => {
+                        return Err(Nl80211Error::UnexpectedMessage(NetlinkMessage::new(
+                            header, payload,
+                        )))
+                    }
+                }
+            }
+            Err(e) => return Err(Nl80211Error::Bug(format!("BUG: decode error {:?}", e))),
+        }
+    }};
+}

--- a/wl-nl80211/src/message.rs
+++ b/wl-nl80211/src/message.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use netlink_packet_core::DecodeError;
+use netlink_packet_generic::{GenlFamily, GenlHeader};
+use netlink_packet_utils::{nla::NlasIterator, Emitable, Parseable, ParseableParametrized};
+
+use crate::attr::Nl80211Attr;
+
+const NL80211_CMD_GET_INTERFACE: u8 = 5;
+const NL80211_CMD_NEW_INTERFACE: u8 = 7;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Nl80211Cmd {
+    InterfaceGet,
+    InterfaceNew,
+}
+
+impl From<Nl80211Cmd> for u8 {
+    fn from(cmd: Nl80211Cmd) -> Self {
+        match cmd {
+            Nl80211Cmd::InterfaceGet => NL80211_CMD_GET_INTERFACE,
+            Nl80211Cmd::InterfaceNew => NL80211_CMD_NEW_INTERFACE,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Nl80211Message {
+    pub cmd: Nl80211Cmd,
+    pub nlas: Vec<Nl80211Attr>,
+}
+
+impl GenlFamily for Nl80211Message {
+    fn family_name() -> &'static str {
+        "nl80211"
+    }
+
+    fn version(&self) -> u8 {
+        1
+    }
+
+    fn command(&self) -> u8 {
+        self.cmd.into()
+    }
+}
+
+impl Nl80211Message {
+    pub fn new_interface_get() -> Self {
+        Nl80211Message {
+            cmd: Nl80211Cmd::InterfaceGet,
+            nlas: vec![],
+        }
+    }
+}
+
+impl Emitable for Nl80211Message {
+    fn buffer_len(&self) -> usize {
+        self.nlas.as_slice().buffer_len()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.nlas.as_slice().emit(buffer)
+    }
+}
+
+fn parse_nlas(buffer: &[u8]) -> Result<Vec<Nl80211Attr>, DecodeError> {
+    let mut nlas = Vec::new();
+    for nla in NlasIterator::new(buffer) {
+        let error_msg = format!("Failed to parse nl80211 message attribute {:?}", nla);
+        let nla = &nla.context(error_msg.clone())?;
+        nlas.push(Nl80211Attr::parse(nla).context(error_msg)?);
+    }
+    Ok(nlas)
+}
+
+impl ParseableParametrized<[u8], GenlHeader> for Nl80211Message {
+    fn parse_with_param(buffer: &[u8], header: GenlHeader) -> Result<Self, DecodeError> {
+        Ok(match header.cmd {
+            NL80211_CMD_NEW_INTERFACE => Self {
+                cmd: Nl80211Cmd::InterfaceNew,
+                nlas: parse_nlas(buffer)?,
+            },
+            cmd => {
+                return Err(DecodeError::from(format!(
+                    "Unsupported nl80211 reply command: {}",
+                    cmd
+                )))
+            }
+        })
+    }
+}

--- a/wl-nl80211/src/stats.rs
+++ b/wl-nl80211/src/stats.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer},
+    parsers::parse_u32,
+    DecodeError,
+    Emitable,
+    Parseable,
+};
+
+const NL80211_TXQ_STATS_BACKLOG_BYTES: u16 = 1;
+const NL80211_TXQ_STATS_BACKLOG_PACKETS: u16 = 2;
+const NL80211_TXQ_STATS_FLOWS: u16 = 3;
+const NL80211_TXQ_STATS_DROPS: u16 = 4;
+const NL80211_TXQ_STATS_ECN_MARKS: u16 = 5;
+const NL80211_TXQ_STATS_OVERLIMIT: u16 = 6;
+const NL80211_TXQ_STATS_OVERMEMORY: u16 = 7;
+const NL80211_TXQ_STATS_COLLISIONS: u16 = 8;
+const NL80211_TXQ_STATS_TX_BYTES: u16 = 9;
+const NL80211_TXQ_STATS_TX_PACKETS: u16 = 10;
+const NL80211_TXQ_STATS_MAX_FLOWS: u16 = 11;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Nl80211TransmitQueueStat {
+    BacklogBytes(u32),
+    BacklogPackets(u32),
+    Flows(u32),
+    Drops(u32),
+    EcnMarks(u32),
+    Overlimit(u32),
+    Overmemory(u32),
+    Collisions(u32),
+    TxBytes(u32),
+    TxPackets(u32),
+    MaxFlows(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for Nl80211TransmitQueueStat {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::BacklogBytes(_)
+            | Self::BacklogPackets(_)
+            | Self::Flows(_)
+            | Self::Drops(_)
+            | Self::EcnMarks(_)
+            | Self::Overlimit(_)
+            | Self::Overmemory(_)
+            | Self::Collisions(_)
+            | Self::TxBytes(_)
+            | Self::TxPackets(_)
+            | Self::MaxFlows(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+    fn kind(&self) -> u16 {
+        match self {
+            Self::BacklogBytes(_) => NL80211_TXQ_STATS_BACKLOG_BYTES,
+            Self::BacklogPackets(_) => NL80211_TXQ_STATS_BACKLOG_PACKETS,
+            Self::Flows(_) => NL80211_TXQ_STATS_FLOWS,
+            Self::Drops(_) => NL80211_TXQ_STATS_DROPS,
+            Self::EcnMarks(_) => NL80211_TXQ_STATS_ECN_MARKS,
+            Self::Overlimit(_) => NL80211_TXQ_STATS_OVERLIMIT,
+            Self::Overmemory(_) => NL80211_TXQ_STATS_OVERMEMORY,
+            Self::Collisions(_) => NL80211_TXQ_STATS_COLLISIONS,
+            Self::TxBytes(_) => NL80211_TXQ_STATS_TX_BYTES,
+            Self::TxPackets(_) => NL80211_TXQ_STATS_TX_PACKETS,
+            Self::MaxFlows(_) => NL80211_TXQ_STATS_MAX_FLOWS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::BacklogBytes(d)
+            | Self::BacklogPackets(d)
+            | Self::Flows(d)
+            | Self::Drops(d)
+            | Self::EcnMarks(d)
+            | Self::Overlimit(d)
+            | Self::Overmemory(d)
+            | Self::Collisions(d)
+            | Self::TxBytes(d)
+            | Self::TxPackets(d)
+            | Self::MaxFlows(d) => NativeEndian::write_u32(buffer, *d),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nl80211TransmitQueueStat {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NL80211_TXQ_STATS_BACKLOG_BYTES => {
+                let err_msg = format!(
+                    "Invalid NL80211_TXQ_STATS_BACKLOG_BYTES value {:?}",
+                    payload
+                );
+                Self::BacklogBytes(parse_u32(payload).context(err_msg)?)
+            }
+            NL80211_TXQ_STATS_BACKLOG_PACKETS => {
+                let err_msg = format!(
+                    "Invalid NL80211_TXQ_STATS_BACKLOG_PACKETS value: {:?}",
+                    payload
+                );
+                Self::BacklogPackets(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_FLOWS => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_FLOWS value: {:?}", payload);
+                Self::Flows(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_DROPS => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_DROPS value: {:?}", payload);
+                Self::Drops(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_ECN_MARKS => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_ECN_MARKS value: {:?}", payload);
+                Self::EcnMarks(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_OVERLIMIT => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_OVERLIMIT value: {:?}", payload);
+                Self::Overlimit(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_OVERMEMORY => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_OVERMEMORY value: {:?}", payload);
+                Self::Overmemory(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_COLLISIONS => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_COLLISIONS value: {:?}", payload);
+                Self::Collisions(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_TX_BYTES => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_TX_BYTES value: {:?}", payload);
+                Self::TxBytes(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_TX_PACKETS => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_TX_PACKETS value: {:?}", payload);
+                Self::TxPackets(parse_u32(payload).context(err_msg)?)
+            }
+
+            NL80211_TXQ_STATS_MAX_FLOWS => {
+                let err_msg = format!("Invalid NL80211_TXQ_STATS_MAX_FLOWS value: {:?}", payload);
+                Self::MaxFlows(parse_u32(payload).context(err_msg)?)
+            }
+            _ => Self::Other(DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?),
+        })
+    }
+}


### PR DESCRIPTION
The `nl80211` name is occupied in crates.io, so we use `wl-nl80211`
instead.

Initially we only add the support of `NL80211_CMD_GET_INTERFACE` equal
to command `iw dev`.

Except `NL80211_ATTR_MLO_LINKS` all other NLAs are tested on my laptop.

Example code is stored as `wl-nl80211/examples/dump_nl80211_iface.rs`.