### PR TITLE
Add ENOBUFS handling for unsolicited messages

### DIFF
--- a/audit/examples/events.rs
+++ b/audit/examples/events.rs
@@ -8,14 +8,14 @@ use futures::stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    let (connection, mut handle, mut messages) = new_connection().map_err(|e| format!("{}", e))?;
+    let (connection, mut handle, mut events) = new_connection().map_err(|e| format!("{}", e))?;
 
     tokio::spawn(connection);
     handle.enable_events().await.map_err(|e| format!("{}", e))?;
 
     env_logger::init();
-    while let Some((msg, _)) = messages.next().await {
-        println!("{:?}", msg);
+    while let Some(event) = events.next().await {
+        println!("{event:?}");
     }
     Ok(())
 }

--- a/audit/src/lib.rs
+++ b/audit/src/lib.rs
@@ -21,10 +21,12 @@ use futures::channel::mpsc::UnboundedReceiver;
 pub fn new_connection() -> io::Result<(
     proto::Connection<packet::AuditMessage, sys::TokioSocket, packet::NetlinkAuditCodec>,
     Handle,
-    UnboundedReceiver<(
-        packet::NetlinkMessage<packet::AuditMessage>,
-        sys::SocketAddr,
-    )>,
+    UnboundedReceiver<
+        packet::NetlinkEvent<(
+            packet::NetlinkMessage<packet::AuditMessage>,
+            sys::SocketAddr,
+        )>,
+    >,
 )> {
     new_connection_with_socket()
 }
@@ -33,10 +35,12 @@ pub fn new_connection() -> io::Result<(
 pub fn new_connection_with_socket<S>() -> io::Result<(
     proto::Connection<packet::AuditMessage, S, packet::NetlinkAuditCodec>,
     Handle,
-    UnboundedReceiver<(
-        packet::NetlinkMessage<packet::AuditMessage>,
-        sys::SocketAddr,
-    )>,
+    UnboundedReceiver<
+        packet::NetlinkEvent<(
+            packet::NetlinkMessage<packet::AuditMessage>,
+            sys::SocketAddr,
+        )>,
+    >,
 )>
 where
     S: sys::AsyncSocket,

--- a/ethtool/src/connection.rs
+++ b/ethtool/src/connection.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use futures::channel::mpsc::UnboundedReceiver;
 use genetlink::message::RawGenlMessage;
-use netlink_packet_core::NetlinkMessage;
+use netlink_packet_core::{NetlinkEvent, NetlinkMessage};
 use netlink_proto::Connection;
 use netlink_sys::{AsyncSocket, SocketAddr};
 
@@ -15,7 +15,7 @@ use crate::EthtoolHandle;
 pub fn new_connection() -> io::Result<(
     Connection<RawGenlMessage>,
     EthtoolHandle,
-    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RawGenlMessage>, SocketAddr)>>,
 )> {
     new_connection_with_socket()
 }
@@ -24,7 +24,7 @@ pub fn new_connection() -> io::Result<(
 pub fn new_connection_with_socket<S>() -> io::Result<(
     Connection<RawGenlMessage, S>,
     EthtoolHandle,
-    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RawGenlMessage>, SocketAddr)>>,
 )>
 where
     S: AsyncSocket,

--- a/genetlink/src/connection.rs
+++ b/genetlink/src/connection.rs
@@ -2,7 +2,7 @@
 
 use crate::{message::RawGenlMessage, GenetlinkHandle};
 use futures::channel::mpsc::UnboundedReceiver;
-use netlink_packet_core::NetlinkMessage;
+use netlink_packet_core::{NetlinkEvent, NetlinkMessage};
 use netlink_proto::{
     self,
     sys::{protocols::NETLINK_GENERIC, AsyncSocket, SocketAddr},
@@ -28,7 +28,7 @@ use std::io;
 pub fn new_connection() -> io::Result<(
     Connection<RawGenlMessage>,
     GenetlinkHandle,
-    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RawGenlMessage>, SocketAddr)>>,
 )> {
     new_connection_with_socket()
 }
@@ -38,7 +38,7 @@ pub fn new_connection() -> io::Result<(
 pub fn new_connection_with_socket<S>() -> io::Result<(
     Connection<RawGenlMessage, S>,
     GenetlinkHandle,
-    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RawGenlMessage>, SocketAddr)>>,
 )>
 where
     S: AsyncSocket,

--- a/mptcp-pm/src/connection.rs
+++ b/mptcp-pm/src/connection.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use futures::channel::mpsc::UnboundedReceiver;
 use genetlink::message::RawGenlMessage;
-use netlink_packet_core::NetlinkMessage;
+use netlink_packet_core::{NetlinkEvent, NetlinkMessage};
 use netlink_proto::Connection;
 use netlink_sys::{AsyncSocket, SocketAddr};
 
@@ -15,7 +15,7 @@ use crate::MptcpPathManagerHandle;
 pub fn new_connection() -> io::Result<(
     Connection<RawGenlMessage>,
     MptcpPathManagerHandle,
-    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RawGenlMessage>, SocketAddr)>>,
 )> {
     new_connection_with_socket()
 }
@@ -24,7 +24,7 @@ pub fn new_connection() -> io::Result<(
 pub fn new_connection_with_socket<S>() -> io::Result<(
     Connection<RawGenlMessage, S>,
     MptcpPathManagerHandle,
-    UnboundedReceiver<(NetlinkMessage<RawGenlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RawGenlMessage>, SocketAddr)>>,
 )>
 where
     S: AsyncSocket,

--- a/netlink-packet-audit/src/lib.rs
+++ b/netlink-packet-audit/src/lib.rs
@@ -8,6 +8,7 @@ pub use self::utils::{traits, DecodeError};
 pub use netlink_packet_core::{
     ErrorMessage,
     NetlinkBuffer,
+    NetlinkEvent,
     NetlinkHeader,
     NetlinkMessage,
     NetlinkPayload,

--- a/netlink-packet-core/src/message.rs
+++ b/netlink-packet-core/src/message.rs
@@ -18,6 +18,15 @@ use crate::{
     Parseable,
 };
 
+/// Represent a Netlink event
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum NetlinkEvent<M> {
+    /// An actual message was received from Netlink
+    Message(M),
+    /// The socket receive buffer filled up
+    Overrun,
+}
+
 /// Represent a netlink message.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NetlinkMessage<I> {

--- a/netlink-packet-route/src/lib.rs
+++ b/netlink-packet-route/src/lib.rs
@@ -10,6 +10,7 @@ pub use self::utils::{traits, DecodeError};
 pub use netlink_packet_core::{
     ErrorMessage,
     NetlinkBuffer,
+    NetlinkEvent,
     NetlinkHeader,
     NetlinkMessage,
     NetlinkPayload,

--- a/netlink-sys/src/socket.rs
+++ b/netlink-sys/src/socket.rs
@@ -81,7 +81,7 @@ impl Socket {
         let res = unsafe {
             libc::socket(
                 libc::PF_NETLINK,
-                libc::SOCK_DGRAM | libc::SOCK_CLOEXEC,
+                libc::SOCK_RAW | libc::SOCK_CLOEXEC,
                 protocol as libc::c_int,
             )
         };
@@ -445,6 +445,18 @@ impl Socket {
     pub fn get_cap_ack(&self) -> Result<bool> {
         let res = getsockopt::<libc::c_int>(self.0, libc::SOL_NETLINK, libc::NETLINK_CAP_ACK)?;
         Ok(res == 1)
+    }
+
+    pub fn set_buf_size(&mut self, tx: i32, rx: i32) -> Result<()> {
+        setsockopt(self.0, libc::SOL_SOCKET, libc::SO_SNDBUF, tx as libc::c_int)?;
+        setsockopt(self.0, libc::SOL_SOCKET, libc::SO_RCVBUF, rx as libc::c_int)?;
+        Ok(())
+    }
+
+    pub fn get_buf_size(&self) -> Result<(i32, i32)> {
+        let tx = getsockopt::<libc::c_int>(self.0, libc::SOL_SOCKET, libc::SO_SNDBUF)?;
+        let rx = getsockopt::<libc::c_int>(self.0, libc::SOL_SOCKET, libc::SO_RCVBUF)?;
+        Ok((tx, rx))
     }
 }
 

--- a/rtnetlink/examples/listen.rs
+++ b/rtnetlink/examples/listen.rs
@@ -5,6 +5,7 @@
 
 use futures::stream::StreamExt;
 
+use netlink_proto::packet::NetlinkEvent;
 use rtnetlink::{
     constants::{RTMGRP_IPV4_ROUTE, RTMGRP_IPV6_ROUTE},
     new_connection,
@@ -14,7 +15,7 @@ use rtnetlink::{
 #[tokio::main]
 async fn main() -> Result<(), String> {
     // Open the netlink socket
-    let (mut connection, _, mut messages) = new_connection().map_err(|e| format!("{}", e))?;
+    let (mut connection, _, mut events) = new_connection().map_err(|e| format!("{}", e))?;
 
     // These flags specify what kinds of broadcast messages we want to listen for.
     let mgroup_flags = RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE;
@@ -29,9 +30,14 @@ async fn main() -> Result<(), String> {
         .expect("failed to bind");
     tokio::spawn(connection);
 
-    while let Some((message, _)) = messages.next().await {
-        let payload = message.payload;
-        println!("Route change message - {:?}", payload);
+    while let Some(event) = events.next().await {
+        match event {
+            NetlinkEvent::Message((message, _)) => {
+                let payload = message.payload;
+                println!("Route change message - {:?}", payload);
+            }
+            NetlinkEvent::Overrun => println!("Netlink socket overrun. Some messages were lost"),
+        }
     }
     Ok(())
 }

--- a/rtnetlink/src/connection.rs
+++ b/rtnetlink/src/connection.rs
@@ -5,7 +5,7 @@ use std::io;
 use futures::channel::mpsc::UnboundedReceiver;
 
 use crate::{
-    packet::{NetlinkMessage, RtnlMessage},
+    packet::{NetlinkEvent, NetlinkMessage, RtnlMessage},
     proto::Connection,
     sys::{protocols::NETLINK_ROUTE, AsyncSocket, SocketAddr},
     Handle,
@@ -16,7 +16,7 @@ use crate::{
 pub fn new_connection() -> io::Result<(
     Connection<RtnlMessage>,
     Handle,
-    UnboundedReceiver<(NetlinkMessage<RtnlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RtnlMessage>, SocketAddr)>>,
 )> {
     new_connection_with_socket()
 }
@@ -25,7 +25,7 @@ pub fn new_connection() -> io::Result<(
 pub fn new_connection_with_socket<S>() -> io::Result<(
     Connection<RtnlMessage, S>,
     Handle,
-    UnboundedReceiver<(NetlinkMessage<RtnlMessage>, SocketAddr)>,
+    UnboundedReceiver<NetlinkEvent<(NetlinkMessage<RtnlMessage>, SocketAddr)>>,
 )>
 where
     S: AsyncSocket,


### PR DESCRIPTION
This can happen when large burst of messages come all of a sudden, which happen very easily when routing protocols are involved (e.g. BGP). The current implementation incorrectly assumes that any failure to read from the socket is akin to the socket closed. This is not the case.

This adds handling for this specific error, which translates to a wrapper struct in the unsolicited messages stream: either a message, or an overrun. This lets applications handle best for their usecase such event: either resync because messages are lost, or do nothing if the listening is informational only (e.g. logging).

This PR fixes the issue raised in https://github.com/little-dude/netlink/issues/139