### PR TITLE
Fix ip_monitor example

### DIFF
--- a/rtnetlink/examples/ip_monitor.rs
+++ b/rtnetlink/examples/ip_monitor.rs
@@ -8,6 +8,16 @@ use rtnetlink::{
     sys::{AsyncSocket, SocketAddr},
 };
 
+fn nl_mgrp(group: u32) -> u32 {
+    if group > 31 {
+        panic!("use NETLINK_ADD_MEMBERSHIP for this group");
+    }
+    if group == 0 {
+        0
+    } else {
+        1 << (group - 1)
+    }
+}
 #[tokio::main]
 async fn main() -> Result<(), String> {
     // conn - `Connection` that has a netlink socket which is a `Future` that polls the socket
@@ -19,21 +29,21 @@ async fn main() -> Result<(), String> {
     let (mut conn, mut _handle, mut messages) = new_connection().map_err(|e| format!("{}", e))?;
 
     // These flags specify what kinds of broadcast messages we want to listen for.
-    let groups = RTNLGRP_LINK
-        | RTNLGRP_IPV4_IFADDR
-        | RTNLGRP_IPV6_IFADDR
-        | RTNLGRP_IPV4_ROUTE
-        | RTNLGRP_IPV6_ROUTE
-        | RTNLGRP_MPLS_ROUTE
-        | RTNLGRP_IPV4_MROUTE
-        | RTNLGRP_IPV6_MROUTE
-        | RTNLGRP_NEIGH
-        | RTNLGRP_IPV4_NETCONF
-        | RTNLGRP_IPV6_NETCONF
-        | RTNLGRP_IPV4_RULE
-        | RTNLGRP_IPV6_RULE
-        | RTNLGRP_NSID
-        | RTNLGRP_MPLS_NETCONF;
+    let groups = nl_mgrp(RTNLGRP_LINK)
+        | nl_mgrp(RTNLGRP_IPV4_IFADDR)
+        | nl_mgrp(RTNLGRP_IPV6_IFADDR)
+        | nl_mgrp(RTNLGRP_IPV4_ROUTE)
+        | nl_mgrp(RTNLGRP_IPV6_ROUTE)
+        | nl_mgrp(RTNLGRP_MPLS_ROUTE)
+        | nl_mgrp(RTNLGRP_IPV4_MROUTE)
+        | nl_mgrp(RTNLGRP_IPV6_MROUTE)
+        | nl_mgrp(RTNLGRP_NEIGH)
+        | nl_mgrp(RTNLGRP_IPV4_NETCONF)
+        | nl_mgrp(RTNLGRP_IPV6_NETCONF)
+        | nl_mgrp(RTNLGRP_IPV4_RULE)
+        | nl_mgrp(RTNLGRP_IPV6_RULE)
+        | nl_mgrp(RTNLGRP_NSID)
+        | nl_mgrp(RTNLGRP_MPLS_NETCONF);
 
     let addr = SocketAddr::new(0, groups);
     conn.socket_mut()

--- a/rtnetlink/examples/ip_monitor.rs
+++ b/rtnetlink/examples/ip_monitor.rs
@@ -8,9 +8,9 @@ use rtnetlink::{
     sys::{AsyncSocket, SocketAddr},
 };
 
-fn nl_mgrp(group: u32) -> u32 {
+const fn nl_mgrp(group: u32) -> u32 {
     if group > 31 {
-        panic!("use NETLINK_ADD_MEMBERSHIP for this group");
+        panic!("use netlink_sys::Socket::add_membership() for this group");
     }
     if group == 0 {
         0


### PR DESCRIPTION
List of groups that's specified in nl_group field of the address is
actually a bitfield, whereas `RTNLGRP_*` constants are 1, 2, 3, etc,
so they must be shifted before using them in nl_group.

See iproute2 source for example[1][2].

[1] https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/tree/ip/ipmonitor.c?id=deb485541f34cc77e5228ab6ba6e1af58014727b#n198
[2] https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/tree/include/utils.h?id=deb485541f34cc77e5228ab6ba6e1af58014727b#n230